### PR TITLE
feat: discover Cowart canvases from structured exec_command workdir

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 - This repository is the user's only Build Week project. Keep all product code, assets, tests, and Git commits inside this directory.
 - Cowart is an externally installed Codex plugin at `/Users/azhuilab/plugins/cowart`; never vendor, clone, or copy its code into this repository.
-- Cowart runtime data belongs outside this repository. MOSA's dedicated canvas is `/Users/azhuilab/.codex/cowart-data/mosa`; additional registered Cowart projects keep their own `<projectDir>/canvas` directories.
+- Cowart runtime data belongs outside this repository. MOSA's dedicated canvas is `/Users/azhuilab/.codex/cowart-data/mosa`; automatically detected Cowart projects keep their own `<projectDir>/canvas` directories.
 
 ## Natural-language launch commands
 
@@ -29,8 +29,8 @@
 
 ## Cowart-to-library automatic registration
 
-- MOSA starts a Cowart bridge manager with the web server. It watches the dedicated canvas plus each project explicitly registered in MOSA Settings → Cowart canvases; a registered project is monitored only at `<projectDir>/canvas/pages/`.
-- Registered project roots are persisted outside the repository in `~/.codex/mosa/cowart-projects.json`. Never scan arbitrary Cowart projects or broad filesystem roots to discover canvases.
+- MOSA starts a Cowart bridge manager with the web server. It watches the dedicated canvas plus each project automatically detected from a real Cowart launch call in local Codex task records; a detected project is monitored only at `<projectDir>/canvas/pages/`.
+- Detected project roots are persisted outside the repository in `~/.codex/mosa/cowart-projects.json`. Discovery must stay event-based and require Cowart-owned marker files; never scan arbitrary project directories or broad filesystem roots for canvases.
 - The bridge is the source of truth for auto-archival. It covers Cowart image generation, AI-holder replacement, and annotation editing without changing the Cowart plugin or requiring the creating task to call `asset_create`.
 - It deduplicates by the exact Cowart page-asset path. The bridge skips images whose Cowart asset metadata identifies an existing MOSA asset.
 - Cowart snapshots expose an image description but not the full generation prompt. Auto-archived records therefore label their Prompt as canvas alt text; attach the original full prompt later when it is available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Added Node 22 baseline, ESLint, source checks, dependency audit scripts, and GitHub Actions CI for `main` and `develop`.
 - Added verified JSON-to-SQLite migration with FTS5 search, stable cursor pagination, empty-group preservation, JSON backup, corruption reporting, and resumable verification.
 - Added durable WebP preview/thumbnail jobs and gallery pagination while keeping original image URLs compatible.
-- Added opt-in monitoring for multiple project-local Cowart canvases while preserving the MOSA dedicated canvas.
-- Added persisted project registration, per-canvas bridge status, and Cowart project provenance on archived assets.
+- Added automatic monitoring for project-local Cowart canvases opened from Codex while preserving the MOSA dedicated canvas.
+- Added event-based canvas discovery, persisted project registration, per-canvas bridge status, and Cowart project provenance on archived assets.
 
 ## 0.1.0 — OpenAI Build Week release
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ The optional integrations become active when their local source directories are 
 | 来源 | 归档方式 | 保存的信息 | 需要的前提 |
 | --- | --- | --- | --- |
 | Codex 生图 | 监听 `~/.codex/generated_images/`，优先以硬链接入库 | 任务 ID、原始路径、时间、文件哈希、尺寸与可用的任务提示词 | 素材管理器服务保持运行 |
-| Cowart 画布 | 素材管理器服务读取已保存的 Cowart 画布快照，自动同步新页面图片 | 图片、画布描述、尺寸、画布对象与页面资产来源 | 服务保持运行；在 MOSA 设置中登记项目画布 |
+| Cowart 画布 | 素材管理器服务读取已保存的 Cowart 画布快照，自动同步新页面图片 | 图片、画布描述、尺寸、画布对象与页面资产来源 | 服务保持运行；在 Codex 中打开项目画布 |
 
-Codex 自动归档的范围仅限 Codex 标准生成目录，不会扫描用户的 Downloads、桌面或其他本地图片。Cowart 只监听 MOSA 专用画布和在设置中明确登记的项目 `<项目>/canvas/`，不会扫描其他项目。
+Codex 自动归档的范围仅限 Codex 标准生成目录，不会扫描用户的 Downloads、桌面或其他本地图片。Cowart 只监听 MOSA 专用画布，以及从本地 Codex 任务中的真实 Cowart 启动事件自动发现的 `<项目>/canvas/`；不会扫描其他项目目录。
 
 ### 本地启动
 
@@ -169,7 +169,7 @@ node scripts/migrate-codex-hardlinks.mjs
 
 Cowart 在这个目录保存画布后，新生成的图片、AI 图片框替换结果和批注编辑结果都会自动入库。桥接器以 Cowart 画布快照中的页面资产路径去重；从素材管理器插回画布的图片会携带来源 ID，桥接器会跳过它，避免重复归档。
 
-要归档其他项目的画布，在 MOSA 的 **设置 → Cowart 画布** 中填入该项目的绝对路径。MOSA 会只监控该项目的 `<项目>/canvas/`，项目之间仍保持各自的 Cowart 画布；已登记列表保存在 `~/.codex/mosa/cowart-projects.json`，服务重启后仍会生效。MOSA 不会自动扫描或收集未登记项目的画布。
+打开其他项目的 Cowart 画布后，MOSA 会从本地 Codex 任务记录中的 `render_cowart_canvas_widget` 或 Cowart 本地启动调用自动识别项目根目录，验证该项目确实存在 Cowart 画布标记，然后立即监听 `<项目>/canvas/`。项目之间仍保持各自的画布；自动发现列表保存在 `~/.codex/mosa/cowart-projects.json`，服务重启后仍会生效。这个流程基于真实启动事件，不会扫描机器上的任意项目目录。
 
 Cowart 快照仅提供画布描述（alt text），不保存完整生图 Prompt。因此 Cowart 自动归档的素材会明确标记为 `canvas-alt-text-only`；需要完整 Prompt 时，可在详情页后补或从原生成任务补录。
 
@@ -191,14 +191,14 @@ Cowart 是外部 Codex 插件，运行数据刻意保存在仓库外，不会被
 COWART_MOSA_CANVAS_DIR=/absolute/path/to/cowart-data/my-project npm start
 ```
 
-这个环境变量只改变 MOSA 专用画布。其他项目画布请通过设置菜单登记，而不是通过扫描机器上的目录。
+这个环境变量只改变 MOSA 专用画布。其他项目画布会在 Cowart 被实际打开后自动发现。
 
 ### 最短端到端验证
 
 1. 运行 `npm start`，打开 Web App。
 2. 新开任意 Codex 任务（不需要关联 MOSA 项目）。
 3. 生成一张图片；在 Web 中等待最多 3 秒，确认出现 **Codex** 来源的新素材、任务 ID、原始路径与提示词状态。
-4. 若使用普通项目画布，先在 **设置 → Cowart 画布** 登记项目根目录；然后打开该项目的 Cowart 画布，生成、替换或批注编辑一张图片并保存画布。
+4. 打开任意项目的 Cowart 画布，生成、替换或批注编辑一张图片并保存；MOSA 会自动发现并监听这个项目画布。
 5. 等待最多 2 秒，回到 Web 查看带有 **Cowart** 来源标记的新素材；也可访问 `/api/cowart-bridge` 查看同步状态。
 6. 将一张库内素材插回画布，确认素材总数没有因同一文件再次增加。
 
@@ -212,7 +212,7 @@ COWART_MOSA_CANVAS_DIR=/absolute/path/to/cowart-data/my-project npm start
 | `CODEX_GENERATED_IMAGES_DIR` | `~/.codex/generated_images` | 允许 `asset_create` 读取的 Codex 图片来源根目录 |
 | `CODEX_SESSIONS_DIR` | `~/.codex/sessions` | 用于读取对应 Codex 任务提示词的会话记录根目录 |
 | `COWART_MOSA_CANVAS_DIR` | `~/.codex/cowart-data/mosa` | MOSA 专用 Cowart 画布数据目录 |
-| `MOSA_COWART_REGISTRY_PATH` | `~/.codex/mosa/cowart-projects.json` | 已登记项目画布列表；每项只监听 `<项目>/canvas/` |
+| `MOSA_COWART_REGISTRY_PATH` | `~/.codex/mosa/cowart-projects.json` | 自动发现的项目画布列表；每项只监听 `<项目>/canvas/` |
 | `COWART_MCP_SERVER_PATH` | `~/plugins/cowart/mcp/server.mjs` | 可选的 Cowart MCP 服务入口，用于 Web 中的一键插入 |
 
 ### 本地数据结构
@@ -245,7 +245,7 @@ Cowart 运行数据不在仓库中：
 
 ```text
 ~/.codex/cowart-data/mosa/             # MOSA 专用画布
-~/.codex/mosa/cowart-projects.json     # 已登记项目根目录
+~/.codex/mosa/cowart-projects.json     # 自动发现的项目根目录
 ```
 
 #### Git 与本地素材
@@ -281,7 +281,7 @@ node mosa/mcp/server.mjs
 
 - 未迁移时数据以 JSON 本地文件保存；验证完成后 SQLite 是唯一运行期元数据权威。JSON 只保留为兼容回退与迁移备份，不做双写。
 - Codex 图片归档在素材管理器服务运行时自动监听标准生成目录；MCP `asset_create` 可用于显式保存和补充生成元数据。
-- Cowart 自动归档依赖素材管理器服务运行，并且只覆盖 MOSA 专用画布和明确登记的项目画布。
+- Cowart 自动归档依赖素材管理器服务运行，并且只覆盖 MOSA 专用画布和从真实 Cowart 启动事件发现的项目画布。
 - Cowart 自动归档保留画布描述，不具备完整 Prompt；原始 Prompt 需要从生成任务补录。
 - “同配方再生成”当前复制 Codex 指令，不直接调用图像模型。
 

--- a/app/app.js
+++ b/app/app.js
@@ -8,32 +8,20 @@ const translations = {
 };
 
 Object.assign(translations.zh, {
-  cowartCanvases: "Cowart 画布",
+  cowartCanvases: "自动发现的 Cowart 画布",
   cowartInsertTarget: "回插画布",
-  cowartProjectPath: "项目路径",
-  cowartProjectPathPlaceholder: "/Users/name/project",
-  addCowartCanvas: "添加项目画布",
-  removeCowartCanvas: "移除监控画布",
   mosaCanvas: "MOSA 专用画布",
-  cowartCanvasAdded: "已开始监控：{name}",
-  cowartCanvasRemoved: "已停止监控：{name}",
-  cowartProjectPathRequired: "请输入项目的绝对路径",
+  projectCanvas: "项目画布 · {name}",
   statusWatchingOneCanvas: "监控 1 个画布",
   statusWatchingCanvasCount: "监控 {count} 个画布",
   loadMore: "加载更多",
 });
 
 Object.assign(translations.en, {
-  cowartCanvases: "Cowart canvases",
+  cowartCanvases: "Detected Cowart canvases",
   cowartInsertTarget: "Insert canvas",
-  cowartProjectPath: "Project path",
-  cowartProjectPathPlaceholder: "/Users/name/project",
-  addCowartCanvas: "Add project canvas",
-  removeCowartCanvas: "Remove monitored canvas",
-  mosaCanvas: "MOSA canvas",
-  cowartCanvasAdded: "Now monitoring: {name}",
-  cowartCanvasRemoved: "Stopped monitoring: {name}",
-  cowartProjectPathRequired: "Enter an absolute project path",
+  mosaCanvas: "MOSA dedicated canvas",
+  projectCanvas: "Project canvas · {name}",
   statusWatchingOneCanvas: "1 canvas",
   statusWatchingCanvasCount: "{count} canvases",
   loadMore: "Load more",
@@ -117,16 +105,16 @@ function renderCowartCanvasSettings() {
   const entries = state.cowartCanvases.map((canvas) => {
     const label = cowartCanvasLabel(canvas);
     const status = canvas.lastError ? "error" : canvas.enabled ? "ok" : "off";
-    const removeButton = canvas.managed ? "" : `<button class="icon-button quiet settings-cowart-remove" type="button" data-remove-cowart-canvas="${escapeHtml(canvas.id)}" title="${escapeHtml(t("removeCowartCanvas"))}" aria-label="${escapeHtml(`${t("removeCowartCanvas")}: ${label}`)}"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M8 6V4h8v2m-7 4v7m6-7v7M6 6l1 15h10l1-15"/></svg></button>`;
-    return `<div class="settings-cowart-entry" title="${escapeHtml(canvas.canvasDir || canvas.projectDir || "")}"><span class="settings-cowart-status" data-state="${status}" aria-hidden="true"></span><span class="settings-cowart-name">${escapeHtml(label)}</span>${removeButton}</div>`;
+    return `<div class="settings-cowart-entry" title="${escapeHtml(canvas.canvasDir || canvas.projectDir || "")}"><span class="settings-cowart-status" data-state="${status}" aria-hidden="true"></span><span class="settings-cowart-name">${escapeHtml(label)}</span></div>`;
   }).join("");
-  return `<section class="settings-section settings-cowart-section"><p>${t("cowartCanvases")}</p><form class="settings-cowart-add" data-cowart-canvas-form><label class="visually-hidden" for="cowartProjectPath">${t("cowartProjectPath")}</label><input id="cowartProjectPath" data-cowart-project-path placeholder="${escapeHtml(t("cowartProjectPathPlaceholder"))}" aria-label="${escapeHtml(t("cowartProjectPath"))}" /><button class="icon-button quiet" type="submit" title="${escapeHtml(t("addCowartCanvas"))}" aria-label="${escapeHtml(t("addCowartCanvas"))}"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg></button></form><div class="settings-cowart-list">${entries}</div></section>`;
+  return `<section class="settings-section settings-cowart-section"><p>${t("cowartCanvases")}</p><div class="settings-cowart-list">${entries}</div></section>`;
 }
 
 function cowartCanvasLabel(canvas = {}) {
   if (canvas.managed) return t("mosaCanvas");
   const path = String(canvas.projectDir || "").replace(/\/+$/, "");
-  return path.split("/").pop() || path || t("cowartCanvases");
+  const name = path.split("/").pop() || path || t("cowartCanvases");
+  return t("projectCanvas", { name });
 }
 
 function cowartInsertTargetIdFor(asset) {
@@ -297,6 +285,12 @@ function isDetailEditorActive() {
 async function refreshBridgeStatus() {
   try {
     const { codex, cowart, cowartInsert } = await api("/api/bridges");
+    const nextCanvases = Array.isArray(cowart?.sources) ? cowart.sources : [];
+    if (cowartCanvasListSignature(nextCanvases) !== cowartCanvasListSignature(state.cowartCanvases)) {
+      state.cowartCanvases = nextCanvases;
+      renderSettingsMenu();
+      if (state.detailOpen && !isDetailEditorActive()) renderDetail();
+    }
     state.cowartInsertAvailable = Boolean(cowartInsert?.available);
     const hasError = codex?.lastError || cowart?.lastError;
     const codexOn = Boolean(codex?.enabled);
@@ -324,6 +318,10 @@ async function refreshBridgeStatus() {
     setStatus(t("statusUnavailable"), "error");
     updateCowartInsertControls();
   }
+}
+
+function cowartCanvasListSignature(canvases) {
+  return (canvases || []).map((canvas) => `${canvas.id}:${canvas.canvasDir}:${canvas.enabled}:${canvas.lastError || ""}`).join("|");
 }
 
 function updateCodexHint() {
@@ -363,19 +361,6 @@ function bindEvents() {
     state.project = select.value; state.selectedId = null; state.filter = { type: "all", value: "" }; state.query = ""; els.searchInput.value = "";
     await loadStats(); await loadAssets();
   });
-  els.settingsMenu?.addEventListener("submit", (event) => {
-    if (!event.target.matches("[data-cowart-canvas-form]")) return;
-    event.preventDefault();
-    runAction(async () => {
-      const input = event.target.querySelector("[data-cowart-project-path]");
-      const projectDir = input?.value.trim() || "";
-      if (!projectDir) throw new Error(t("cowartProjectPathRequired"));
-      const result = await api("/api/cowart-canvases", { method: "POST", body: { projectDir } });
-      await loadCowartCanvases();
-      await refreshBridgeStatus();
-      showToast(t("cowartCanvasAdded", { name: cowartCanvasLabel(result.canvas) }), "success");
-    });
-  });
   els.settingsMenu?.addEventListener("click", (event) => {
     const languageMenuTrigger = event.target.closest("[data-language-menu]");
     if (languageMenuTrigger) {
@@ -391,15 +376,6 @@ function bindEvents() {
     if (localeButton) return setLanguage(localeButton.dataset.locale);
     const openLibraryButton = event.target.closest("[data-open-library]");
     if (openLibraryButton) runAction(async () => { if (!state.libraryPath) return; await api("/api/open-folder", { method: "POST", body: { path: state.libraryPath } }); showToast(t("openInFinder"), "success"); });
-    const removeCanvasButton = event.target.closest("[data-remove-cowart-canvas]");
-    if (removeCanvasButton) runAction(async () => {
-      const id = removeCanvasButton.dataset.removeCowartCanvas;
-      const canvas = state.cowartCanvases.find((entry) => entry.id === id);
-      const result = await api(`/api/cowart-canvases/${encodeURIComponent(id)}`, { method: "DELETE" });
-      await loadCowartCanvases();
-      await refreshBridgeStatus();
-      showToast(t("cowartCanvasRemoved", { name: cowartCanvasLabel(result.canvas || canvas) }), "success");
-    });
   });
   els.closeImportModal?.addEventListener("click", closeImportModal);
   els.cancelImportBtn?.addEventListener("click", closeImportModal);

--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MOSA — 创作资产库</title>
-    <link rel="stylesheet" href="/styles.css?v=15" />
+    <link rel="stylesheet" href="/styles.css?v=16" />
   </head>
   <body>
     <div class="toast-container" id="toastContainer" aria-live="polite"></div>
@@ -116,6 +116,6 @@
       <aside class="detail" id="detailPanel" data-i18n-aria-label="assetInspector" aria-label="素材检视器" aria-hidden="true"></aside>
     </div>
 
-    <script type="module" src="/app.js"></script>
+    <script type="module" src="/app.js?v=17"></script>
   </body>
 </html>

--- a/app/styles.css
+++ b/app/styles.css
@@ -88,19 +88,13 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
 .settings-submenu-trigger svg { flex: 0 0 auto; }
 .language-menu { position: fixed; z-index: 45; top: var(--language-menu-top, 12px); left: var(--language-menu-left, 12px); width: min(184px, calc(100vw - 24px)); padding: 8px; border: 1px solid var(--line); border-radius: 10px; background: var(--surface); box-shadow: var(--shadow); }
 .language-menu button { width: 100%; }
-.settings-cowart-add { display: flex; align-items: center; gap: 4px; padding: 0 3px; }
-.settings-cowart-add input { min-width: 0; height: 32px; flex: 1; padding: 0 7px; border: 1px solid transparent; border-radius: 7px; background: var(--surface-muted); font-size: 12px; }
-.settings-cowart-add input:hover, .settings-cowart-add input:focus { border-color: var(--line); }
-.settings-menu .settings-cowart-add .icon-button { display: inline-grid; width: 32px; min-width: 32px; height: 32px; padding: 0; place-items: center; }
-.settings-cowart-list { display: grid; max-height: 126px; gap: 2px; margin: 5px 3px 0; overflow: auto; }
+.settings-cowart-list { display: grid; max-height: 154px; gap: 2px; margin: 0 3px; overflow: auto; }
 .settings-cowart-entry { display: flex; min-width: 0; height: 28px; align-items: center; gap: 7px; padding-left: 7px; border-radius: 6px; color: var(--ink-secondary); font-size: 11px; }
 .settings-cowart-entry:hover { background: var(--surface-muted); }
 .settings-cowart-status { width: 6px; height: 6px; flex: 0 0 auto; border-radius: 50%; background: var(--ink-tertiary); }
 .settings-cowart-status[data-state="ok"] { background: var(--success); }
 .settings-cowart-status[data-state="error"] { background: var(--danger); }
 .settings-cowart-name { min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.settings-menu .settings-cowart-entry .settings-cowart-remove { display: inline-grid; width: 28px; min-width: 28px; height: 28px; padding: 0; place-items: center; color: var(--ink-tertiary); }
-.settings-menu .settings-cowart-entry .settings-cowart-remove:hover { color: var(--danger); }
 
 /* Main gallery */
 .library { display: flex; min-width: 0; min-height: 0; flex-direction: column; overflow: hidden; }

--- a/lib/cowart-bridge-manager.mjs
+++ b/lib/cowart-bridge-manager.mjs
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { createCowartAssetBridge } from "./cowart-bridge.mjs";
 
 /**
- * Runs one narrow Cowart bridge per explicitly registered project canvas.
+ * Runs one narrow Cowart bridge per detected and persisted project canvas.
  * It deliberately has no filesystem discovery, so MOSA never scans unrelated
  * projects or arbitrary directories on the machine.
  */

--- a/lib/cowart-canvas-discovery.mjs
+++ b/lib/cowart-canvas-discovery.mjs
@@ -1,0 +1,377 @@
+import { watch } from "node:fs";
+import { readFile, readdir, realpath, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+
+const DEFAULT_LOOKBACK_DAYS = 14;
+
+/**
+ * Discovers project-local Cowart canvases from actual canvas launch calls in
+ * local Codex task records. This keeps discovery event-based and avoids
+ * scanning arbitrary project directories on the machine.
+ */
+export function createCowartCanvasDiscovery(options = {}) {
+  if (typeof options.onDiscover !== "function") {
+    throw new Error("Cowart canvas discovery requires an onDiscover callback.");
+  }
+
+  const sessionsDir = resolve(options.sessionsDir || join(homedir(), ".codex", "sessions"));
+  const managerDir = options.managerDir ? resolve(options.managerDir) : null;
+  const dedicatedCanvasDir = options.dedicatedCanvasDir ? resolve(options.dedicatedCanvasDir) : null;
+  const knownProjectDirs = typeof options.knownProjectDirs === "function" ? options.knownProjectDirs : () => [];
+  const debounceMs = Number.isFinite(options.debounceMs) ? Math.max(0, options.debounceMs) : 500;
+  const pollIntervalMs = Number.isFinite(options.pollIntervalMs) ? Math.max(500, options.pollIntervalMs) : 5000;
+  const lookbackDays = Number.isFinite(options.lookbackDays) ? Math.max(1, options.lookbackDays) : DEFAULT_LOOKBACK_DAYS;
+  const cache = new Map();
+  const dirtySessionPaths = new Set();
+  let watcher = null;
+  let poller = null;
+  let timer = null;
+  let reconciling = false;
+  let reconcileAgain = false;
+  let initialScan = true;
+  const state = {
+    sessionsDir,
+    enabled: false,
+    lastScanAt: null,
+    lastDiscoveredAt: null,
+    lastDiscoveredCount: 0,
+    totalDiscovered: 0,
+    candidateCount: 0,
+    lastError: null,
+  };
+
+  async function reconcile() {
+    if (reconciling) {
+      reconcileAgain = true;
+      return { discovered: [], candidates: [], queued: true };
+    }
+    reconciling = true;
+    try {
+      const candidates = await discoverCowartProjectsFromCodexSessions({
+        sessionsDir,
+        lookbackDays,
+        cache,
+        dirtySessionPaths,
+        fullScan: initialScan,
+      });
+      initialScan = false;
+      dirtySessionPaths.clear();
+      state.candidateCount = candidates.length;
+
+      const known = new Set(knownProjectDirs().filter(Boolean).map((value) => resolve(value)));
+      const discovered = [];
+      let discoveryError = null;
+      for (const candidate of candidates) {
+        if (known.has(candidate.projectDir)) continue;
+        if (managerDir && candidate.projectDir === managerDir) continue;
+        if (dedicatedCanvasDir && candidate.canvasDir === dedicatedCanvasDir) continue;
+        try {
+          const result = await options.onDiscover({
+            projectDir: candidate.projectDir,
+            discoveredBy: "codex-cowart-launch",
+            discoveredAt: candidate.lastSeenAt,
+          });
+          known.add(candidate.projectDir);
+          discovered.push(result?.canvas || result?.project || candidate);
+        } catch (error) {
+          discoveryError = error instanceof Error ? error.message : String(error);
+        }
+      }
+
+      state.lastScanAt = new Date().toISOString();
+      state.lastDiscoveredCount = discovered.length;
+      state.totalDiscovered += discovered.length;
+      if (discovered.length > 0) state.lastDiscoveredAt = state.lastScanAt;
+      state.lastError = discoveryError;
+      return { discovered, candidates, queued: false };
+    } catch (error) {
+      state.lastScanAt = new Date().toISOString();
+      state.lastError = error instanceof Error ? error.message : String(error);
+      throw error;
+    } finally {
+      reconciling = false;
+      if (reconcileAgain) {
+        reconcileAgain = false;
+        scheduleReconcile();
+      }
+    }
+  }
+
+  function scheduleReconcile(sessionPath = null) {
+    if (sessionPath) dirtySessionPaths.add(resolve(sessionsDir, sessionPath));
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      reconcile().catch(() => {});
+    }, debounceMs);
+  }
+
+  async function start() {
+    await reconcile();
+    try {
+      watcher = watch(sessionsDir, { recursive: true }, (_event, fileName) => {
+        const changedPath = fileName == null ? "" : String(fileName);
+        const sessionPath = changedPath.endsWith(".jsonl") ? changedPath : null;
+        scheduleReconcile(sessionPath);
+      });
+      watcher.on("error", () => {
+        watcher?.close();
+        watcher = null;
+      });
+    } catch {
+      watcher = null;
+    }
+    poller = setInterval(() => reconcile().catch(() => {}), pollIntervalMs);
+    state.enabled = true;
+    return status();
+  }
+
+  function stop() {
+    if (timer) clearTimeout(timer);
+    timer = null;
+    if (poller) clearInterval(poller);
+    poller = null;
+    watcher?.close();
+    watcher = null;
+    state.enabled = false;
+  }
+
+  function status() {
+    return { ...state, watching: Boolean(watcher), polling: Boolean(poller) };
+  }
+
+  return { start, stop, reconcile, scheduleReconcile, status };
+}
+
+export async function discoverCowartProjectsFromCodexSessions(options = {}) {
+  const sessionsDir = resolve(options.sessionsDir || join(homedir(), ".codex", "sessions"));
+  const lookbackDays = Number.isFinite(options.lookbackDays) ? Math.max(1, options.lookbackDays) : DEFAULT_LOOKBACK_DAYS;
+  const cache = options.cache instanceof Map ? options.cache : new Map();
+  const dirtyPaths = new Set([...(options.dirtySessionPaths || [])].map((value) => resolve(value)));
+  const sessionPaths = new Set(await recentSessionPaths(sessionsDir, lookbackDays, options.fullScan === true));
+  for (const filePath of options.dirtySessionPaths || []) {
+    if (isSafeChildPath(sessionsDir, filePath) && String(filePath).endsWith(".jsonl")) sessionPaths.add(resolve(filePath));
+  }
+
+  const candidatesByProject = new Map();
+  for (const sessionPath of sessionPaths) {
+    let details;
+    try {
+      details = await stat(sessionPath);
+    } catch {
+      continue;
+    }
+    if (!details.isFile()) continue;
+    const cutoff = Date.now() - lookbackDays * 24 * 60 * 60 * 1000;
+    if (options.fullScan === true && details.mtimeMs < cutoff && !dirtyPaths.has(sessionPath)) continue;
+
+    const cached = cache.get(sessionPath);
+    let projectDirs;
+    if (cached?.mtimeMs === details.mtimeMs && cached?.size === details.size) {
+      projectDirs = cached.projectDirs;
+    } else {
+      projectDirs = await projectDirsFromSession(sessionPath);
+      cache.set(sessionPath, { mtimeMs: details.mtimeMs, size: details.size, projectDirs });
+    }
+
+    for (const requestedProjectDir of projectDirs) {
+      const candidate = await cowartProjectCandidate(requestedProjectDir, sessionPath, details.mtime);
+      if (!candidate) continue;
+      const previous = candidatesByProject.get(candidate.projectDir);
+      if (!previous || previous.lastSeenAt < candidate.lastSeenAt) candidatesByProject.set(candidate.projectDir, candidate);
+    }
+  }
+
+  return [...candidatesByProject.values()].sort((left, right) => left.lastSeenAt.localeCompare(right.lastSeenAt));
+}
+
+async function projectDirsFromSession(sessionPath) {
+  const raw = await readFile(sessionPath, "utf8");
+  const contextDirs = new Set();
+  const explicitDirs = new Set();
+  let openedDefaultCanvas = false;
+
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (event?.type === "turn_context" && isAbsoluteString(event.payload?.cwd)) {
+      contextDirs.add(resolve(event.payload.cwd));
+      continue;
+    }
+    if (event?.type !== "response_item") continue;
+    const call = cowartLaunchCall(event.payload);
+    if (!call.opened) continue;
+    openedDefaultCanvas = true;
+    for (const projectDir of call.projectDirs) explicitDirs.add(resolve(projectDir));
+  }
+
+  if (!openedDefaultCanvas) return [];
+  return explicitDirs.size > 0 ? [...explicitDirs] : [...contextDirs];
+}
+
+function cowartLaunchCall(payload = {}) {
+  const name = String(payload.name || payload.tool_name || "");
+  const rawArguments = payload.arguments ?? payload.input ?? payload.params ?? "";
+  const parsedArguments = parseArguments(rawArguments);
+  if (name.includes("render_cowart_canvas_widget")) {
+    return { opened: true, projectDirs: projectDirsFromArguments(parsedArguments) };
+  }
+
+  if (payload.type !== "custom_tool_call" && payload.type !== "function_call") {
+    return { opened: false, projectDirs: [] };
+  }
+  const source = typeof rawArguments === "string" ? rawArguments : JSON.stringify(rawArguments);
+  const invokesNativeWidget = /tools\.[A-Za-z0-9_$]*render_cowart_canvas_widget\s*\(/.test(source);
+  const invokesLocalCanvas = /\bcmd\s*:\s*["'](?:\.\/|\/[^"']*\/)?scripts\/start-canvas\.sh(?:\s|["'])/.test(source)
+    || /^\s*(?:\.\/|\/\S*\/)?scripts\/start-canvas\.sh(?:\s|$)/.test(String(parsedArguments?.cmd || ""));
+  if (!invokesNativeWidget && !invokesLocalCanvas) return { opened: false, projectDirs: [] };
+
+  const projectDirs = invokesLocalCanvas
+    ? projectDirsFromExecArguments(parsedArguments, source)
+    : projectDirsFromArguments(parsedArguments);
+  if (projectDirs.length === 0 && invokesNativeWidget) {
+    const match = /\bprojectDir\s*:\s*["']([^"']+)["']/.exec(source);
+    if (isAbsoluteString(match?.[1])) projectDirs.push(match[1]);
+  }
+  return { opened: true, projectDirs };
+}
+
+function parseArguments(value) {
+  if (value && typeof value === "object") return value;
+  if (typeof value !== "string" || !value.trim()) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function projectDirsFromArguments(args) {
+  return isAbsoluteString(args?.projectDir) ? [args.projectDir] : [];
+}
+
+/**
+ * Extracts candidate project directories from a structured exec_command call
+ * that launches start-canvas.sh.  Priority: projectDir > workdir > cwd, deduped.
+ * Falls back to regex on the raw source string for JS-call-style arguments
+ * where the structured fields are absent.
+ */
+function projectDirsFromExecArguments(args, source) {
+  const dirs = [];
+  for (const field of ["projectDir", "workdir", "cwd"]) {
+    if (isAbsoluteString(args?.[field])) dirs.push(args[field].trim());
+  }
+  if (dirs.length > 0) return dedupeResolved(dirs);
+
+  // Regex fallback for JS-call-style arguments (e.g. {cmd:"...", workdir:"..."})
+  // that were parsed into an object but whose keys may use quoted strings.
+  const workdirMatch = /\bworkdir\s*:\s*["']([^"']+)["']/i.exec(source);
+  const cwdMatch = /\bcwd\s*:\s*["']([^"']+)["']/i.exec(source);
+  const projectDirMatch = /\bprojectDir\s*:\s*["']([^"']+)["']/i.exec(source);
+  if (isAbsoluteString(projectDirMatch?.[1])) dirs.push(projectDirMatch[1]);
+  if (isAbsoluteString(workdirMatch?.[1])) dirs.push(workdirMatch[1]);
+  if (isAbsoluteString(cwdMatch?.[1])) dirs.push(cwdMatch[1]);
+  return dedupeResolved(dirs);
+}
+
+function dedupeResolved(dirs) {
+  const seen = new Set();
+  const result = [];
+  for (const dir of dirs) {
+    const resolved = resolve(dir);
+    if (!seen.has(resolved)) {
+      seen.add(resolved);
+      result.push(dir);
+    }
+  }
+  return result;
+}
+
+async function cowartProjectCandidate(requestedProjectDir, sessionPath, lastSeen) {
+  if (!isAbsoluteString(requestedProjectDir)) return null;
+  let projectDir;
+  try {
+    projectDir = await realpath(requestedProjectDir);
+  } catch {
+    return null;
+  }
+  const canvasDir = join(projectDir, "canvas");
+  if (!(await hasCowartCanvasMarker(canvasDir))) return null;
+  return {
+    projectDir,
+    canvasDir,
+    sessionPath,
+    lastSeenAt: lastSeen.toISOString(),
+  };
+}
+
+async function hasCowartCanvasMarker(canvasDir) {
+  for (const marker of ["cowart-view-state.json", "cowart-selection.json", join("pages", "manifest.json")]) {
+    try {
+      if ((await stat(join(canvasDir, marker))).isFile()) return true;
+    } catch {
+      // Continue checking the narrow set of Cowart-owned marker files.
+    }
+  }
+  return false;
+}
+
+async function recentSessionPaths(sessionsDir, lookbackDays, fullScan) {
+  if (fullScan) return walkJsonlFiles(sessionsDir);
+  const directories = new Set([sessionsDir]);
+  for (let offset = 0; offset < lookbackDays; offset += 1) {
+    const date = new Date(Date.now() - offset * 24 * 60 * 60 * 1000);
+    directories.add(join(sessionsDir, datePart(date.getFullYear()), datePart(date.getMonth() + 1), datePart(date.getDate())));
+    directories.add(join(sessionsDir, datePart(date.getUTCFullYear()), datePart(date.getUTCMonth() + 1), datePart(date.getUTCDate())));
+  }
+
+  const files = [];
+  for (const directory of directories) {
+    let entries;
+    try {
+      entries = await readdir(directory, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isFile() && entry.name.endsWith(".jsonl")) files.push(join(directory, entry.name));
+    }
+  }
+  return files;
+}
+
+async function walkJsonlFiles(root) {
+  let entries;
+  try {
+    entries = await readdir(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const files = [];
+  for (const entry of entries) {
+    const entryPath = join(root, entry.name);
+    if (entry.isDirectory()) files.push(...await walkJsonlFiles(entryPath));
+    else if (entry.isFile() && entry.name.endsWith(".jsonl")) files.push(entryPath);
+  }
+  return files;
+}
+
+function isSafeChildPath(parent, child) {
+  const root = `${resolve(parent)}/`;
+  return resolve(child).startsWith(root);
+}
+
+function isAbsoluteString(value) {
+  return typeof value === "string" && value.trim() && isAbsolute(value.trim());
+}
+
+function datePart(value) {
+  return String(value).padStart(2, "0");
+}

--- a/lib/cowart-canvas-discovery.mjs
+++ b/lib/cowart-canvas-discovery.mjs
@@ -258,40 +258,39 @@ function projectDirsFromArguments(args) {
 }
 
 /**
- * Extracts candidate project directories from a structured exec_command call
- * that launches start-canvas.sh.  Priority: projectDir > workdir > cwd, deduped.
- * Falls back to regex on the raw source string for JS-call-style arguments
- * where the structured fields are absent.
+ * Extracts the highest-priority candidate project directory from an
+ * exec_command call that launches start-canvas.sh.  Priority:
+ * projectDir > workdir > cwd -- only the first absolute field wins.
+ *
+ * Structured JSON: if `args.projectDir` is absolute, it is returned
+ * alone; otherwise `args.workdir`; otherwise `args.cwd`.  Falls back to
+ * regex extraction on the raw source string for JS-call-style
+ * arguments where the structured fields are absent.
+ *
+ * This deliberately returns a single directory so a Cowart launch
+ * cannot expand the watched scope beyond the caller's explicit intent.
  */
 function projectDirsFromExecArguments(args, source) {
-  const dirs = [];
-  for (const field of ["projectDir", "workdir", "cwd"]) {
-    if (isAbsoluteString(args?.[field])) dirs.push(args[field].trim());
-  }
-  if (dirs.length > 0) return dedupeResolved(dirs);
+  const candidate = pickFirstAbsoluteString(args?.projectDir) ?? pickFirstAbsoluteString(args?.workdir) ?? pickFirstAbsoluteString(args?.cwd);
+  if (candidate) return [candidate];
 
   // Regex fallback for JS-call-style arguments (e.g. {cmd:"...", workdir:"..."})
-  // that were parsed into an object but whose keys may use quoted strings.
-  const workdirMatch = /\bworkdir\s*:\s*["']([^"']+)["']/i.exec(source);
-  const cwdMatch = /\bcwd\s*:\s*["']([^"']+)["']/i.exec(source);
-  const projectDirMatch = /\bprojectDir\s*:\s*["']([^"']+)["']/i.exec(source);
-  if (isAbsoluteString(projectDirMatch?.[1])) dirs.push(projectDirMatch[1]);
-  if (isAbsoluteString(workdirMatch?.[1])) dirs.push(workdirMatch[1]);
-  if (isAbsoluteString(cwdMatch?.[1])) dirs.push(cwdMatch[1]);
-  return dedupeResolved(dirs);
+  // where the keys live inside a stringified expression.  Same priority order.
+  const fromRegex =
+    matchAbsoluteString(/\bprojectDir\s*:\s*["']([^"']+)["']/i, source) ??
+    matchAbsoluteString(/\bworkdir\s*:\s*["']([^"']+)["']/i, source) ??
+    matchAbsoluteString(/\bcwd\s*:\s*["']([^"']+)["']/i, source);
+  return fromRegex ? [fromRegex] : [];
 }
 
-function dedupeResolved(dirs) {
-  const seen = new Set();
-  const result = [];
-  for (const dir of dirs) {
-    const resolved = resolve(dir);
-    if (!seen.has(resolved)) {
-      seen.add(resolved);
-      result.push(dir);
-    }
-  }
-  return result;
+function pickFirstAbsoluteString(value) {
+  return isAbsoluteString(value) ? value.trim() : null;
+}
+
+function matchAbsoluteString(regex, source) {
+  if (typeof source !== "string") return null;
+  const match = regex.exec(source);
+  return isAbsoluteString(match?.[1]) ? match[1] : null;
 }
 
 async function cowartProjectCandidate(requestedProjectDir, sessionPath, lastSeen) {

--- a/server.mjs
+++ b/server.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { createAssetStore, mimeTypeForFile } from "./lib/asset-store.mjs";
 import { createCodexImageBridge } from "./lib/codex-image-bridge.mjs";
 import { createCowartBridgeManager } from "./lib/cowart-bridge-manager.mjs";
+import { createCowartCanvasDiscovery } from "./lib/cowart-canvas-discovery.mjs";
 import { createCowartProjectRegistry } from "./lib/cowart-project-registry.mjs";
 import { createCowartMcpClient } from "./lib/cowart-mcp-client.mjs";
 import { chooseCowartInsertTarget, normalizeCowartInsertResult, resolveCowartInsertCanvas, verifyCowartInsert } from "./lib/cowart-insert.mjs";
@@ -16,6 +17,7 @@ const managerDir = resolve(fileURLToPath(new URL(".", import.meta.url)));
 const projectRoot = resolve(process.env.MOSA_PROJECT_DIR || join(managerDir, ".."));
 const port = Number(process.env.MOSA_PORT || 43517);
 const libraryDir = resolve(process.env.MOSA_LIBRARY_DIR || join(homedir(), "MOSA Library"));
+const codexSessionsDir = resolve(process.env.CODEX_SESSIONS_DIR || join(homedir(), ".codex", "sessions"));
 const store = createAssetStore({ projectRoot, managerDir, libraryDir });
 const cowartProjectRegistry = createCowartProjectRegistry({
   managerDir,
@@ -30,7 +32,14 @@ const cowartBridge = createCowartBridgeManager({
 const codexBridge = createCodexImageBridge({
   store,
   imagesDir: store.codexImagesDir,
-  sessionsDir: process.env.CODEX_SESSIONS_DIR,
+  sessionsDir: codexSessionsDir,
+});
+const cowartCanvasDiscovery = createCowartCanvasDiscovery({
+  sessionsDir: codexSessionsDir,
+  managerDir,
+  dedicatedCanvasDir: store.cowartCanvasDir,
+  knownProjectDirs: () => cowartBridge.sources().map((source) => source.projectDir),
+  onDiscover: ({ projectDir }) => cowartBridge.addProject({ projectDir }),
 });
 const cowartMcpClient = createCowartMcpClient({ serverPath: process.env.COWART_MCP_SERVER_PATH });
 const appDir = join(managerDir, "app");
@@ -38,6 +47,7 @@ const derivativeWorker = createDerivativeWorker({ store });
 
 await store.ensureProject("default");
 await cowartBridge.start();
+await cowartCanvasDiscovery.start();
 await codexBridge.start();
 derivativeWorker.start();
 
@@ -97,11 +107,17 @@ async function handleApi(req, res, url) {
   }
 
   if (req.method === "GET" && url.pathname === "/api/bridges") {
-    sendJson(res, 200, { codex: codexBridge.status(), cowart: cowartBridge.status(), cowartInsert: cowartMcpClient.status() });
+    sendJson(res, 200, {
+      codex: codexBridge.status(),
+      cowart: cowartBridge.status(),
+      cowartDiscovery: cowartCanvasDiscovery.status(),
+      cowartInsert: cowartMcpClient.status(),
+    });
     return;
   }
 
   if (req.method === "GET" && url.pathname === "/api/cowart-canvases") {
+    await cowartCanvasDiscovery.reconcile();
     sendJson(res, 200, { canvases: cowartBridge.sources() });
     return;
   }

--- a/test/accessibility-contract.test.mjs
+++ b/test/accessibility-contract.test.mjs
@@ -101,7 +101,9 @@ test("uses a single language chosen from system, Chinese, or English", async () 
   assert.match(app, /data-language-menu/);
   assert.match(app, /function positionLanguageMenu\(\)/);
   assert.match(app, /document\.documentElement\.lang/);
-  assert.match(app, /data-cowart-canvas-form/);
-  assert.match(app, /data-remove-cowart-canvas/);
+  assert.match(app, /自动发现的 Cowart 画布/);
+  assert.match(app, /function cowartCanvasListSignature\(canvases\)/);
+  assert.doesNotMatch(app, /data-cowart-canvas-form/);
+  assert.doesNotMatch(app, /data-remove-cowart-canvas/);
   assert.match(app, /\/api\/cowart-canvases/);
 });

--- a/test/cowart-bridge-manager.test.mjs
+++ b/test/cowart-bridge-manager.test.mjs
@@ -7,7 +7,7 @@ import { createAssetStore } from "../lib/asset-store.mjs";
 import { createCowartBridgeManager } from "../lib/cowart-bridge-manager.mjs";
 import { createCowartProjectRegistry } from "../lib/cowart-project-registry.mjs";
 
-test("archives explicitly registered project-local Cowart canvases", async (t) => {
+test("archives registered project-local Cowart canvases", async (t) => {
   const root = await mkdtemp(join(tmpdir(), "mosa-cowart-manager-"));
   t.after(() => rm(root, { recursive: true, force: true }));
 

--- a/test/cowart-canvas-discovery.test.mjs
+++ b/test/cowart-canvas-discovery.test.mjs
@@ -173,6 +173,126 @@ test("does not discover project when arguments mention start-canvas.sh in a comm
   assert.equal(discovered.length, 0);
 });
 
+test("discovered project is the projectDir even when workdir and cwd point to other canvas-bearing projects", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-cowart-priority-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sessionsDir = join(root, "sessions");
+  const projectDirProject = join(root, "projectdir-project");
+  const workdirProject = join(root, "workdir-project");
+  const cwdProject = join(root, "cwd-project");
+  // All three have a Cowart marker so the test would only show wrong-priority
+  // picks if the function returned multiple fields.
+  await Promise.all([
+    writeCanvasMarker(projectDirProject),
+    writeCanvasMarker(workdirProject),
+    writeCanvasMarker(cwdProject),
+    mkdir(sessionsDir, { recursive: true }),
+  ]);
+
+  await writeFile(join(sessionsDir, "priority.jsonl"), [
+    JSON.stringify({
+      type: "response_item",
+      payload: {
+        type: "custom_tool_call",
+        name: "exec",
+        arguments: JSON.stringify({
+          cmd: "./scripts/start-canvas.sh",
+          projectDir: projectDirProject,
+          workdir: workdirProject,
+          cwd: cwdProject,
+        }),
+      },
+    }),
+  ].join("\n") + "\n", "utf8");
+
+  const discovered = await discoverCowartProjectsFromCodexSessions({ sessionsDir, fullScan: true });
+  const canonicalProjectDirProject = await realpath(projectDirProject);
+  assert.deepEqual(
+    discovered.map((entry) => entry.projectDir),
+    [canonicalProjectDirProject],
+    "expected only the projectDir project to be discovered",
+  );
+});
+
+test("falls back to workdir when projectDir is missing and cwd points to another canvas", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-cowart-workdir-fallback-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sessionsDir = join(root, "sessions");
+  const workdirProject = join(root, "workdir-project");
+  const cwdProject = join(root, "cwd-project");
+  await Promise.all([
+    writeCanvasMarker(workdirProject),
+    writeCanvasMarker(cwdProject),
+    mkdir(sessionsDir, { recursive: true }),
+  ]);
+
+  await writeFile(join(sessionsDir, "workdir-fallback.jsonl"), [
+    JSON.stringify({
+      type: "response_item",
+      payload: {
+        type: "custom_tool_call",
+        name: "exec",
+        arguments: JSON.stringify({
+          cmd: "./scripts/start-canvas.sh",
+          workdir: workdirProject,
+          cwd: cwdProject,
+        }),
+      },
+    }),
+  ].join("\n") + "\n", "utf8");
+
+  const discovered = await discoverCowartProjectsFromCodexSessions({ sessionsDir, fullScan: true });
+  const canonicalWorkdirProject = await realpath(workdirProject);
+  assert.deepEqual(
+    discovered.map((entry) => entry.projectDir),
+    [canonicalWorkdirProject],
+    "expected only the workdir project to be discovered when projectDir is absent",
+  );
+});
+
+test("JS-call-style regex fallback also picks only the first valid field by priority", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-cowart-js-priority-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sessionsDir = join(root, "sessions");
+  const projectDirProject = join(root, "projectdir-project");
+  const workdirProject = join(root, "workdir-project");
+  const cwdProject = join(root, "cwd-project");
+  await Promise.all([
+    writeCanvasMarker(projectDirProject),
+    writeCanvasMarker(workdirProject),
+    writeCanvasMarker(cwdProject),
+    mkdir(sessionsDir, { recursive: true }),
+  ]);
+
+  // JS-call-style: arguments is a stringified expression, parsed by
+  // parseArguments into an object, but we also exercise the raw-source
+  // fallback by setting a projectDir on the object so the first branch
+  // wins without hitting the regex.  Then a second session with NO
+  // structured fields forces the regex fallback and checks workdir wins.
+  await writeFile(join(sessionsDir, "regex-priority.jsonl"), [
+    JSON.stringify({
+      type: "response_item",
+      payload: {
+        type: "custom_tool_call",
+        name: "exec",
+        arguments: JSON.stringify({
+          cmd: "./scripts/start-canvas.sh",
+          workdir: workdirProject,
+          cwd: cwdProject,
+        }),
+      },
+    }),
+  ].join("\n") + "\n", "utf8");
+
+  const discovered = await discoverCowartProjectsFromCodexSessions({ sessionsDir, fullScan: true });
+  const canonicalWorkdirProject = await realpath(workdirProject);
+  assert.deepEqual(
+    discovered.map((entry) => entry.projectDir),
+    [canonicalWorkdirProject],
+    "expected regex fallback to surface only the workdir project",
+  );
+});
+
 async function writeCanvasMarker(projectDir) {
   const canvasDir = join(projectDir, "canvas");
   await mkdir(canvasDir, { recursive: true });

--- a/test/cowart-canvas-discovery.test.mjs
+++ b/test/cowart-canvas-discovery.test.mjs
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { discoverCowartProjectsFromCodexSessions } from "../lib/cowart-canvas-discovery.mjs";
+
+test("discovers only projects with a real Cowart launch call and canvas marker", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-cowart-discovery-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sessionsDir = join(root, "sessions");
+  const nativeProject = join(root, "native-project");
+  const fallbackProject = join(root, "fallback-project");
+  const incidentalProject = join(root, "incidental-project");
+  await Promise.all([
+    writeCanvasMarker(nativeProject),
+    writeCanvasMarker(fallbackProject),
+    writeCanvasMarker(incidentalProject),
+    mkdir(sessionsDir, { recursive: true }),
+  ]);
+
+  await Promise.all([
+    writeSession(join(sessionsDir, "native.jsonl"), nativeProject, {
+      type: "mcp_tool_call",
+      name: "mcp__cowart_mcp__render_cowart_canvas_widget",
+      arguments: JSON.stringify({ projectDir: nativeProject }),
+    }),
+    writeSession(join(sessionsDir, "fallback.jsonl"), fallbackProject, {
+      type: "custom_tool_call",
+      name: "exec",
+      arguments: `const result = await tools.exec_command({cmd:"./scripts/start-canvas.sh ${fallbackProject}",workdir:"${fallbackProject}"});`,
+    }),
+    writeSession(join(sessionsDir, "incidental.jsonl"), incidentalProject, {
+      type: "custom_tool_call",
+      name: "exec",
+      arguments: "const result = await tools.exec_command({cmd:\"rg -n start-canvas.sh .\"});",
+    }),
+  ]);
+
+  const discovered = await discoverCowartProjectsFromCodexSessions({ sessionsDir, fullScan: true });
+  const canonicalNativeProject = await realpath(nativeProject);
+  const canonicalFallbackProject = await realpath(fallbackProject);
+  assert.deepEqual(
+    new Set(discovered.map((entry) => entry.projectDir)),
+    new Set([canonicalNativeProject, canonicalFallbackProject]),
+  );
+  assert.equal(discovered.every((entry) => entry.canvasDir === join(entry.projectDir, "canvas")), true);
+});
+
+test("discovers project from structured JSON arguments with workdir and no turn_context.cwd", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-cowart-workdir-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sessionsDir = join(root, "sessions");
+  const workdirProject = join(root, "workdir-project");
+  await Promise.all([
+    writeCanvasMarker(workdirProject),
+    mkdir(sessionsDir, { recursive: true }),
+  ]);
+
+  // Session with NO turn_context -- the project dir is only in structured
+  // JSON arguments as { cmd, workdir }.
+  await writeFile(join(sessionsDir, "workdir-only.jsonl"), [
+    JSON.stringify({
+      type: "response_item",
+      payload: {
+        type: "custom_tool_call",
+        name: "exec",
+        arguments: JSON.stringify({
+          cmd: "./scripts/start-canvas.sh",
+          workdir: workdirProject,
+        }),
+      },
+    }),
+  ].join("\n") + "\n", "utf8");
+
+  const discovered = await discoverCowartProjectsFromCodexSessions({ sessionsDir, fullScan: true });
+  const canonicalWorkdirProject = await realpath(workdirProject);
+  assert.deepEqual(
+    discovered.map((entry) => entry.projectDir),
+    [canonicalWorkdirProject],
+  );
+  assert.equal(discovered[0].canvasDir, join(canonicalWorkdirProject, "canvas"));
+});
+
+test("discovers project from structured JSON arguments with cwd and no turn_context.cwd", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-cowart-cwd-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sessionsDir = join(root, "sessions");
+  const cwdProject = join(root, "cwd-project");
+  await Promise.all([
+    writeCanvasMarker(cwdProject),
+    mkdir(sessionsDir, { recursive: true }),
+  ]);
+
+  await writeFile(join(sessionsDir, "cwd-only.jsonl"), [
+    JSON.stringify({
+      type: "response_item",
+      payload: {
+        type: "custom_tool_call",
+        name: "exec",
+        arguments: JSON.stringify({
+          cmd: "./scripts/start-canvas.sh",
+          cwd: cwdProject,
+        }),
+      },
+    }),
+  ].join("\n") + "\n", "utf8");
+
+  const discovered = await discoverCowartProjectsFromCodexSessions({ sessionsDir, fullScan: true });
+  const canonicalCwdProject = await realpath(cwdProject);
+  assert.deepEqual(
+    discovered.map((entry) => entry.projectDir),
+    [canonicalCwdProject],
+  );
+});
+
+test("does not discover project when cmd only mentions start-canvas.sh in a search", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-cowart-falsepos-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sessionsDir = join(root, "sessions");
+  const searchProject = join(root, "search-project");
+  await Promise.all([
+    writeCanvasMarker(searchProject),
+    mkdir(sessionsDir, { recursive: true }),
+  ]);
+
+  // The cmd is a search/rg command that merely mentions start-canvas.sh as
+  // a search term -- this must NOT be treated as a launch.
+  await writeFile(join(sessionsDir, "search-mention.jsonl"), [
+    JSON.stringify({
+      type: "response_item",
+      payload: {
+        type: "custom_tool_call",
+        name: "exec",
+        arguments: JSON.stringify({
+          cmd: "rg -n start-canvas.sh .",
+          workdir: searchProject,
+        }),
+      },
+    }),
+  ].join("\n") + "\n", "utf8");
+
+  const discovered = await discoverCowartProjectsFromCodexSessions({ sessionsDir, fullScan: true });
+  assert.equal(discovered.length, 0);
+});
+
+test("does not discover project when arguments mention start-canvas.sh in a comment or string", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-cowart-comment-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const sessionsDir = join(root, "sessions");
+  const commentProject = join(root, "comment-project");
+  await Promise.all([
+    writeCanvasMarker(commentProject),
+    mkdir(sessionsDir, { recursive: true }),
+  ]);
+
+  // The cmd is an echo/comment that mentions start-canvas.sh -- not a launch.
+  await writeFile(join(sessionsDir, "comment-mention.jsonl"), [
+    JSON.stringify({
+      type: "response_item",
+      payload: {
+        type: "custom_tool_call",
+        name: "exec",
+        arguments: JSON.stringify({
+          cmd: 'echo "run start-canvas.sh to open canvas"',
+          workdir: commentProject,
+        }),
+      },
+    }),
+  ].join("\n") + "\n", "utf8");
+
+  const discovered = await discoverCowartProjectsFromCodexSessions({ sessionsDir, fullScan: true });
+  assert.equal(discovered.length, 0);
+});
+
+async function writeCanvasMarker(projectDir) {
+  const canvasDir = join(projectDir, "canvas");
+  await mkdir(canvasDir, { recursive: true });
+  await writeFile(join(canvasDir, "cowart-view-state.json"), "{}\n", "utf8");
+}
+
+async function writeSession(sessionPath, cwd, call) {
+  await writeFile(sessionPath, [
+    { type: "turn_context", payload: { cwd } },
+    { type: "response_item", payload: call },
+  ].map((entry) => JSON.stringify(entry)).join("\n") + "\n", "utf8");
+}

--- a/test/cowart-canvas-discovery.test.mjs
+++ b/test/cowart-canvas-discovery.test.mjs
@@ -250,7 +250,7 @@ test("falls back to workdir when projectDir is missing and cwd points to another
   );
 });
 
-test("JS-call-style regex fallback also picks only the first valid field by priority", async (t) => {
+test("regex fallback on an un-stringified JS call still picks only the first valid field by priority", async (t) => {
   const root = await mkdtemp(join(tmpdir(), "mosa-cowart-js-priority-"));
   t.after(() => rm(root, { recursive: true, force: true }));
   const sessionsDir = join(root, "sessions");
@@ -264,32 +264,38 @@ test("JS-call-style regex fallback also picks only the first valid field by prio
     mkdir(sessionsDir, { recursive: true }),
   ]);
 
-  // JS-call-style: arguments is a stringified expression, parsed by
-  // parseArguments into an object, but we also exercise the raw-source
-  // fallback by setting a projectDir on the object so the first branch
-  // wins without hitting the regex.  Then a second session with NO
-  // structured fields forces the regex fallback and checks workdir wins.
-  await writeFile(join(sessionsDir, "regex-priority.jsonl"), [
+  // The Codex session records the raw source of the tool call verbatim.
+  // parseArguments() cannot turn an un-stringified JS expression into a
+  // structured object, so the extractor must consult `source` via the
+  // projectDir > workdir > cwd regex fallback.  All three directories
+  // have valid Cowart markers; the test only passes if the regex
+  // fallback honours the same priority order and stops at projectDir.
+  const jsExpression = [
+    "const result = await tools.exec_command({",
+    `  cmd:"./scripts/start-canvas.sh",`,
+    `  projectDir:"${projectDirProject}",`,
+    `  workdir:"${workdirProject}",`,
+    `  cwd:"${cwdProject}"`,
+    "});",
+  ].join("\n");
+
+  await writeFile(join(sessionsDir, "js-call-priority.jsonl"), [
     JSON.stringify({
       type: "response_item",
       payload: {
         type: "custom_tool_call",
         name: "exec",
-        arguments: JSON.stringify({
-          cmd: "./scripts/start-canvas.sh",
-          workdir: workdirProject,
-          cwd: cwdProject,
-        }),
+        arguments: jsExpression,
       },
     }),
   ].join("\n") + "\n", "utf8");
 
   const discovered = await discoverCowartProjectsFromCodexSessions({ sessionsDir, fullScan: true });
-  const canonicalWorkdirProject = await realpath(workdirProject);
+  const canonicalProjectDirProject = await realpath(projectDirProject);
   assert.deepEqual(
     discovered.map((entry) => entry.projectDir),
-    [canonicalWorkdirProject],
-    "expected regex fallback to surface only the workdir project",
+    [canonicalProjectDirProject],
+    "expected regex fallback to discover only the projectDir project",
   );
 });
 

--- a/test/server-routes.test.mjs
+++ b/test/server-routes.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { once } from "node:events";
-import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
@@ -10,14 +10,49 @@ import { createSqliteAssetStore } from "../lib/sqlite-asset-store.mjs";
 
 test("returns 404 for a missing library image without stopping the server", async (t) => {
   const root = await mkdtemp(join(tmpdir(), "mosa-server-"));
+  const sessionsDir = join(root, "sessions");
+  const detectedProject = join(root, "detected-project");
+  const workdirOnlyProject = join(root, "workdir-only-project");
+  await mkdir(join(detectedProject, "canvas"), { recursive: true });
+  await mkdir(join(workdirOnlyProject, "canvas"), { recursive: true });
+  await mkdir(sessionsDir, { recursive: true });
+  await writeFile(join(detectedProject, "canvas", "cowart-view-state.json"), "{}\n", "utf8");
+  await writeFile(join(workdirOnlyProject, "canvas", "cowart-view-state.json"), "{}\n", "utf8");
+  // Session 1: has turn_context.cwd + JS-call-style start-canvas.sh
+  await writeFile(join(sessionsDir, "cowart-open.jsonl"), [
+    JSON.stringify({ type: "turn_context", payload: { cwd: detectedProject } }),
+    JSON.stringify({
+      type: "response_item",
+      payload: {
+        type: "custom_tool_call",
+        name: "exec",
+        arguments: `const result = await tools.exec_command({cmd:"./scripts/start-canvas.sh ${detectedProject}",workdir:"${detectedProject}"});`,
+      },
+    }),
+  ].join("\n") + "\n");
+  // Session 2: NO turn_context.cwd -- project dir only in structured JSON workdir.
+  await writeFile(join(sessionsDir, "workdir-only.jsonl"), [
+    JSON.stringify({
+      type: "response_item",
+      payload: {
+        type: "custom_tool_call",
+        name: "exec",
+        arguments: JSON.stringify({
+          cmd: "./scripts/start-canvas.sh",
+          workdir: workdirOnlyProject,
+        }),
+      },
+    }),
+  ].join("\n") + "\n");
   const server = spawn(process.execPath, ["server.mjs"], {
     cwd: process.cwd(),
     env: {
       ...process.env,
       MOSA_PORT: "0",
       MOSA_PROJECT_DIR: root,
+      MOSA_LIBRARY_DIR: join(root, "library"),
       CODEX_GENERATED_IMAGES_DIR: join(root, "generated-images"),
-      CODEX_SESSIONS_DIR: join(root, "sessions"),
+      CODEX_SESSIONS_DIR: sessionsDir,
       COWART_MOSA_CANVAS_DIR: join(root, "cowart-data"),
       MOSA_COWART_REGISTRY_PATH: join(root, "state", "cowart-projects.json"),
     },
@@ -44,6 +79,15 @@ test("returns 404 for a missing library image without stopping the server", asyn
   assert.equal(bridgeStatus.status, 200);
   assert.equal(server.exitCode, null);
 
+  const automaticallyDetected = await fetch(`http://127.0.0.1:${port}/api/cowart-canvases`);
+  assert.equal(automaticallyDetected.status, 200);
+  const detectedCanvases = (await automaticallyDetected.json()).canvases;
+  const canonicalDetectedProject = await realpath(detectedProject);
+  const canonicalWorkdirOnlyProject = await realpath(workdirOnlyProject);
+  assert.equal(detectedCanvases.length, 3);
+  assert.equal(detectedCanvases.some((canvas) => canvas.projectDir === canonicalDetectedProject), true);
+  assert.equal(detectedCanvases.some((canvas) => canvas.projectDir === canonicalWorkdirOnlyProject), true);
+
   const otherProject = join(root, "other-project");
   await mkdir(otherProject, { recursive: true });
   const canonicalOtherProject = await realpath(otherProject);
@@ -59,7 +103,7 @@ test("returns 404 for a missing library image without stopping the server", asyn
 
   const canvases = await fetch(`http://127.0.0.1:${port}/api/cowart-canvases`);
   assert.equal(canvases.status, 200);
-  assert.equal((await canvases.json()).canvases.length, 2);
+  assert.equal((await canvases.json()).canvases.length, 4);
 
   const removeCanvas = await fetch(`http://127.0.0.1:${port}/api/cowart-canvases/${encodeURIComponent(added.canvas.id)}`, { method: "DELETE" });
   assert.equal(removeCanvas.status, 200);
@@ -119,23 +163,28 @@ test("SQLite HTTP surface paginates assets and serves durable derivatives", asyn
 
 async function waitForServerPort(server) {
   server.stdout.setEncoding("utf8");
+  server.stderr.setEncoding("utf8");
   return new Promise((resolvePort, rejectPort) => {
     let output = "";
+    let errorOutput = "";
     const timer = setTimeout(() => finish(new Error("Timed out waiting for MOSA server startup.")), 5000);
     const onOutput = (chunk) => {
       output += chunk;
       const match = /MOSA: http:\/\/127\.0\.0\.1:(\d+)/.exec(output);
       if (match) finish(null, Number(match[1]));
     };
-    const onExit = () => finish(new Error("MOSA server exited during startup."));
+    const onErrorOutput = (chunk) => { errorOutput += chunk; };
+    const onExit = () => finish(new Error(`MOSA server exited during startup.${errorOutput ? `\n${errorOutput}` : ""}`));
     const finish = (error, port) => {
       clearTimeout(timer);
       server.stdout.off("data", onOutput);
+      server.stderr.off("data", onErrorOutput);
       server.off("exit", onExit);
       if (error) rejectPort(error);
       else resolvePort(port);
     };
     server.stdout.on("data", onOutput);
+    server.stderr.on("data", onErrorOutput);
     server.once("exit", onExit);
   });
 }


### PR DESCRIPTION
## Summary

The canvas discovery module only read `projectDir` from tool call arguments, so a real `start-canvas.sh` launch whose project directory lived only in `workdir` or `cwd` (with no `turn_context.cwd`) was silently missed.

## Changes

- **`lib/cowart-canvas-discovery.mjs`**: New `projectDirsFromExecArguments()` extracts project directories with priority `projectDir > workdir > cwd` from structured JSON arguments, with a regex fallback for JS-call-style argument strings. Only real `start-canvas.sh` launches or `render_cowart_canvas_widget` calls trigger discovery.
- **`server.mjs`**: Wires up `createCowartCanvasDiscovery` with session-dir-based event discovery; `GET /api/cowart-canvases` triggers reconcile before responding.
- **`app/app.js`**: Settings page now shows "自动发现的 Cowart 画布" (detected canvases only); manual add/remove UI removed. `refreshBridgeStatus` updates canvas list reactively.
- **Tests**: 4 new regression tests (workdir discovery, cwd discovery, search false-positive, echo false-positive) + server integration test covers the workdir-only path.

## Discovery boundaries (unchanged)

- Only reads `CODEX_SESSIONS_DIR` JSONL session records
- Only accepts real `render_cowart_canvas_widget` or `start-canvas.sh` launch calls
- `realpath` + Cowart marker validation required
- No broad filesystem scanning, no Downloads/Desktop scans
- `rg`/`echo`/comments mentioning `start-canvas.sh` do NOT trigger discovery

## Verification

| Command | Result |
|---------|--------|
| `npm test` | 46 passed, 1 skipped, 0 fail |
| `npm run lint` | Clean |
| `npm run check` | 33 files syntax-checked |
| `npm run audit` | 0 vulnerabilities |
| `git diff --check` | Clean |