### PR TITLE
docs: prepare Build Week licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 fengseekling-coder
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -241,3 +241,7 @@ node mosa/mcp/server.mjs
 4. 将库内素材插入 Cowart，展示去重保护与可复用性。
 5. 提交证据：本仓库的 2026-07-17 至 2026-07-19 提交记录可追溯 Codex/GPT-5.6 的增量构建；GitHub 项目简介和本节已说明该闭环。
 6. 待提交前完成：在主构建 Codex 任务中执行 `/feedback`，并记录返回的 Feedback Session ID。不要以普通 Codex 任务 ID 代替该 ID。
+
+## License
+
+MOSA is available under the [MIT License](LICENSE).

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,8 @@
   "packages": {
     "": {
       "name": "mosa",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "mosa",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "start": "node server.mjs",


### PR DESCRIPTION
## What changed

- Add an MIT license for the public Build Week repository.
- Declare the same license in npm package metadata and the lockfile.
- Link the license from the README.

## Why

OpenAI Build Week requires a public repository to include relevant licensing. This makes the repository status explicit for judges and downstream users.

## Validation

- `npm test` (24 passing)
- `git diff --check`
- Submission outputs and local video files remain ignored and were not committed.
