### PR TITLE
feat: add branching recipe version history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Added durable WebP preview/thumbnail jobs and gallery pagination while keeping original image URLs compatible.
 - Added automatic monitoring for project-local Cowart canvases opened from Codex while preserving the MOSA dedicated canvas.
 - Added event-based canvas discovery, persisted project registration, per-canvas bridge status, and Cowart project provenance on archived assets.
+- Added asset-based recipe version trees with stable branching history, archived-node visibility, and independent images and provenance per version.
+- Added REST, MCP, and bilingual Web UI surfaces for creating and browsing versions, with required change summaries and typed relationship errors.
+- Added SQLite schema v2 migration tracking, indexed version traversal, duplicate-ID migration validation, and conflict-safe concurrent creates.
+- Changed `asset_duplicate` to start an independent version root while retaining `duplicated_from` provenance.
+- Fixed registered external Cowart canvases so imports trust only that canvas's `pages` root without widening normal import permissions.
 
 ## 0.1.0 — OpenAI Build Week release
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -6,6 +6,7 @@
 
 - 工作目录：`/Users/azhuilab/codex_aigc/mosa`
 - Phase 0-2 已通过 PR #3 合并至 `main`（`b09b657`）；迁移交接记录通过 PR #4 合并（`6d71a6f`），Cowart 自动发现通过 PR #5 合并（`38be7f4`）。
+- `agent/recipe-history` 在 `main@bebec4f` 上实现配方版本树，尚未部署到 `43519`；生产服务仍运行已合并的 PR #5 代码。
 - 真实素材库 `/Users/azhuilab/MOSA Library` 已于 2026-07-22 完成 SQLite 迁移：导入 270 个旧资产与 1 个空分组，并在迁移期间校验了全部 270 个原图哈希。
 - 旧 JSON 与 Prompt 备份位于 `/Users/azhuilab/MOSA Library/legacy-json-backup/2026-07-22T12-26-53-909Z`；不要删除 JSON 源目录、该备份或 `mosa.db`，也不要手工修改迁移状态。
 - `mosa verify` 在迁移后通过（270 个资产）；SQLite 服务启动后 Codex 归档桥接继续正常归档。2026-07-22 受控重启后的最终验收通过（283 个资产、0 个失败）。资产数是动态快照，应以 `ok: true` 与空 `failures` 判断完整性。
@@ -25,7 +26,7 @@
 - SQLite 使用 `better-sqlite3`、FTS5 和游标分页；数据库维护项目、资产、标签、版本、派生任务及迁移状态。
 - `mosa migrate` 先清点并校验旧 JSON 与原图哈希，迁移时保留 JSON/Prompt 备份；失败或未完成时不会激活 SQLite。
 - REST `GET /api/assets` 和 MCP `asset_list` 支持 `limit`（默认 100，最大 250）与 `cursor`，响应保留原有资产字段并增加 `page.total`、`page.nextCursor`。
-- 支持软归档和复制，并保留版本/来源关系。
+- 支持软归档；`asset_duplicate` 创建独立版本根，并通过 `duplicated_from` 保留复制来源。
 - 运行期后端只由迁移完成状态选择，环境变量不能绕过验证或让已迁移素材库回退双写。
 
 ### Phase 2：派生图和图库性能
@@ -43,20 +44,33 @@
 - 本地启动调用只选择一个项目：`projectDir` 优先于 `workdir`，后者优先于 `cwd`。搜索、注释或 `echo` 中提到 `start-canvas.sh` 不会触发监听。
 - 设置页只展示自动发现的画布；保留现有画布 API 以兼容已有客户端。`GET /api/bridges` 在新服务进程中包含 `cowartDiscovery` 状态。
 
+### 后续集成：配方版本树
+
+- 每个版本是独立 asset，拥有自己的图片、Prompt、配方和来源；新图可通过 `imagePath` 直接保存为子版本，不传新图时复制父图形成配方快照。
+- `POST /api/assets/:project/:asset/versions` 与 MCP `asset_version_create` 从当前节点分支并强制填写 `version_change`；GET 路由与 `asset_version_history` 返回包含归档节点的完整稳定 DFS 历史。
+- 普通 PATCH 禁止修改 `parent_asset_id`、`parentAssetId` 与 `child_asset_ids`；children 由父边动态派生。缺失父、跨项目、自环/循环及重复 ID 返回稳定错误。
+- SQLite schema v2 增加父边索引和一次性迁移记录，保留现有 `migration_state`；旧 JSON 迁移会先做父序、重复 ID、跨项目和循环校验。
+- Web 详情页提供双语时间线、“保存当前配方”和“另存为新版本”；异步历史响应只更新 timeline，不覆盖编辑表单。
+- 已登记的外部 Cowart 画布仅在单次桥接导入中信任其 `<canvasDir>/pages` 根，普通素材导入白名单不变。
+
 ## 关键文件
 
 | 领域 | 文件 |
 | --- | --- |
 | SQLite 存储 | `lib/sqlite-asset-store.mjs` |
+| JSON 存储 | `lib/asset-store.mjs` |
+| 版本树共享契约 | `lib/asset-version-history.mjs` |
 | JSON 到 SQLite 迁移与验证 | `lib/library-migration.mjs` |
 | WebP 派生图任务 worker | `lib/derivative-worker.mjs` |
 | CLI | `bin/mosa.mjs` |
 | HTTP 服务和路由 | `server.mjs` |
 | Cowart 画布自动发现 | `lib/cowart-canvas-discovery.mjs` |
 | MCP v1 兼容层 | `mcp/server.mjs` |
+| 版本时间线 UI | `app/app.js`、`app/styles.css` |
 | CI 与本地检查 | `.github/workflows/ci.yml`、`scripts/check-source.mjs` |
 | Core 存储测试 | `test/sqlite-store.test.mjs`、`test/library-migration.test.mjs`、`test/performance.test.mjs` |
 | Cowart 发现回归测试 | `test/cowart-canvas-discovery.test.mjs`、`test/server-routes.test.mjs` |
+| 版本树回归测试 | `test/asset-version-history.test.mjs`、`test/mcp-version-history.test.mjs` |
 
 ## 数据与兼容边界
 
@@ -64,7 +78,7 @@
 - 迁移完成后，SQLite 是唯一运行期权威；JSON 仅作可验证备份，不做长期双写。
 - JSON 损坏、缺失原图或哈希不符会报告具体路径并以非零状态退出，不允许静默跳过。
 - 保持现有 Codex 来源目录白名单、Cowart 的事件式自动发现与服务端允许列表、回插目标允许列表和原图 URL 行为；不扫描任意 Cowart 项目目录。
-- 本次不包含 Tauri、AI 元数据/Embedding、版本树 UI 或 MCP 2.0。
+- 本次不包含 Tauri、AI 元数据/Embedding 或 MCP 2.0。
 
 ## 已完成验证
 
@@ -116,11 +130,27 @@ curl -sS http://127.0.0.1:43519/api/cowart-canvases
 # MOSA 专用画布、new-chat、shen
 npm exec mosa -- verify --library /Users/azhuilab/MOSA\ Library
 # assets: 283; failures: 0; ok: true; migration_state: completed
+
+# agent/recipe-history 分支验证（未触碰生产端口或真实素材库）
+npm test
+# 64 passed, 1 skipped（性能测试默认跳过；包含 2 个 HTTP 路由测试）
+node --test test/asset-version-history.test.mjs test/sqlite-store.test.mjs
+# 9 passed
+node --test test/library-migration.test.mjs
+# 8 passed
+node --test test/mcp-version-history.test.mjs test/accessibility-contract.test.mjs
+# 7 passed
+node --test test/asset-store.test.mjs test/codex-image-bridge.test.mjs test/cowart-bridge-manager.test.mjs test/cowart-bridge.test.mjs test/cowart-canvas-discovery.test.mjs
+# 29 passed
+npm run lint
+npm run check
+git diff --check
+# passed; syntax checked 36 JavaScript files
 ```
 
 ## 后续维护
 
-1. `43519` 已完成 PR #5 的受控重启，无需重复操作。以后仅在获准的维护窗口内重启；不要终止 `43517` 的旧 JSON 服务。新进程必须使用已迁移素材库：
+1. `43519` 已完成 PR #5 的受控重启，但未加载 `agent/recipe-history`。不要用本分支改动生产素材库或端口做验证；以后仅在获准的维护窗口内重启，也不要终止 `43517` 的旧 JSON 服务。新进程必须使用已迁移素材库：
 
 ```bash
 MOSA_LIBRARY_DIR='/Users/azhuilab/MOSA Library' MOSA_PORT=43519 npm start

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,11 +2,19 @@
 
 更新日期：2026-07-22
 
+## 交接结论
+
+- 当前待审分支：`agent/recipe-history`，提交 `efd0d19`，Draft PR [#7](https://github.com/fengseekling-coder/mosa/pull/7) 指向 `main`。
+- 配方版本树实现已完成并推送：JSON/SQLite、REST/MCP、Web 时间线、迁移和 Cowart 导入边界均在该 PR 内。
+- 最终验证：`npm test` 为 64 passed、1 skipped；lint、源码检查和 `git diff --check` 均通过。PR 尚未合并，分支尚未部署。
+- 当前产品是本地 Web UI，不是 Tauri 或可安装的 macOS 桌面应用；本次没有引入桌面壳、`.app` 或 `.dmg`。
+- 下一步只应审阅并合并 PR #7；生产部署必须在维护窗口内执行，且不得改动 `43517`、`43519` 或真实素材库，除非明确授权。
+
 ## 当前状态
 
 - 工作目录：`/Users/azhuilab/codex_aigc/mosa`
 - Phase 0-2 已通过 PR #3 合并至 `main`（`b09b657`）；迁移交接记录通过 PR #4 合并（`6d71a6f`），Cowart 自动发现通过 PR #5 合并（`38be7f4`）。
-- `agent/recipe-history` 在 `main@bebec4f` 上实现配方版本树，尚未部署到 `43519`；生产服务仍运行已合并的 PR #5 代码。
+- `agent/recipe-history` 基于 `main@bebec4f` 实现配方版本树，已推送为 Draft PR #7，尚未部署到 `43519`；生产服务仍运行已合并的 PR #5 代码。
 - 真实素材库 `/Users/azhuilab/MOSA Library` 已于 2026-07-22 完成 SQLite 迁移：导入 270 个旧资产与 1 个空分组，并在迁移期间校验了全部 270 个原图哈希。
 - 旧 JSON 与 Prompt 备份位于 `/Users/azhuilab/MOSA Library/legacy-json-backup/2026-07-22T12-26-53-909Z`；不要删除 JSON 源目录、该备份或 `mosa.db`，也不要手工修改迁移状态。
 - `mosa verify` 在迁移后通过（270 个资产）；SQLite 服务启动后 Codex 归档桥接继续正常归档。2026-07-22 受控重启后的最终验收通过（283 个资产、0 个失败）。资产数是动态快照，应以 `ok: true` 与空 `failures` 判断完整性。

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm exec mosa -- thumbnails rebuild
 
 Use `--library /absolute/path/to/library` to choose another location. Corrupt JSON, corrupt collection data, missing originals, or hash mismatches leave SQLite inactive and report the exact paths. Empty collections are preserved. After a successful migration, `npm start` automatically selects the completed SQLite library; use `MOSA_LIBRARY_DIR` only when choosing a non-default location.
 
-SQLite adds FTS5 search and cursor pagination (`limit` up to 250) without changing existing REST fields or MCP v1 tool names. The gallery requests 100 thumbnails at a time, the inspector uses a 1600px preview when ready, and `/library/<project>/images/<file>` still serves the original asset.
+SQLite adds FTS5 search and cursor pagination (`limit` up to 250) while preserving existing REST fields and MCP tools. Schema v2 adds indexed recipe-version traversal, and the version API/MCP tools are additive. The gallery requests 100 thumbnails at a time, the inspector uses a 1600px preview when ready, and `/library/<project>/images/<file>` still serves the original asset.
 
 The UI follows the system language by default. To inspect the English interface, open **Settings → Language → English** after starting MOSA.
 
@@ -75,9 +75,10 @@ The optional integrations become active when their local source directories are 
 ### What judges can verify
 
 1. Browse and search the included visual records in the Web app.
-2. Open an asset to inspect its full prompt, source type, Codex task ID, original path, dimensions, and provenance status.
-3. Run `npm test` to verify JSON compatibility, SQLite migration, derivative jobs, route behavior, accessibility contracts, Codex reconciliation, and Cowart deduplication. Run `npm run test:performance` separately for the 50,000-asset benchmark.
-4. Review the dated Git history and the `Built with Codex and GPT-5.6` section above for the Build Week implementation record.
+2. Open an asset to inspect its full prompt, provenance, and root-to-branch recipe history, including archived versions.
+3. Save metadata in place, branch a new version with a required change summary, and switch between version nodes without depending on the active gallery page or filter.
+4. Run `npm test` to verify JSON compatibility, SQLite migration, version trees, derivative jobs, route behavior, accessibility contracts, Codex reconciliation, and Cowart deduplication. Run `npm run test:performance` separately for the 50,000-asset benchmark.
+5. Review the dated Git history and the `Built with Codex and GPT-5.6` section above for the Build Week implementation record.
 
 ## 中文产品与集成说明
 
@@ -260,6 +261,23 @@ git add -f assets/default/images/<asset>.png \
 
 本地 HTTP 服务只接受同源浏览器请求，不应通过远程网页、反向代理或公网端口暴露。
 
+### 配方版本历史
+
+MOSA 的版本不是覆盖式编辑日志，而是由独立素材组成的树。每个节点保留自己的图片、Prompt、配方、来源与时间；可以从根节点或任意历史节点继续分支，已归档节点也仍会出现在完整历史中。
+
+- **保存当前配方**通过普通 PATCH 更新当前节点，不创建新版本。
+- **另存为新版本**创建当前节点的直接子节点，`version_change` 必填；传入新的 `imagePath` 时保存真实新图，不传时复制父图作为配方快照。
+- `asset_duplicate` 始终创建新的独立版本根，只在来源中保留 `duplicated_from`。
+- `parent_asset_id` 与 `child_asset_ids` 是只读关系字段，不能通过普通元数据 PATCH 改写。
+- 历史顺序为从根开始的稳定深度优先遍历，包含所有分支和已归档版本。
+
+HTTP 接口：
+
+```text
+GET  /api/assets/:project/:asset/versions
+POST /api/assets/:project/:asset/versions
+```
+
 ### MCP 工具
 
 - `asset_create`
@@ -269,6 +287,8 @@ git add -f assets/default/images/<asset>.png \
 - `asset_attach_prompt`
 - `asset_archive`
 - `asset_duplicate`
+- `asset_version_create`
+- `asset_version_history`
 
 可以直接在仓库父目录运行 MCP 服务进行本地调试：
 
@@ -283,16 +303,17 @@ node mosa/mcp/server.mjs
 - Codex 图片归档在素材管理器服务运行时自动监听标准生成目录；MCP `asset_create` 可用于显式保存和补充生成元数据。
 - Cowart 自动归档依赖素材管理器服务运行，并且只覆盖 MOSA 专用画布和从真实 Cowart 启动事件发现的项目画布。
 - Cowart 自动归档保留画布描述，不具备完整 Prompt；原始 Prompt 需要从生成任务补录。
-- “同配方再生成”当前复制 Codex 指令，不直接调用图像模型。
+- “同配方再生成”复制一条 Codex 指令；生成完成后，Codex 应把图像工具返回的实际 `imagePath` 传给 `asset_version_create`，将新图保存为当前节点的子版本。
 
 ### Build Week 演示清单
 
 1. 展示真实 Codex `image_generation_end` 记录，以及监听器无需点击 Import 即自动归档完整 Prompt 与来源。
 2. 展示 Cowart 中生成或编辑图片后，无需额外入库指令即出现在素材库。
-3. 在 Web 中搜索素材，打开详情页展示 Prompt、配方和来源。
-4. 将库内素材插入 Cowart，展示去重保护与可复用性。
-5. 提交证据：本仓库的 2026-07-17 至 2026-07-19 提交记录可追溯 Codex/GPT-5.6 的增量构建；GitHub 项目简介和本节已说明该闭环。
-6. 已在主构建 Codex 任务中执行 `/feedback`，并将返回的 Session ID 记录在提交材料中。
+3. 在 Web 中搜索素材，打开详情页展示 Prompt、配方、来源与完整版本分支。
+4. 从历史节点另存新版本，展示必填变更说明、真实新图接入和归档版本可见性。
+5. 将库内素材插入 Cowart，展示去重保护与可复用性。
+6. 提交证据：本仓库的 2026-07-17 至 2026-07-19 提交记录可追溯 Codex/GPT-5.6 的增量构建；GitHub 项目简介和本节已说明该闭环。
+7. 已在主构建 Codex 任务中执行 `/feedback`，并将返回的 Session ID 记录在提交材料中。
 
 ## License
 

--- a/app/app.js
+++ b/app/app.js
@@ -27,9 +27,47 @@ Object.assign(translations.en, {
   loadMore: "Load more",
 });
 
+Object.assign(translations.zh, {
+  versionHistory: "版本历史",
+  versionLoading: "正在加载版本…",
+  versionLoadFailed: "无法加载版本历史",
+  versionLabel: "版本 {number}",
+  currentVersion: "当前版本",
+  initialVersion: "初始版本",
+  versionChange: "变更说明",
+  versionChangePlaceholder: "说明这个版本相对当前版本有哪些变化",
+  noVersionChange: "未记录变更说明",
+  saveAsVersion: "另存为新版本",
+  savingVersion: "正在保存版本…",
+  versionSaved: "新版本已保存",
+  versionChangeRequired: "请填写变更说明",
+  discardVersionChanges: "有尚未保存的修改，仍要切换版本吗？",
+  archivedVersion: "已归档",
+  generatedInstruction: "请用相同配方再生成一张图片，并通过 MOSA 的 asset_version_create 保存为当前素材的新版本：",
+});
+
+Object.assign(translations.en, {
+  versionHistory: "Version history",
+  versionLoading: "Loading versions…",
+  versionLoadFailed: "Unable to load version history",
+  versionLabel: "Version {number}",
+  currentVersion: "Current version",
+  initialVersion: "Initial version",
+  versionChange: "Change summary",
+  versionChangePlaceholder: "Describe what changed from the current version",
+  noVersionChange: "No change summary",
+  saveAsVersion: "Save as new version",
+  savingVersion: "Saving version…",
+  versionSaved: "New version saved",
+  versionChangeRequired: "Enter a change summary",
+  discardVersionChanges: "You have unsaved changes. Switch versions anyway?",
+  archivedVersion: "Archived",
+  generatedInstruction: "Regenerate this image with the same recipe, then use MOSA's asset_version_create tool to save it as a new version of the current asset:",
+});
+
 const preference = safeStorageGet("mosa.ui-language") || "system";
 const state = {
-  project: "default", projects: [], cowartCanvases: [], assets: [], pageTotal: 0, nextCursor: null, loadedPageCount: 0, selectedId: null, detailOpen: false, detailDirty: false, imagePreviewId: null, previewReturnFocus: null, query: "",
+  project: "default", projects: [], cowartCanvases: [], assets: [], pageTotal: 0, nextCursor: null, loadedPageCount: 0, selectedId: null, detailAsset: null, versionHistory: null, detailOpen: false, detailDirty: false, imagePreviewId: null, previewReturnFocus: null, query: "",
   filter: { type: "all", value: "" }, groups: { total: 0, favorites: 0, recent: 0, codex: 0, cowart: 0, groups: [], categories: [], styles: [] }, cowartInsertAvailable: false, cowartInsertTargetId: safeStorageGet("mosa.cowart-insert-target") || "mosa",
   libraryPath: "", codexImagesDir: "", modalReturnFocus: null, languagePreference: preference, locale: resolveLocale(preference)
 };
@@ -146,6 +184,7 @@ function bindKeyboardNav() {
     if (els.importModal?.classList.contains("open") || event.target.matches("input, textarea, select")) return;
     if (!state.assets.length) return;
     const index = state.assets.findIndex((asset) => asset.id === state.selectedId);
+    if (index < 0) return;
     if (event.key === "ArrowUp" && index > 0) selectAsset(state.assets[index - 1].id, true);
     if (event.key === "ArrowDown" && index < state.assets.length - 1) selectAsset(state.assets[index + 1].id, true);
   });
@@ -224,19 +263,23 @@ async function loadAssets(options = {}) {
   if (requestId !== assetRequestSequence || assetRequestKey(request) !== assetRequestKey(currentAssetRequest())) return false;
 
   const previousAssets = state.assets;
-  const previousSelected = previousAssets.find((asset) => asset.id === state.selectedId);
+  const previousSelected = selectedAsset();
   const incomingAssets = result.assets || [];
   const nextAssets = options.append
     ? [...state.assets, ...incomingAssets.filter((asset) => !state.assets.some((current) => current.id === asset.id && current.project_id === asset.project_id))]
     : incomingAssets;
-  const nextSelected = nextAssets.find((asset) => asset.id === state.selectedId);
+  const nextSelected = nextAssets.find((asset) => asset.id === state.selectedId)
+    || (state.detailAsset?.id === state.selectedId && state.detailAsset.project_id === request.project ? state.detailAsset : null);
   const assetsChanged = assetListVersion(previousAssets) !== assetListVersion(nextAssets);
   const selectedChanged = assetVersion(previousSelected) !== assetVersion(nextSelected);
   state.assets = nextAssets;
   state.pageTotal = Number(result.page?.total || nextAssets.length);
   state.nextCursor = result.page?.nextCursor || null;
   state.loadedPageCount = options.append ? state.loadedPageCount + 1 : 1;
-  if (state.selectedId && !state.assets.some((asset) => asset.id === state.selectedId)) state.selectedId = null;
+  if (state.detailAsset?.project_id !== request.project) state.detailAsset = null;
+  if (state.detailAsset && state.assets.some((asset) => asset.id === state.detailAsset.id && asset.project_id === state.detailAsset.project_id)) state.detailAsset = null;
+  if (state.selectedId && !state.assets.some((asset) => asset.id === state.selectedId)
+    && !(state.detailAsset?.id === state.selectedId && state.detailAsset.project_id === request.project)) state.selectedId = null;
   if (!options.background || assetsChanged) {
     renderGrid();
     updateViewTitle();
@@ -279,7 +322,7 @@ function assetVersion(asset) {
 
 function isDetailEditorActive() {
   const active = document.activeElement;
-  return state.detailDirty || (active instanceof HTMLElement && Boolean(els.detailPanel?.contains(active) && active.closest("[data-edit]")));
+  return state.detailDirty || (active instanceof HTMLElement && Boolean(els.detailPanel?.contains(active) && active.closest("[data-edit], [data-version-change]")));
 }
 
 async function refreshBridgeStatus() {
@@ -358,7 +401,7 @@ function bindEvents() {
   els.settingsMenu?.addEventListener("change", async (event) => {
     const select = event.target.closest("[data-project-select]");
     if (!select) return;
-    state.project = select.value; state.selectedId = null; state.filter = { type: "all", value: "" }; state.query = ""; els.searchInput.value = "";
+    state.project = select.value; clearDetailSelection(); state.filter = { type: "all", value: "" }; state.query = ""; els.searchInput.value = "";
     await loadStats(); await loadAssets();
   });
   els.settingsMenu?.addEventListener("click", (event) => {
@@ -409,7 +452,7 @@ function setLanguage(value) {
 
 function setFilter(type, value = "") {
   state.filter = { type, value };
-  state.selectedId = null;
+  clearDetailSelection();
   renderQuickFilters(); renderFilterPanel(); loadAssets();
 }
 
@@ -529,8 +572,26 @@ function renderErrorState(error) {
 }
 
 function selectAsset(id, shouldScroll = false) {
-  if (!id) return; state.selectedId = id; setDetailOpen(true); updateSelectedCard();
+  if (!id || !confirmDetailNavigation(id)) return;
+  state.selectedId = id; state.detailAsset = null; state.versionHistory = null; setDetailOpen(true); updateSelectedCard();
   if (shouldScroll) els.assetGrid.querySelector(`.asset-card[data-id="${CSS.escape(id)}"]`)?.scrollIntoView({ behavior: "smooth", block: "center" });
+}
+
+function clearDetailSelection() {
+  state.selectedId = null;
+  state.detailAsset = null;
+  state.versionHistory = null;
+}
+
+function confirmDetailNavigation(nextAssetId) {
+  return !state.detailDirty || nextAssetId === state.selectedId || window.confirm(t("discardVersionChanges"));
+}
+
+function selectedAsset() {
+  return state.assets.find((asset) => asset.id === state.selectedId)
+    || (state.detailAsset?.id === state.selectedId ? state.detailAsset : null)
+    || state.versionHistory?.versions?.find((asset) => asset.id === state.selectedId)
+    || null;
 }
 
 function updateSelectedCard() { els.assetGrid?.querySelectorAll(".asset-card").forEach((card) => { const selected = card.dataset.id === state.selectedId; card.classList.toggle("selected", selected); card.querySelector(".asset-card-select")?.setAttribute("aria-pressed", String(selected)); }); }
@@ -569,13 +630,15 @@ async function saveGroup() {
     await loadStats();
     showToast(`${t("groupCreated")}${result.group.name}`, "success");
     state.filter = { type: "group", value: result.group.name };
-    state.selectedId = null;
+    clearDetailSelection();
     renderQuickFilters(); renderFilterPanel(); await loadAssets();
   });
 }
 
 function openImagePreview(id, trigger) {
-  const asset = state.assets.find((item) => item.id === id);
+  const asset = state.assets.find((item) => item.id === id)
+    || state.versionHistory?.versions?.find((item) => item.id === id)
+    || (state.detailAsset?.id === id ? state.detailAsset : null);
   if (!asset || !els.imagePreviewModal || !els.imagePreviewImage || !els.imagePreviewTitle) return;
   state.imagePreviewId = asset.id;
   state.previewReturnFocus = trigger instanceof HTMLElement ? trigger : document.activeElement;
@@ -620,18 +683,79 @@ function trapImagePreviewFocus(event) {
   event.preventDefault(); focusable[next].focus();
 }
 
+let detailRenderSequence = 0;
+
 function renderDetail() {
   if (!els.detailPanel) return;
-  const asset = state.assets.find((item) => item.id === state.selectedId);
+  const renderId = ++detailRenderSequence;
+  const asset = selectedAsset();
   state.detailDirty = false;
   if (!asset) { els.detailPanel.innerHTML = `<div class="detail-empty"><svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="m21 15-5-5L5 21"/></svg><p>${t(state.assets.length ? "noSelection" : "noAssets")}</p><span>${t(state.assets.length ? "noSelectionHint" : "noAssetsHint")}</span></div>`; return; }
   const source = asset.source || {}; const rating = Math.min(5, Math.max(0, Math.round(asset.rating || 0))); const groupOptions = state.groups.groups.map(([name]) => `<option value="${escapeHtml(name)}"></option>`).join("");
   const metadata = [["skill", asset.skill], ["style", asset.style], ["ratio", asset.ratio], ["theme", asset.theme], ["group", asset.group], ["category", asset.category], ["rating", asset.rating ? `${asset.rating}/5` : ""]].filter(([, value]) => value !== undefined && value !== null && value !== "");
   const sourceRows = buildSourceRows(source).filter(([, value]) => value !== undefined && value !== null && value !== "");
-  els.detailPanel.innerHTML = `<div class="detail-studio-bar"><span>${t("assetInspector")}</span><button class="detail-close" type="button" data-action="close-detail">${t("close")}</button></div><div class="detail-image-wrap"><img class="detail-image" src="${asset.preview_url || asset.image_url}" alt="${escapeHtml(asset.theme || asset.id)}" title="${t("viewFullImage")}" /></div><div class="detail-head"><h3>${escapeHtml(asset.theme || asset.asset || asset.id)}</h3><p>${escapeHtml(asset.id)} · ${formatDate(asset.created_at)}</p></div><div class="detail-actions"><button class="action-btn primary" data-action="copy-prompt">${t("copyPrompt")}</button><button class="action-btn secondary" data-action="regenerate">${t("regenerate")}</button><button class="action-btn secondary" data-action="copy-path">${t("copyPath")}</button></div><section class="section"><div class="section-head"><h4>${t("prompt")}</h4></div><div class="prompt-box">${asset.prompt ? escapeHtml(asset.prompt) : `<span class="empty-copy">${t("notRecorded")}</span>`}</div></section><section class="section"><div class="section-head"><h4>${t("recipe")}</h4></div>${metadata.length ? `<div class="meta-table">${metadata.map(([key, value]) => `<div class="meta-row"><span class="meta-key">${t(key)}</span><span class="meta-val">${key === "rating" ? `<span class="rating-stars">${"★".repeat(rating)}${"☆".repeat(5 - rating)}</span>` : escapeHtml(value)}</span></div>`).join("")}</div>` : `<p class="empty-copy">${t("noDetails")}</p>`}</section><details class="detail-disclosure"><summary>${t("sourceInfo")}</summary><div class="disclosure-content">${sourceRows.length ? `<div class="meta-table">${sourceRows.map(([key, value]) => `<div class="meta-row"><span class="meta-key">${t(key)}</span><span class="meta-val source-value">${escapeHtml(value)}</span></div>`).join("")}</div>` : `<p class="empty-copy">${t("noDetails")}</p>`}</div></details><details class="detail-disclosure"><summary>${t("editMetadata")}</summary><div class="disclosure-content detail-fields"><label class="field"><span>${t("prompt")}</span><textarea data-edit="prompt" rows="5">${escapeHtml(asset.prompt || "")}</textarea></label><div class="two"><label class="field"><span>${t("skill")}</span><input data-edit="skill" value="${escapeHtml(asset.skill || "")}" /></label><label class="field"><span>${t("style")}</span><input data-edit="style" value="${escapeHtml(asset.style || "")}" /></label></div><div class="two"><label class="field"><span>${t("ratio")}</span><input data-edit="ratio" value="${escapeHtml(asset.ratio || "")}" /></label><label class="field"><span>${t("theme")}</span><input data-edit="theme" value="${escapeHtml(asset.theme || "")}" /></label></div><div class="two"><label class="field"><span>${t("group")}</span><input data-edit="group" value="${escapeHtml(asset.group || "")}" list="groupSuggestionsEdit" /><datalist id="groupSuggestionsEdit">${groupOptions}</datalist></label><label class="field"><span>${t("category")}</span><select data-edit="category"><option value="">${t("none")}</option>${categoryOptions(asset.category)}</select></label></div><label class="field"><span>${t("rating")}</span><div class="rating-edit" data-edit="rating">${[1,2,3,4,5].map((number) => `<button type="button" data-val="${number}" class="${number <= rating ? "on" : ""}">${number <= rating ? "★" : "☆"}</button>`).join("")}</div></label><label class="field"><span>${t("businessFields")}</span><textarea data-edit="business_fields" rows="3">${escapeHtml(JSON.stringify(asset.business_fields || {}, null, 2))}</textarea></label><button class="save-recipe-btn" data-action="save-recipe">${t("saveRecipe")}</button></div></details><details class="detail-disclosure"><summary>${t("imageLocation")}</summary><div class="disclosure-content"><div class="path-box">${escapeHtml(asset.image_path)}</div></div></details>`;
+  const cachedHistory = versionHistoryForAsset(asset);
+  els.detailPanel.innerHTML = `<div class="detail-studio-bar"><span>${t("assetInspector")}</span><button class="detail-close" type="button" data-action="close-detail">${t("close")}</button></div><div class="detail-image-wrap"><img class="detail-image" src="${asset.preview_url || asset.image_url}" alt="${escapeHtml(asset.theme || asset.id)}" title="${t("viewFullImage")}" /></div><div class="detail-head"><h3 id="detailTitle" tabindex="-1">${escapeHtml(asset.theme || asset.asset || asset.id)}</h3><p>${escapeHtml(asset.id)} · ${formatDate(asset.created_at)}</p></div><div class="detail-actions"><button class="action-btn primary" type="button" data-action="copy-prompt">${t("copyPrompt")}</button><button class="action-btn secondary" type="button" data-action="regenerate">${t("regenerate")}</button><button class="action-btn secondary" type="button" data-action="copy-path">${t("copyPath")}</button></div><section class="section"><div class="section-head"><h4>${t("prompt")}</h4></div><div class="prompt-box">${asset.prompt ? escapeHtml(asset.prompt) : `<span class="empty-copy">${t("notRecorded")}</span>`}</div></section><section class="section"><div class="section-head"><h4>${t("recipe")}</h4></div>${metadata.length ? `<div class="meta-table">${metadata.map(([key, value]) => `<div class="meta-row"><span class="meta-key">${t(key)}</span><span class="meta-val">${key === "rating" ? `<span class="rating-stars">${"★".repeat(rating)}${"☆".repeat(5 - rating)}</span>` : escapeHtml(value)}</span></div>`).join("")}</div>` : `<p class="empty-copy">${t("noDetails")}</p>`}</section><details class="detail-disclosure" open><summary>${t("versionHistory")}</summary><div class="disclosure-content version-history-region" data-version-history aria-live="polite">${cachedHistory ? versionHistoryMarkup(cachedHistory, asset.id) : `<p class="version-history-status" role="status">${t("versionLoading")}</p>`}</div></details><details class="detail-disclosure"><summary>${t("sourceInfo")}</summary><div class="disclosure-content">${sourceRows.length ? `<div class="meta-table">${sourceRows.map(([key, value]) => `<div class="meta-row"><span class="meta-key">${t(key)}</span><span class="meta-val source-value">${escapeHtml(value)}</span></div>`).join("")}</div>` : `<p class="empty-copy">${t("noDetails")}</p>`}</div></details><details class="detail-disclosure"><summary>${t("editMetadata")}</summary><div class="disclosure-content detail-fields"><label class="field"><span>${t("prompt")}</span><textarea data-edit="prompt" rows="5">${escapeHtml(asset.prompt || "")}</textarea></label><div class="two"><label class="field"><span>${t("skill")}</span><input data-edit="skill" value="${escapeHtml(asset.skill || "")}" /></label><label class="field"><span>${t("style")}</span><input data-edit="style" value="${escapeHtml(asset.style || "")}" /></label></div><div class="two"><label class="field"><span>${t("ratio")}</span><input data-edit="ratio" value="${escapeHtml(asset.ratio || "")}" /></label><label class="field"><span>${t("theme")}</span><input data-edit="theme" value="${escapeHtml(asset.theme || "")}" /></label></div><div class="two"><label class="field"><span>${t("group")}</span><input data-edit="group" value="${escapeHtml(asset.group || "")}" list="groupSuggestionsEdit" /><datalist id="groupSuggestionsEdit">${groupOptions}</datalist></label><label class="field"><span>${t("category")}</span><select data-edit="category"><option value="">${t("none")}</option>${categoryOptions(asset.category)}</select></label></div><label class="field"><span>${t("rating")}</span><div class="rating-edit" data-edit="rating">${[1,2,3,4,5].map((number) => `<button type="button" data-val="${number}" class="${number <= rating ? "on" : ""}" aria-label="${number}/5">${number <= rating ? "★" : "☆"}</button>`).join("")}</div></label><label class="field"><span>${t("businessFields")}</span><textarea data-edit="business_fields" rows="3">${escapeHtml(JSON.stringify(asset.business_fields || {}, null, 2))}</textarea></label><label class="field version-change-field"><span>${t("versionChange")}</span><textarea data-version-change rows="2" placeholder="${escapeHtml(t("versionChangePlaceholder"))}"></textarea></label><div class="recipe-save-actions"><button class="recipe-save-btn secondary" type="button" data-action="save-recipe">${t("saveRecipe")}</button><button class="recipe-save-btn primary" type="button" data-action="save-version">${t("saveAsVersion")}</button></div></div></details><details class="detail-disclosure"><summary>${t("imageLocation")}</summary><div class="disclosure-content"><div class="path-box">${escapeHtml(asset.image_path)}</div></div></details>`;
   els.detailPanel.querySelector(".detail-actions")?.prepend(createCowartInsertControl(asset));
   updateCowartInsertControls();
-  bindDetailEvents(asset);
+  bindDetailEvents(asset, renderId);
+  bindVersionHistoryEvents(cachedHistory);
+  void loadVersionHistory(asset);
+}
+
+let versionHistoryRequestSequence = 0;
+
+function versionHistoryForAsset(asset) {
+  const history = state.versionHistory;
+  if (!history || history.project_id !== asset.project_id) return null;
+  return history.versions?.some((version) => version.id === asset.id) ? history : null;
+}
+
+async function loadVersionHistory(asset) {
+  const requestId = ++versionHistoryRequestSequence;
+  const selectedKey = `${asset.project_id}\u0000${asset.id}`;
+  try {
+    const result = await api(`/api/assets/${encodeURIComponent(asset.project_id)}/${encodeURIComponent(asset.id)}/versions`);
+    if (requestId !== versionHistoryRequestSequence || `${state.project}\u0000${state.selectedId}` !== selectedKey) return;
+    state.versionHistory = result.history;
+    renderVersionHistoryRegion(result.history, asset.id);
+  } catch (error) {
+    if (requestId !== versionHistoryRequestSequence || `${state.project}\u0000${state.selectedId}` !== selectedKey) return;
+    renderVersionHistoryRegion(null, asset.id, error);
+  }
+}
+
+function renderVersionHistoryRegion(history, selectedId, error = null) {
+  const region = els.detailPanel?.querySelector("[data-version-history]");
+  if (!region || state.selectedId !== selectedId) return;
+  region.innerHTML = error
+    ? `<p class="version-history-status error" role="status">${escapeHtml(t("versionLoadFailed"))}: ${escapeHtml(error.message)}</p>`
+    : versionHistoryMarkup(history, selectedId);
+  bindVersionHistoryEvents(history);
+}
+
+function versionHistoryMarkup(history, selectedId) {
+  const versions = history?.versions || [];
+  return `<ol class="version-timeline" aria-label="${escapeHtml(t("versionHistory"))}">${versions.map((version) => {
+    const selected = version.id === selectedId;
+    const depth = Math.min(Math.max(Number(version.version_depth) || 0, 0), 6);
+    const change = version.version_change || (version.version_index === 1 ? t("initialVersion") : t("noVersionChange"));
+    return `<li class="version-timeline-item${selected ? " selected" : ""}" style="--version-depth:${depth}"><button type="button" data-version-id="${escapeHtml(version.id)}"${selected ? ' aria-current="true"' : ""}><span class="version-marker" aria-hidden="true"></span><span class="version-content"><span class="version-title"><strong>${escapeHtml(t("versionLabel", { number: version.version_index }))}</strong>${selected ? `<span class="version-current">${t("currentVersion")}</span>` : ""}${version.archived ? `<span class="version-archived">${t("archivedVersion")}</span>` : ""}</span><span class="version-change">${escapeHtml(change)}</span><time datetime="${escapeHtml(version.created_at || "")}">${escapeHtml(formatDate(version.created_at))}</time></span></button></li>`;
+  }).join("")}</ol>`;
+}
+
+function bindVersionHistoryEvents(history) {
+  if (!history) return;
+  els.detailPanel?.querySelectorAll("[data-version-id]").forEach((button) => button.addEventListener("click", () => {
+    const asset = history.versions.find((version) => version.id === button.dataset.versionId);
+    if (!asset || asset.id === state.selectedId || !confirmDetailNavigation(asset.id)) return;
+    state.selectedId = asset.id;
+    state.detailAsset = asset;
+    state.versionHistory = history;
+    updateSelectedCard();
+    renderDetail();
+    requestAnimationFrame(() => els.detailPanel?.querySelector("#detailTitle")?.focus());
+  }));
 }
 
 function categoryOptions(selected) { return ["product", "concept", "texture", "reference", "other"].map((value) => `<option value="${value}"${selected === value ? " selected" : ""}>${t(`category${value[0].toUpperCase()}${value.slice(1)}`)}</option>`).join(""); }
@@ -642,9 +766,9 @@ function buildSourceRows(source) {
 }
 function sourceName(source = {}) { return source.type === "codex-generated" ? t("sourceCodex") : source.type === "cowart-generated" ? t("sourceCowart") : t("sourceManual"); }
 
-function bindDetailEvents(asset) {
+function bindDetailEvents(asset, renderId) {
   const panel = els.detailPanel;
-  panel.querySelectorAll("[data-edit]").forEach((field) => {
+  panel.querySelectorAll("[data-edit], [data-version-change]").forEach((field) => {
     field.addEventListener("input", () => { state.detailDirty = true; });
     field.addEventListener("change", () => { state.detailDirty = true; });
   });
@@ -667,17 +791,94 @@ function bindDetailEvents(asset) {
   panel.querySelector('[data-action="copy-prompt"]')?.addEventListener("click", () => runAction(async () => { await navigator.clipboard.writeText(asset.prompt || ""); showToast(t("copySuccess"), "success"); }));
   panel.querySelector('[data-action="copy-path"]')?.addEventListener("click", () => runAction(async () => { await navigator.clipboard.writeText(asset.image_path); showToast(t("pathCopied"), "success"); }));
   panel.querySelector('[data-action="regenerate"]')?.addEventListener("click", () => runAction(async () => {
-    const instruction = [t("generatedInstruction"), "", `asset_id: ${asset.id}`, `skill: ${asset.skill || ""}`, `style: ${asset.style || ""}`, `ratio: ${asset.ratio || ""}`, `theme: ${asset.theme || ""}`, `group: ${asset.group || ""}`, `category: ${asset.category || ""}`, `business_fields: ${JSON.stringify(asset.business_fields || {})}`, "", asset.prompt || ""].join("\n");
+    const instruction = [t("generatedInstruction"), "", "tool: asset_version_create", `projectId: ${asset.project_id}`, `assetId: ${asset.id}`, "imagePath: <path returned by image generation>", "version_change:", `skill: ${asset.skill || ""}`, `style: ${asset.style || ""}`, `ratio: ${asset.ratio || ""}`, `theme: ${asset.theme || ""}`, `group: ${asset.group || ""}`, `category: ${asset.category || ""}`, `business_fields: ${JSON.stringify(asset.business_fields || {})}`, "", asset.prompt || ""].join("\n");
     await navigator.clipboard.writeText(instruction); showToast(t("instructionCopied"), "success");
   }));
   panel.querySelectorAll('[data-edit="rating"] button').forEach((button) => button.addEventListener("click", () => { state.detailDirty = true; const value = Number(button.dataset.val); panel.querySelectorAll('[data-edit="rating"] button').forEach((star) => { const on = Number(star.dataset.val) <= value; star.classList.toggle("on", on); star.textContent = on ? "★" : "☆"; }); }));
   panel.querySelector('[data-action="save-recipe"]')?.addEventListener("click", () => runAction(async () => {
-    const businessText = panel.querySelector('[data-edit="business_fields"]').value;
-    let businessFields = {}; try { businessFields = businessText.trim() ? JSON.parse(businessText) : {}; } catch { throw new Error(t("invalidJson")); }
-    const patch = { prompt: panel.querySelector('[data-edit="prompt"]').value, skill: panel.querySelector('[data-edit="skill"]').value, style: panel.querySelector('[data-edit="style"]').value, ratio: panel.querySelector('[data-edit="ratio"]').value, theme: panel.querySelector('[data-edit="theme"]').value, group: panel.querySelector('[data-edit="group"]').value, category: panel.querySelector('[data-edit="category"]').value, rating: panel.querySelectorAll('[data-edit="rating"] button.on').length, business_fields: businessFields };
-    const result = await api(`/api/assets/${encodeURIComponent(asset.project_id)}/${encodeURIComponent(asset.id)}`, { method: "PATCH", body: patch });
-    state.selectedId = result.asset.id; showToast(t("recipeSaved"), "success"); await loadStats(); await loadAssets();
+    const originProjectId = asset.project_id;
+    const originAssetId = asset.id;
+    setRecipeActionsBusy(panel, true, "save-recipe");
+    try {
+      const result = await api(`/api/assets/${encodeURIComponent(originProjectId)}/${encodeURIComponent(originAssetId)}`, { method: "PATCH", body: readRecipeDraft(panel) });
+      showToast(t("recipeSaved"), "success");
+      if (!isCurrentDetailAction(renderId, originProjectId, originAssetId)) return;
+      state.selectedId = result.asset.id;
+      state.detailAsset = result.asset;
+      state.versionHistory = null;
+      state.detailDirty = false;
+      await loadStats();
+      if (!isCurrentDetailSelection(result.asset.project_id, result.asset.id)) return;
+      await loadAssets();
+      if (isCurrentDetailSelection(result.asset.project_id, result.asset.id)) requestAnimationFrame(() => els.detailPanel?.querySelector("#detailTitle")?.focus());
+    } finally {
+      if (renderId === detailRenderSequence) setRecipeActionsBusy(panel, false, "save-recipe");
+    }
   }));
+  panel.querySelector('[data-action="save-version"]')?.addEventListener("click", () => runAction(async () => {
+    const versionChange = panel.querySelector("[data-version-change]")?.value.trim() || "";
+    if (!versionChange) throw new Error(t("versionChangeRequired"));
+    const originProjectId = asset.project_id;
+    const originAssetId = asset.id;
+    setRecipeActionsBusy(panel, true, "save-version");
+    try {
+      const result = await api(`/api/assets/${encodeURIComponent(originProjectId)}/${encodeURIComponent(originAssetId)}/versions`, {
+        method: "POST",
+        body: { ...readRecipeDraft(panel), version_change: versionChange },
+      });
+      showToast(t("versionSaved"), "success");
+      if (!isCurrentDetailAction(renderId, originProjectId, originAssetId)) return;
+      state.selectedId = result.asset.id;
+      state.detailAsset = result.asset;
+      state.versionHistory = null;
+      state.detailDirty = false;
+      await loadStats();
+      if (!isCurrentDetailSelection(result.asset.project_id, result.asset.id)) return;
+      await loadAssets();
+      if (isCurrentDetailSelection(result.asset.project_id, result.asset.id)) requestAnimationFrame(() => els.detailPanel?.querySelector("#detailTitle")?.focus());
+    } finally {
+      if (renderId === detailRenderSequence) setRecipeActionsBusy(panel, false, "save-version");
+    }
+  }));
+}
+
+function readRecipeDraft(panel) {
+  const businessText = panel.querySelector('[data-edit="business_fields"]').value;
+  let businessFields = {};
+  try {
+    businessFields = businessText.trim() ? JSON.parse(businessText) : {};
+  } catch {
+    throw new Error(t("invalidJson"));
+  }
+  return {
+    prompt: panel.querySelector('[data-edit="prompt"]').value,
+    skill: panel.querySelector('[data-edit="skill"]').value,
+    style: panel.querySelector('[data-edit="style"]').value,
+    ratio: panel.querySelector('[data-edit="ratio"]').value,
+    theme: panel.querySelector('[data-edit="theme"]').value,
+    group: panel.querySelector('[data-edit="group"]').value,
+    category: panel.querySelector('[data-edit="category"]').value,
+    rating: panel.querySelectorAll('[data-edit="rating"] button.on').length,
+    business_fields: businessFields,
+  };
+}
+
+function setRecipeActionsBusy(panel, busy, activeAction) {
+  panel.querySelectorAll(".recipe-save-btn").forEach((button) => { button.disabled = busy; });
+  panel.querySelectorAll('input[data-edit], textarea[data-edit], select[data-edit], [data-version-change], [data-edit="rating"] button').forEach((field) => { field.disabled = busy; });
+  const activeButton = panel.querySelector(`[data-action="${activeAction}"]`);
+  if (!activeButton?.isConnected) return;
+  activeButton.textContent = busy
+    ? t(activeAction === "save-version" ? "savingVersion" : "saving")
+    : t(activeAction === "save-version" ? "saveAsVersion" : "saveRecipe");
+}
+
+function isCurrentDetailAction(renderId, projectId, assetId) {
+  return renderId === detailRenderSequence && isCurrentDetailSelection(projectId, assetId);
+}
+
+function isCurrentDetailSelection(projectId, assetId) {
+  return state.project === projectId && state.selectedId === assetId;
 }
 
 function updateCowartInsertControls() {

--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MOSA — 创作资产库</title>
-    <link rel="stylesheet" href="/styles.css?v=16" />
+    <link rel="stylesheet" href="/styles.css?v=17" />
   </head>
   <body>
     <div class="toast-container" id="toastContainer" aria-live="polite"></div>
@@ -116,6 +116,6 @@
       <aside class="detail" id="detailPanel" data-i18n-aria-label="assetInspector" aria-label="素材检视器" aria-hidden="true"></aside>
     </div>
 
-    <script type="module" src="/app.js?v=17"></script>
+    <script type="module" src="/app.js?v=18"></script>
   </body>
 </html>

--- a/app/styles.css
+++ b/app/styles.css
@@ -192,6 +192,24 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
 .detail-disclosure summary::after { margin-left: auto; color: var(--ink-tertiary); content: "+"; font-size: 17px; font-weight: 400; }
 .detail-disclosure[open] summary::after { content: "–"; }
 .disclosure-content { padding: 0 0 15px; }
+.version-history-region { min-height: 36px; }
+.version-history-status { padding: 3px 0 8px; color: var(--ink-tertiary); font-size: 11px; }
+.version-history-status.error { color: var(--danger); overflow-wrap: anywhere; }
+.version-timeline { display: grid; gap: 2px; padding: 0; margin: 0; list-style: none; }
+.version-timeline-item { min-width: 0; margin-left: calc(var(--version-depth, 0) * 12px); }
+.version-timeline-item > button { position: relative; display: flex; width: 100%; min-width: 0; gap: 9px; align-items: flex-start; padding: 7px 8px; border: 0; border-radius: 7px; color: var(--ink-secondary); background: transparent; cursor: pointer; text-align: left; }
+.version-timeline-item > button:hover { color: var(--ink); background: var(--surface-muted); }
+.version-timeline-item.selected > button { color: var(--ink); background: var(--accent-soft); }
+.version-marker { width: 8px; height: 8px; flex: 0 0 auto; margin-top: 5px; border: 2px solid var(--ink-tertiary); border-radius: 50%; background: var(--surface); }
+.version-timeline-item.selected .version-marker { border-color: var(--accent); background: var(--accent); }
+.version-content { display: grid; min-width: 0; flex: 1; gap: 2px; }
+.version-title { display: flex; min-width: 0; flex-wrap: wrap; gap: 5px; align-items: center; }
+.version-title strong { color: inherit; font-size: 11px; }
+.version-current, .version-archived { padding: 1px 5px; border-radius: 5px; font-size: 9px; font-weight: 700; }
+.version-current { color: var(--accent-deep); background: #fff; }
+.version-archived { color: var(--ink-secondary); background: var(--surface-deep); }
+.version-change { color: var(--ink-secondary); font-size: 11px; line-height: 1.4; overflow-wrap: anywhere; }
+.version-content time { color: var(--ink-tertiary); font-size: 9px; }
 .detail-empty { display: flex; min-height: 100%; align-items: center; justify-content: center; padding: 40px 28px; flex-direction: column; color: var(--ink-tertiary); text-align: center; }
 .detail-empty svg { opacity: .3; }
 .detail-empty p { margin-top: 10px; color: var(--ink-secondary); font-weight: 680; }
@@ -213,8 +231,14 @@ input::placeholder, textarea::placeholder { color: var(--ink-tertiary); }
 .rating-edit { display: flex; gap: 2px; }
 .rating-edit button { width: 29px; height: 29px; padding: 0; border: 0; border-radius: 6px; color: #c5c3bd; background: transparent; cursor: pointer; font-size: 16px; }
 .rating-edit button:hover, .rating-edit button.on { color: #b78116; background: #fbf6e7; }
-.save-recipe-btn { width: 100%; height: 36px; border: 1px solid var(--accent); border-radius: 8px; color: #fff; background: var(--accent); cursor: pointer; font-size: 12px; font-weight: 700; }
-.save-recipe-btn:hover { border-color: var(--accent-deep); background: var(--accent-deep); }
+.version-change-field { margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--line); }
+.recipe-save-actions { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 7px; margin-top: 10px; }
+.recipe-save-btn { min-width: 0; min-height: 38px; padding: 6px 8px; border-radius: 8px; cursor: pointer; font-size: 11px; font-weight: 700; line-height: 1.25; white-space: normal; }
+.recipe-save-btn.primary { border: 1px solid var(--accent); color: #fff; background: var(--accent); }
+.recipe-save-btn.primary:hover { border-color: var(--accent-deep); background: var(--accent-deep); }
+.recipe-save-btn.secondary { border: 1px solid var(--line-strong); color: var(--ink-secondary); background: var(--surface); }
+.recipe-save-btn.secondary:hover { color: var(--ink); background: var(--surface-muted); }
+.recipe-save-btn:disabled { cursor: wait; opacity: .55; }
 .modal-overlay { position: fixed; z-index: 100; inset: 0; display: none; align-items: center; justify-content: center; padding: 20px; background: rgba(22,22,20,.28); backdrop-filter: blur(7px); }
 .modal-overlay.open { display: flex; }
 .modal-card { display: flex; width: 526px; max-width: 100%; max-height: min(760px, 88vh); flex-direction: column; overflow: hidden; border: 1px solid var(--line); border-radius: 14px; background: var(--surface); box-shadow: 0 24px 72px rgba(10,10,9,.26); }

--- a/lib/asset-store.mjs
+++ b/lib/asset-store.mjs
@@ -4,6 +4,17 @@ import { createHash, randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { basename, dirname, extname, join, relative, resolve, sep } from "node:path";
 import { createSqliteAssetStore, hasCompletedSqliteLibrary } from "./sqlite-asset-store.mjs";
+import {
+  assetAlreadyExistsError,
+  assetNotFoundError,
+  assetStoreError,
+  assertMutableVersionPatch,
+  buildAssetVersionHistory,
+  derivedAssetSource,
+  pickVersionOverrides,
+  requireVersionChange,
+  versionParentError,
+} from "./asset-version-history.mjs";
 
 const IMAGE_EXTENSIONS = new Set([".apng", ".avif", ".gif", ".jpg", ".jpeg", ".png", ".svg", ".webp"]);
 const DEFAULT_PROJECT_ID = "default";
@@ -79,18 +90,7 @@ export function createJsonAssetStore(options = {}) {
     },
     async listAssets(filters = {}) {
       const projectId = await this.ensureProject(filters.projectId || DEFAULT_PROJECT_ID);
-      const dir = this.metadataDir(projectId);
-      const entries = await readdir(dir, { withFileTypes: true });
-      const assets = [];
-      for (const entry of entries) {
-        if (!entry.isFile() || extname(entry.name).toLowerCase() !== ".json") continue;
-        try {
-          const asset = JSON.parse(await readFile(join(dir, entry.name), "utf8"));
-          assets.push(withRuntimeUrls(asset));
-        } catch {
-          continue;
-        }
-      }
+      const assets = deriveChildAssetIds(await readProjectAssets(this, projectId)).map(withRuntimeUrls);
 
       return assets
         .filter((asset) => matchesQuery(asset, filters.query))
@@ -193,52 +193,78 @@ export function createJsonAssetStore(options = {}) {
     async getAsset(projectId, assetId) {
       const cleanProjectId = sanitizeProjectId(projectId || DEFAULT_PROJECT_ID);
       const cleanAssetId = sanitizeId(assetId, "asset");
-      const file = join(this.metadataDir(cleanProjectId), `${cleanAssetId}.json`);
-      const asset = JSON.parse(await readFile(file, "utf8"));
-      return withRuntimeUrls(asset);
+      const asset = await readAssetMetadata(this, cleanProjectId, cleanAssetId);
+      const projectAssets = await readProjectAssets(this, cleanProjectId);
+      const assets = deriveChildAssetIds([
+        ...projectAssets.filter((item) => item.id !== cleanAssetId),
+        asset,
+      ]);
+      return withRuntimeUrls(assets.find((item) => item.id === cleanAssetId));
     },
-    async createAsset(input = {}) {
+    async createAsset(input = {}, context = {}) {
       const projectId = await this.ensureProject(input.projectId || DEFAULT_PROJECT_ID);
-      const { sourcePath, readablePath } = await resolveReadableImagePath(this, input.imagePath);
+      const { sourcePath, readablePath } = await resolveReadableImagePath(this, input.imagePath, context?.trustedSourceRoots);
       const contentHash = createHash("sha256").update(await readFile(readablePath)).digest("hex");
 
       const codexSource = await codexSourceMetadata(this, readablePath);
       const originalName = sanitizeFileName(input.asset || input.fileName || basename(sourcePath));
       const assetId = sanitizeId(input.assetId || `${slugName(originalName)}-${shortStamp()}`, "asset");
-      const imageName = await uniqueFileName(this.imagesDir(projectId), `${assetId}${extname(originalName) || extname(sourcePath) || ".png"}`);
-      const imagePath = join(this.imagesDir(projectId), imageName);
-      const storageMode = codexSource ? await hardLinkOrCopy(readablePath, imagePath) : (await copyFile(readablePath, imagePath), "copy");
-
-      const prompt = String(input.prompt || "").trim();
-      const promptPath = join(this.promptsDir(projectId), `${assetId}.md`);
-      await writeFile(promptPath, promptFileContent({ ...input, id: assetId }, prompt), "utf8");
-
-      const now = new Date().toISOString();
-      const metadata = normalizeAssetMetadata({
-        ...input,
-        id: assetId,
-        project_id: projectId,
-        asset: imageName,
-        image_path: imagePath,
-        prompt_path: promptPath,
-        prompt,
-        created_at: input.created_at || now,
-        updated_at: now,
-        source: {
-          type: input.sourceType || (codexSource ? "codex-generated" : "local-file"),
-          path: sourcePath,
-          copied_at: now,
-          ...(codexSource || {}),
-          ...(input.source && typeof input.source === "object" ? input.source : {}),
-          content_sha256: contentHash,
-          storage_mode: storageMode,
+      const parentAssetId = normalizeParentAssetId(input.parent_asset_id ?? input.parentAssetId);
+      const lockPath = join(this.metadataDir(projectId), `.${assetId}.create.lock`);
+      const assetLock = await acquireGroupLock(lockPath);
+      try {
+        try {
+          await lstat(join(this.metadataDir(projectId), `${assetId}.json`));
+          throw assetAlreadyExistsError(assetId);
+        } catch (error) {
+          if (error?.code !== "ENOENT") throw error;
         }
-      });
+        const projectAssets = await readProjectAssets(this, projectId);
+        if (projectAssets.some((asset) => asset.id === assetId)) throw assetAlreadyExistsError(assetId);
+        await assertJsonVersionParent(this, projectId, assetId, parentAssetId, projectAssets);
+        const versionChange = parentAssetId && !context?.allowMissingVersionChange
+          ? requireVersionChange(input)
+          : String(input.version_change ?? input.changeSummary ?? "").trim();
+        const imageName = await uniqueFileName(this.imagesDir(projectId), `${assetId}${extname(sourcePath) || extname(originalName) || ".png"}`);
+        const imagePath = join(this.imagesDir(projectId), imageName);
+        const storageMode = codexSource ? await hardLinkOrCopy(readablePath, imagePath) : (await copyFile(readablePath, imagePath), "copy");
 
-      await writeMetadata(this, metadata);
-      if (metadata.group) await ensureGroup(this, projectId, metadata.group);
-      if (metadata.parent_asset_id) await attachChildVersion(this, metadata);
-      return withRuntimeUrls(metadata);
+        const prompt = String(input.prompt || "").trim();
+        const promptPath = join(this.promptsDir(projectId), `${assetId}.md`);
+        await writeFile(promptPath, promptFileContent({ ...input, id: assetId }, prompt), "utf8");
+
+        const timestamp = new Date().toISOString();
+        const metadata = normalizeAssetMetadata({
+          ...input,
+          id: assetId,
+          project_id: projectId,
+          asset: imageName,
+          image_path: imagePath,
+          prompt_path: promptPath,
+          prompt,
+          parent_asset_id: parentAssetId,
+          version_change: versionChange,
+          child_asset_ids: [],
+          created_at: input.created_at || timestamp,
+          updated_at: timestamp,
+          source: {
+            type: input.sourceType || (codexSource ? "codex-generated" : "local-file"),
+            path: sourcePath,
+            copied_at: timestamp,
+            ...(codexSource || {}),
+            ...(input.source && typeof input.source === "object" ? input.source : {}),
+            content_sha256: contentHash,
+            storage_mode: storageMode,
+          }
+        });
+
+        await writeMetadata(this, metadata);
+        if (metadata.group) await ensureGroup(this, projectId, metadata.group);
+        return withRuntimeUrls(metadata);
+      } finally {
+        await assetLock.handle.close().catch(() => {});
+        await releaseGroupLock(lockPath, assetLock.token);
+      }
     },
     async migrateCodexAssetsToHardLinks(projectId = DEFAULT_PROJECT_ID) {
       const cleanProjectId = await this.ensureProject(projectId);
@@ -265,6 +291,7 @@ export function createJsonAssetStore(options = {}) {
       return result;
     },
     async updateMetadata(projectId, assetId, patch = {}) {
+      assertMutableVersionPatch(patch);
       const current = await this.getAsset(projectId, assetId);
       const prompt = Object.hasOwn(patch, "prompt") ? String(patch.prompt || "").trim() : current.prompt;
       const next = normalizeAssetMetadata({
@@ -291,12 +318,58 @@ export function createJsonAssetStore(options = {}) {
       const current = await this.getAsset(projectId, assetId);
       return this.createAsset({
         ...current,
-        ...input,
+        ...pickVersionOverrides(input),
         projectId: current.project_id,
         assetId: input.assetId || `${current.id}-copy-${shortStamp()}`,
         imagePath: current.image_path,
+        parent_asset_id: null,
+        child_asset_ids: [],
+        version_change: "",
+        archived: false,
+        created_at: undefined,
+        updated_at: undefined,
         sourceType: current.source?.type,
-        source: { ...current.source, duplicated_from: current.id },
+        source: derivedAssetSource(current.source, "duplicated_from", current.id),
+      });
+    },
+    async createAssetVersion(projectId, assetId, input = {}) {
+      const current = await this.getAsset(projectId, assetId);
+      const versionChange = requireVersionChange(input);
+      const replacementImagePath = typeof input.imagePath === "string" && input.imagePath.trim() ? input.imagePath : null;
+      const replacementSource = input.source && typeof input.source === "object" ? input.source : {};
+      return this.createAsset({
+        ...current,
+        ...pickVersionOverrides(input),
+        projectId: current.project_id,
+        assetId: input.assetId || input.assetIdNew || `${current.id}-v-${shortStamp()}`,
+        imagePath: replacementImagePath || current.image_path,
+        parent_asset_id: current.id,
+        child_asset_ids: [],
+        version_change: versionChange,
+        archived: false,
+        created_at: undefined,
+        updated_at: undefined,
+        sourceType: replacementImagePath ? input.sourceType : current.source?.type,
+        source: replacementImagePath
+          ? derivedAssetSource(replacementSource, "versioned_from", current.id)
+          : derivedAssetSource(current.source, "versioned_from", current.id),
+      });
+    },
+    async getAssetVersionHistory(projectId, assetId) {
+      const cleanProjectId = sanitizeProjectId(projectId || DEFAULT_PROJECT_ID);
+      const cleanAssetId = sanitizeId(assetId, "asset");
+      const selectedAsset = await readAssetMetadata(this, cleanProjectId, cleanAssetId);
+      const projectAssets = await readProjectAssets(this, cleanProjectId);
+      const assets = deriveChildAssetIds([
+        ...projectAssets.filter((item) => item.id !== cleanAssetId),
+        selectedAsset,
+      ]).map(withRuntimeUrls);
+      const foreignProjectsByAssetId = await findForeignVersionParents(this, cleanProjectId, assets);
+      return buildAssetVersionHistory({
+        projectId: cleanProjectId,
+        selectedAssetId: cleanAssetId,
+        assets,
+        foreignProjectsByAssetId,
       });
     },
     async assetReadStream(projectId, fileName) {
@@ -350,7 +423,7 @@ function normalizeAssetMetadata(input) {
     group: String(input.group || ""),
     category: String(input.category || ""),
     rating: Number.isFinite(input.rating) ? Math.min(5, Math.max(0, Math.round(input.rating))) : 0,
-    parent_asset_id: input.parent_asset_id || input.parentAssetId || null,
+    parent_asset_id: normalizeParentAssetId(input.parent_asset_id ?? input.parentAssetId),
     version_change: String(input.version_change || input.changeSummary || ""),
     child_asset_ids: uniqueArray(input.child_asset_ids || []),
     created_at: input.created_at || new Date().toISOString(),
@@ -535,17 +608,81 @@ function isGroupLockOwnerAlive(owner) {
   }
 }
 
-async function attachChildVersion(store, child) {
+async function readProjectAssets(store, projectId) {
+  const directory = store.metadataDir(projectId);
+  let entries;
   try {
-    const parent = await store.getAsset(child.project_id, child.parent_asset_id);
-    if (!parent.child_asset_ids.includes(child.id)) {
-      parent.child_asset_ids.push(child.id);
-      parent.updated_at = new Date().toISOString();
-      await writeMetadata(store, parent);
-    }
-  } catch {
-    return;
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === "ENOENT") return [];
+    throw error;
   }
+  const assets = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || extname(entry.name).toLowerCase() !== ".json") continue;
+    try {
+      assets.push(JSON.parse(await readFile(join(directory, entry.name), "utf8")));
+    } catch {
+      // Preserve the existing behavior: corrupt records are ignored by list operations.
+    }
+  }
+  return assets;
+}
+
+async function readAssetMetadata(store, projectId, assetId) {
+  try {
+    return JSON.parse(await readFile(join(store.metadataDir(projectId), `${assetId}.json`), "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") throw assetNotFoundError(assetId);
+    throw error;
+  }
+}
+
+function deriveChildAssetIds(assets) {
+  const childrenByParent = new Map();
+  for (const asset of assets) {
+    if (!asset.parent_asset_id) continue;
+    const children = childrenByParent.get(asset.parent_asset_id) || [];
+    children.push(asset);
+    childrenByParent.set(asset.parent_asset_id, children);
+  }
+  for (const children of childrenByParent.values()) {
+    children.sort((left, right) => String(left.created_at || "").localeCompare(String(right.created_at || "")) || String(left.id || "").localeCompare(String(right.id || "")));
+  }
+  return assets.map((asset) => ({ ...asset, child_asset_ids: (childrenByParent.get(asset.id) || []).map((child) => child.id) }));
+}
+
+async function assertJsonVersionParent(store, projectId, assetId, parentAssetId, projectAssets) {
+  if (!parentAssetId) return;
+  if (parentAssetId === assetId) throw assetStoreError("VERSION_CYCLE", `Asset cannot be its own version parent: ${assetId}`);
+  if (projectAssets.some((asset) => asset.id === parentAssetId)) return;
+  const foreign = await findAssetProjects(store, projectId, new Set([parentAssetId]));
+  throw versionParentError(parentAssetId, foreign.get(parentAssetId));
+}
+
+async function findForeignVersionParents(store, projectId, assets) {
+  const localIds = new Set(assets.map((asset) => asset.id));
+  const missingParentIds = new Set(assets.map((asset) => asset.parent_asset_id).filter((id) => id && !localIds.has(id)));
+  return findAssetProjects(store, projectId, missingParentIds);
+}
+
+async function findAssetProjects(store, projectId, assetIds) {
+  const matches = new Map();
+  if (!assetIds.size) return matches;
+  for (const otherProjectId of await store.listProjects()) {
+    if (otherProjectId === projectId) continue;
+    for (const asset of await readProjectAssets(store, otherProjectId)) {
+      if (!assetIds.has(asset.id)) continue;
+      const projects = matches.get(asset.id) || [];
+      projects.push(otherProjectId);
+      matches.set(asset.id, projects);
+    }
+  }
+  return matches;
+}
+
+function normalizeParentAssetId(value) {
+  return value ? sanitizeId(value, "asset") : null;
 }
 
 async function uniqueFileName(directory, preferredName) {
@@ -666,7 +803,7 @@ function slugName(value) {
 }
 
 function shortStamp() {
-  return Date.now().toString(36);
+  return `${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`;
 }
 
 function uniqueArray(values) {
@@ -678,7 +815,7 @@ function resolveRequiredPath(value, label) {
   return resolve(value);
 }
 
-async function resolveReadableImagePath(store, value) {
+async function resolveReadableImagePath(store, value, trustedSourceRoots = []) {
   const requestedPath = resolveRequiredPath(value, "imagePath");
   if (!IMAGE_EXTENSIONS.has(extname(requestedPath).toLowerCase())) {
     throw new Error(`Unsupported image type: ${requestedPath}`);
@@ -689,7 +826,7 @@ async function resolveReadableImagePath(store, value) {
   if (!requestedStat.isFile()) throw new Error(`imagePath is not a file: ${requestedPath}`);
 
   const readablePath = await realpath(requestedPath);
-  await assertWithinReadableProject(store, readablePath);
+  await assertWithinReadableProject(store, readablePath, trustedSourceRoots);
   return { sourcePath: requestedPath, readablePath };
 }
 
@@ -706,14 +843,15 @@ async function resolveStoredAssetPath(store, projectId, fileName) {
   return assetPath;
 }
 
-async function assertWithinReadableProject(store, filePath) {
+async function assertWithinReadableProject(store, filePath, trustedSourceRoots = []) {
   const allowedRoots = [
     store.projectRoot,
     store.generatedImagesDir,
     store.codexImagesDir,
     store.assetsRoot,
-    store.cowartPageAssetsDir
-  ];
+    store.cowartPageAssetsDir,
+    ...(Array.isArray(trustedSourceRoots) ? trustedSourceRoots : []),
+  ].filter((root) => typeof root === "string" && root);
   const resolvedRoots = (await Promise.all(allowedRoots.map(async (root) => {
     try {
       return await realpath(root);

--- a/lib/asset-version-history.mjs
+++ b/lib/asset-version-history.mjs
@@ -1,0 +1,157 @@
+const VERSION_RELATION_FIELDS = ["parent_asset_id", "parentAssetId", "child_asset_ids"];
+const VERSION_EDITABLE_FIELDS = [
+  "prompt",
+  "skill",
+  "style",
+  "ratio",
+  "business_fields",
+  "theme",
+  "tags",
+  "favorite",
+  "group",
+  "category",
+  "rating",
+];
+
+const ERROR_STATUS = Object.freeze({
+  ASSET_NOT_FOUND: 404,
+  ASSET_ALREADY_EXISTS: 409,
+  INVALID_VERSION_CHANGE: 400,
+  VERSION_RELATION_IMMUTABLE: 400,
+  VERSION_PARENT_NOT_FOUND: 409,
+  VERSION_PROJECT_MISMATCH: 409,
+  VERSION_CYCLE: 409,
+  VERSION_HISTORY_TOO_LARGE: 409,
+});
+
+export class AssetStoreError extends Error {
+  constructor(code, message, options = {}) {
+    super(message, options);
+    this.name = "AssetStoreError";
+    this.code = code;
+    this.statusCode = ERROR_STATUS[code] || 500;
+  }
+}
+
+export function assetStoreError(code, message, options) {
+  return new AssetStoreError(code, message, options);
+}
+
+export function assetNotFoundError(assetId) {
+  return assetStoreError("ASSET_NOT_FOUND", `Asset not found: ${assetId}`);
+}
+
+export function assetAlreadyExistsError(assetId) {
+  return assetStoreError("ASSET_ALREADY_EXISTS", `Asset already exists: ${assetId}`);
+}
+
+export function requireVersionChange(input = {}) {
+  const value = String(input.version_change ?? input.changeSummary ?? "").trim();
+  if (!value) throw assetStoreError("INVALID_VERSION_CHANGE", "Version change summary is required.");
+  return value;
+}
+
+export function assertMutableVersionPatch(patch = {}) {
+  const field = VERSION_RELATION_FIELDS.find((key) => Object.hasOwn(patch, key));
+  if (field) throw assetStoreError("VERSION_RELATION_IMMUTABLE", `Version relationship field is read-only: ${field}`);
+}
+
+export function pickVersionOverrides(input = {}) {
+  return Object.fromEntries(VERSION_EDITABLE_FIELDS.filter((key) => Object.hasOwn(input, key)).map((key) => [key, input[key]]));
+}
+
+export function derivedAssetSource(source, relation, assetId) {
+  const {
+    content_sha256: _contentHash,
+    copied_at: _copiedAt,
+    duplicated_from: _duplicatedFrom,
+    storage_linked_at: _storageLinkedAt,
+    storage_mode: _storageMode,
+    versioned_from: _versionedFrom,
+    ...provenance
+  } = source && typeof source === "object" ? source : {};
+  return { ...provenance, [relation]: assetId };
+}
+
+export function versionParentError(parentAssetId, foreignProjects = []) {
+  const projects = [...new Set(foreignProjects.filter(Boolean).map(String))];
+  if (projects.length) {
+    return assetStoreError(
+      "VERSION_PROJECT_MISMATCH",
+      `Version parent ${parentAssetId} belongs to another project: ${projects.join(", ")}`,
+    );
+  }
+  return assetStoreError("VERSION_PARENT_NOT_FOUND", `Version parent not found: ${parentAssetId}`);
+}
+
+export function buildAssetVersionHistory({
+  projectId,
+  selectedAssetId,
+  assets,
+  foreignProjectsByAssetId = new Map(),
+  maxVersions = 5000,
+}) {
+  const assetMap = new Map((assets || []).map((asset) => [asset.id, asset]));
+  const selected = assetMap.get(selectedAssetId);
+  if (!selected) throw assetNotFoundError(selectedAssetId);
+
+  const ancestorIds = new Set();
+  let root = selected;
+  while (root) {
+    if (ancestorIds.has(root.id)) throw assetStoreError("VERSION_CYCLE", `Version cycle detected at asset: ${root.id}`);
+    ancestorIds.add(root.id);
+    if (!root.parent_asset_id) break;
+    const parent = assetMap.get(root.parent_asset_id);
+    if (!parent) throw versionParentError(root.parent_asset_id, foreignProjects(foreignProjectsByAssetId, root.parent_asset_id));
+    root = parent;
+  }
+
+  const childrenByParent = new Map();
+  for (const asset of assetMap.values()) {
+    if (!asset.parent_asset_id || !assetMap.has(asset.parent_asset_id)) continue;
+    const children = childrenByParent.get(asset.parent_asset_id) || [];
+    children.push(asset);
+    childrenByParent.set(asset.parent_asset_id, children);
+  }
+  for (const children of childrenByParent.values()) children.sort(compareVersionAssets);
+
+  const versions = [];
+  const active = new Set();
+  const visited = new Set();
+  const visit = (asset, depth) => {
+    if (active.has(asset.id)) throw assetStoreError("VERSION_CYCLE", `Version cycle detected at asset: ${asset.id}`);
+    if (visited.has(asset.id)) return;
+    if (versions.length >= maxVersions) {
+      throw assetStoreError("VERSION_HISTORY_TOO_LARGE", `Version history exceeds ${maxVersions} assets.`);
+    }
+    active.add(asset.id);
+    visited.add(asset.id);
+    const children = childrenByParent.get(asset.id) || [];
+    versions.push({
+      ...asset,
+      child_asset_ids: children.map((child) => child.id),
+      version_depth: depth,
+      version_index: versions.length + 1,
+    });
+    for (const child of children) visit(child, depth + 1);
+    active.delete(asset.id);
+  };
+  visit(root, 0);
+
+  return {
+    project_id: projectId,
+    root_asset_id: root.id,
+    selected_asset_id: selectedAssetId,
+    versions,
+  };
+}
+
+function foreignProjects(value, assetId) {
+  if (value instanceof Map) return value.get(assetId) || [];
+  return value?.[assetId] || [];
+}
+
+function compareVersionAssets(left, right) {
+  return String(left.created_at || "").localeCompare(String(right.created_at || ""))
+    || String(left.id || "").localeCompare(String(right.id || ""));
+}

--- a/lib/cowart-bridge.mjs
+++ b/lib/cowart-bridge.mjs
@@ -114,6 +114,7 @@ export function createCowartAssetBridge(options = {}) {
 
 export async function reconcileCowartAssets({ store, canvasDir, projectId = DEFAULT_PROJECT_ID, cowartProjectDir = null, sourceId = null }) {
   const candidates = await readCowartAssetCandidates(canvasDir);
+  const trustedPagesRoot = join(resolve(canvasDir), "pages");
   const currentAssets = await store.listAssets({ projectId });
   const knownSourcePaths = new Set(
     currentAssets
@@ -134,34 +135,37 @@ export async function reconcileCowartAssets({ store, canvasDir, projectId = DEFA
       continue;
     }
 
-    const asset = await store.createAsset({
-      projectId,
-      imagePath: candidate.imagePath,
-      prompt: candidate.altText,
-      skill: "Cowart automatic bridge",
-      ratio: candidate.ratio,
-      theme: candidate.altText,
-      sourceType: "cowart-generated",
-      business_fields: {
-        auto_archived: true,
-        prompt_status: "Cowart canvas only provides alt text; attach the original generation prompt when available.",
+    const asset = await store.createAsset(
+      {
+        projectId,
+        imagePath: candidate.imagePath,
+        prompt: candidate.altText,
+        skill: "Cowart automatic bridge",
+        ratio: candidate.ratio,
+        theme: candidate.altText,
+        sourceType: "cowart-generated",
+        business_fields: {
+          auto_archived: true,
+          prompt_status: "Cowart canvas only provides alt text; attach the original generation prompt when available.",
+        },
+        source: {
+          generation_tool: "cowart",
+          cowart_source_id: sourceId,
+          cowart_project_dir: cowartProjectDir,
+          cowart_canvas_dir: candidate.canvasDir,
+          cowart_page_id: candidate.pageId,
+          cowart_page_asset_path: candidate.imagePath,
+          cowart_page_asset_url: candidate.assetUrl,
+          cowart_asset_id: candidate.cowartAssetId,
+          cowart_shape_id: candidate.shapeId,
+          cowart_shape_meta: candidate.shapeMeta,
+          cowart_annotation_source_shape_id: candidate.annotationSourceShapeId || null,
+          replaced_ai_image_holder: candidate.replacedAiImageHolder || null,
+          prompt_status: "canvas-alt-text-only",
+        },
       },
-      source: {
-        generation_tool: "cowart",
-        cowart_source_id: sourceId,
-        cowart_project_dir: cowartProjectDir,
-        cowart_canvas_dir: candidate.canvasDir,
-        cowart_page_id: candidate.pageId,
-        cowart_page_asset_path: candidate.imagePath,
-        cowart_page_asset_url: candidate.assetUrl,
-        cowart_asset_id: candidate.cowartAssetId,
-        cowart_shape_id: candidate.shapeId,
-        cowart_shape_meta: candidate.shapeMeta,
-        cowart_annotation_source_shape_id: candidate.annotationSourceShapeId || null,
-        replaced_ai_image_holder: candidate.replacedAiImageHolder || null,
-        prompt_status: "canvas-alt-text-only",
-      },
-    });
+      { trustedSourceRoots: [trustedPagesRoot] },
+    );
     knownSourcePaths.add(candidate.imagePath);
     imported.push(asset);
   }

--- a/lib/library-migration.mjs
+++ b/lib/library-migration.mjs
@@ -68,7 +68,7 @@ export async function inspectLegacyLibrary(options = {}) {
       records.push({ projectId, metadataPath, imagePath, metadata });
     }
   }
-  return { legacyAssetsRoot, records, groups, issues };
+  return { legacyAssetsRoot, records: orderLegacyVersionRecords(records, issues), groups, issues };
 }
 
 export async function migrateLegacyLibrary(options = {}) {
@@ -130,14 +130,17 @@ export async function migrateLegacyLibrary(options = {}) {
         report.verified += 1;
         continue;
       }
-      const asset = await store.createAsset({
-        ...record.metadata,
-        projectId: record.projectId,
-        assetId: record.metadata.id,
-        imagePath: record.imagePath,
-        sourceType: record.metadata.source?.type,
-        source: record.metadata.source,
-      });
+      const asset = await store.createAsset(
+        {
+          ...record.metadata,
+          projectId: record.projectId,
+          assetId: record.metadata.id,
+          imagePath: record.imagePath,
+          sourceType: record.metadata.source?.type,
+          source: record.metadata.source,
+        },
+        { allowMissingVersionChange: true },
+      );
       const [sourceHash, storedHash] = await Promise.all([hashFile(record.imagePath), hashFile(asset.image_path)]);
       if (sourceHash !== storedHash) {
         const issue = { kind: "post-import-hash-mismatch", path: record.metadataPath, detail: `Imported SQLite asset ${asset.id} does not match legacy original.` };
@@ -195,6 +198,82 @@ async function backupLegacyJson({ libraryDir, legacyAssetsRoot }) {
     }
   }
   return backupPath;
+}
+
+function orderLegacyVersionRecords(records, issues) {
+  const byProject = new Map();
+  const projectsByAssetId = new Map();
+  const duplicateKeys = new Set();
+  for (const record of records) {
+    const projectId = normalizeLegacyId(record.projectId, "default");
+    const assetId = normalizeLegacyId(record.metadata.id, "asset");
+    const key = `${projectId}\u0000${assetId}`;
+    const projectRecords = byProject.get(projectId) || new Map();
+    const existing = projectRecords.get(assetId);
+    if (existing) {
+      if (!duplicateKeys.has(key)) {
+        duplicateKeys.add(key);
+        issues.push({
+          kind: "duplicate-asset-id",
+          path: record.metadataPath,
+          detail: `Asset ID ${assetId} duplicates ${existing.metadataPath} after normalization.`,
+        });
+      }
+    } else projectRecords.set(assetId, record);
+    byProject.set(projectId, projectRecords);
+    const projects = projectsByAssetId.get(assetId) || new Set();
+    projects.add(projectId);
+    projectsByAssetId.set(assetId, projects);
+  }
+
+  for (const record of records) {
+    const projectId = normalizeLegacyId(record.projectId, "default");
+    const rawParentAssetId = record.metadata.parent_asset_id || record.metadata.parentAssetId;
+    const parentAssetId = rawParentAssetId ? normalizeLegacyId(rawParentAssetId, "asset") : null;
+    if (!parentAssetId || byProject.get(projectId)?.has(parentAssetId)) continue;
+    const foreignProjects = [...(projectsByAssetId.get(parentAssetId) || [])].filter((candidate) => candidate !== projectId);
+    issues.push({
+      kind: foreignProjects.length ? "version-project-mismatch" : "version-parent-missing",
+      path: record.metadataPath,
+      detail: foreignProjects.length
+        ? `Version parent ${parentAssetId} belongs to another project: ${foreignProjects.join(", ")}`
+        : `Version parent does not exist: ${parentAssetId}`,
+    });
+  }
+
+  const ordered = [];
+  const state = new Map();
+  const reportedCycles = new Set();
+  const visit = (record) => {
+    const projectId = normalizeLegacyId(record.projectId, "default");
+    const assetId = normalizeLegacyId(record.metadata.id, "asset");
+    const key = `${projectId}\u0000${assetId}`;
+    if (state.get(key) === "done") return;
+    if (state.get(key) === "active") {
+      if (!reportedCycles.has(key)) {
+        reportedCycles.add(key);
+        issues.push({ kind: "version-cycle", path: record.metadataPath, detail: `Version cycle detected at asset: ${assetId}` });
+      }
+      return;
+    }
+    state.set(key, "active");
+    const rawParentAssetId = record.metadata.parent_asset_id || record.metadata.parentAssetId;
+    const parentAssetId = rawParentAssetId ? normalizeLegacyId(rawParentAssetId, "asset") : null;
+    const parent = parentAssetId ? byProject.get(projectId)?.get(parentAssetId) : null;
+    if (parent) visit(parent);
+    state.set(key, "done");
+    ordered.push(record);
+  };
+  for (const record of records) visit(record);
+  const orderedRecords = new Set(ordered);
+  return [...ordered, ...records.filter((record) => !orderedRecords.has(record))];
+}
+
+function normalizeLegacyId(value, fallback) {
+  return String(value || fallback)
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 96) || fallback;
 }
 
 async function hashFile(path) {

--- a/lib/sqlite-asset-store.mjs
+++ b/lib/sqlite-asset-store.mjs
@@ -1,14 +1,26 @@
 import Database from "better-sqlite3";
-import { createReadStream, existsSync, mkdirSync } from "node:fs";
+import { constants as fsConstants, createReadStream, existsSync, mkdirSync } from "node:fs";
 import { copyFile, link, lstat, mkdir, readFile, realpath, stat, unlink } from "node:fs/promises";
 import { createHash, randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { basename, dirname, extname, join, relative, resolve, sep } from "node:path";
+import {
+  assetAlreadyExistsError,
+  assetNotFoundError,
+  assetStoreError,
+  assertMutableVersionPatch,
+  buildAssetVersionHistory,
+  derivedAssetSource,
+  pickVersionOverrides,
+  requireVersionChange,
+  versionParentError,
+} from "./asset-version-history.mjs";
 
 const IMAGE_EXTENSIONS = new Set([".apng", ".avif", ".gif", ".jpg", ".jpeg", ".png", ".svg", ".webp"]);
 const DEFAULT_PROJECT_ID = "default";
 const DEFAULT_PAGE_SIZE = 100;
 const MAX_PAGE_SIZE = 250;
+const CURRENT_SCHEMA_VERSION = 2;
 const NORMALIZED_METADATA_KEYS = new Set([
   "id", "project_id", "projectId", "asset", "image_path", "prompt_path", "prompt", "skill", "style", "ratio", "business_fields", "theme",
   "tags", "favorite", "archived", "group", "category", "rating", "parent_asset_id", "parentAssetId", "version_change", "changeSummary",
@@ -51,7 +63,12 @@ export function createSqliteAssetStore(options = {}) {
   const databasePath = sqliteDatabasePath(libraryDir);
 
   const database = openDatabase(databasePath);
-  initializeSchema(database);
+  try {
+    initializeSchema(database);
+  } catch (error) {
+    database.close();
+    throw error;
+  }
 
   const store = {
     storageKind: "sqlite",
@@ -185,21 +202,34 @@ export function createSqliteAssetStore(options = {}) {
       const cleanProjectId = sanitizeProjectId(projectId || DEFAULT_PROJECT_ID);
       const cleanAssetId = sanitizeId(assetId, "asset");
       const row = database.prepare("SELECT * FROM assets WHERE project_id = ? AND id = ?").get(cleanProjectId, cleanAssetId);
-      if (!row) throw new Error(`Asset not found: ${cleanAssetId}`);
+      if (!row) throw assetNotFoundError(cleanAssetId);
       return rowToAsset(database, row);
     },
-    async createAsset(input = {}) {
+    async createAsset(input = {}, context = {}) {
       const projectId = await this.ensureProject(input.projectId || DEFAULT_PROJECT_ID);
-      const { sourcePath, readablePath } = await resolveReadableImagePath(store, input.imagePath);
+      const { sourcePath, readablePath } = await resolveReadableImagePath(store, input.imagePath, context?.trustedSourceRoots);
       const contentHash = createHash("sha256").update(await readFile(readablePath)).digest("hex");
       const codexSource = await codexSourceMetadata(store, readablePath);
       const originalName = sanitizeFileName(input.asset || input.fileName || basename(sourcePath));
       const assetId = sanitizeId(input.assetId || `${slugName(originalName)}-${shortStamp()}`, "asset");
+      const parentAssetId = normalizeParentAssetId(input.parent_asset_id ?? input.parentAssetId);
       const existing = database.prepare("SELECT id FROM assets WHERE project_id = ? AND id = ?").get(projectId, assetId);
-      if (existing) throw new Error(`Asset already exists: ${assetId}`);
-      const imageName = `${assetId}${extname(originalName) || extname(sourcePath) || ".png"}`;
+      if (existing) throw assetAlreadyExistsError(assetId);
+      assertSqliteVersionParent(database, projectId, assetId, parentAssetId);
+      const versionChange = parentAssetId && !context?.allowMissingVersionChange
+        ? requireVersionChange(input)
+        : String(input.version_change ?? input.changeSummary ?? "").trim();
+      const imageName = `${assetId}${extname(sourcePath) || extname(originalName) || ".png"}`;
       const imagePath = join(this.imagesDir(projectId), imageName);
-      const storageMode = codexSource ? await hardLinkOrCopy(readablePath, imagePath) : (await copyFile(readablePath, imagePath), "copy");
+      let storageMode;
+      try {
+        storageMode = codexSource
+          ? await hardLinkOrCopy(readablePath, imagePath)
+          : (await copyFile(readablePath, imagePath, fsConstants.COPYFILE_EXCL), "copy");
+      } catch (error) {
+        if (error?.code === "EEXIST") throw assetAlreadyExistsError(assetId);
+        throw error;
+      }
       const timestamp = now();
       const metadata = normalizeAssetMetadata({
         ...input,
@@ -209,6 +239,9 @@ export function createSqliteAssetStore(options = {}) {
         image_path: imagePath,
         prompt_path: null,
         prompt: String(input.prompt || "").trim(),
+        parent_asset_id: parentAssetId,
+        version_change: versionChange,
+        child_asset_ids: [],
         created_at: input.created_at || timestamp,
         updated_at: timestamp,
         source: {
@@ -222,14 +255,16 @@ export function createSqliteAssetStore(options = {}) {
         },
       });
       try {
-        saveAsset(database, metadata, { enqueueDerivative: true });
+        saveAsset(database, metadata, { enqueueDerivative: true, insertOnly: true });
       } catch (error) {
         await unlink(imagePath).catch(() => {});
+        if (isSqliteDuplicateError(error)) throw assetAlreadyExistsError(assetId);
         throw error;
       }
       return rowToAsset(database, database.prepare("SELECT * FROM assets WHERE project_id = ? AND id = ?").get(projectId, assetId));
     },
     async updateMetadata(projectId, assetId, patch = {}) {
+      assertMutableVersionPatch(patch);
       const current = await this.getAsset(projectId, assetId);
       const metadata = normalizeAssetMetadata({
         ...current,
@@ -253,13 +288,59 @@ export function createSqliteAssetStore(options = {}) {
       const current = await this.getAsset(projectId, assetId);
       return this.createAsset({
         ...current,
-        ...input,
+        ...pickVersionOverrides(input),
         projectId: current.project_id,
         assetId: input.assetId || `${current.id}-copy-${shortStamp()}`,
         imagePath: current.image_path,
-        parent_asset_id: input.parent_asset_id ?? current.parent_asset_id,
+        parent_asset_id: null,
+        child_asset_ids: [],
+        version_change: "",
+        archived: false,
+        created_at: undefined,
+        updated_at: undefined,
         sourceType: current.source?.type,
-        source: { ...current.source, duplicated_from: current.id },
+        source: derivedAssetSource(current.source, "duplicated_from", current.id),
+      });
+    },
+    async createAssetVersion(projectId, assetId, input = {}) {
+      const current = await this.getAsset(projectId, assetId);
+      const versionChange = requireVersionChange(input);
+      const replacementImagePath = typeof input.imagePath === "string" && input.imagePath.trim() ? input.imagePath : null;
+      const replacementSource = input.source && typeof input.source === "object" ? input.source : {};
+      return this.createAsset({
+        ...current,
+        ...pickVersionOverrides(input),
+        projectId: current.project_id,
+        assetId: input.assetId || input.assetIdNew || `${current.id}-v-${shortStamp()}`,
+        imagePath: replacementImagePath || current.image_path,
+        parent_asset_id: current.id,
+        child_asset_ids: [],
+        version_change: versionChange,
+        archived: false,
+        created_at: undefined,
+        updated_at: undefined,
+        sourceType: replacementImagePath ? input.sourceType : current.source?.type,
+        source: replacementImagePath
+          ? derivedAssetSource(replacementSource, "versioned_from", current.id)
+          : derivedAssetSource(current.source, "versioned_from", current.id),
+      });
+    },
+    async getAssetVersionHistory(projectId, assetId) {
+      const cleanProjectId = sanitizeProjectId(projectId || DEFAULT_PROJECT_ID);
+      const cleanAssetId = sanitizeId(assetId, "asset");
+      const rootAssetId = findSqliteVersionRoot(database, cleanProjectId, cleanAssetId);
+      const rows = database.prepare(`
+        WITH RECURSIVE family(id) AS (
+          SELECT ?
+          UNION
+          SELECT v.asset_id FROM asset_versions v JOIN family f ON v.parent_asset_id = f.id WHERE v.project_id = ?
+        )
+        SELECT a.* FROM assets a JOIN family f ON f.id = a.id WHERE a.project_id = ?
+      `).all(rootAssetId, cleanProjectId, cleanProjectId);
+      return buildAssetVersionHistory({
+        projectId: cleanProjectId,
+        selectedAssetId: cleanAssetId,
+        assets: rows.map((row) => rowToAsset(database, row)),
       });
     },
     async assetReadStream(projectId, fileName) {
@@ -390,6 +471,17 @@ function initializeSchema(database) {
   database.exec(`
     CREATE TABLE IF NOT EXISTS library_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL);
     CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
+  `);
+  const schemaRow = database.prepare("SELECT value FROM library_meta WHERE key = 'schema_version'").get();
+  const existingVersion = schemaRow ? Number(schemaRow.value) : 0;
+  if (!Number.isInteger(existingVersion) || existingVersion < 0) {
+    throw new Error(`Invalid MOSA schema version: ${schemaRow?.value ?? ""}`);
+  }
+  if (existingVersion > CURRENT_SCHEMA_VERSION) {
+    throw new Error(`MOSA schema version ${existingVersion} is newer than supported version ${CURRENT_SCHEMA_VERSION}.`);
+  }
+
+  database.exec(`
     CREATE TABLE IF NOT EXISTS projects (id TEXT PRIMARY KEY, created_at TEXT NOT NULL);
     CREATE TABLE IF NOT EXISTS groups (project_id TEXT NOT NULL, name TEXT NOT NULL, created_at TEXT NOT NULL, PRIMARY KEY (project_id, name));
     CREATE UNIQUE INDEX IF NOT EXISTS groups_project_name_ci_idx ON groups(project_id, name COLLATE NOCASE);
@@ -435,9 +527,17 @@ function initializeSchema(database) {
     CREATE VIRTUAL TABLE IF NOT EXISTS asset_fts USING fts5(project_id UNINDEXED, asset_id UNINDEXED, content, tokenize='trigram');
   `);
   const timestamp = now();
-  database.prepare("INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (1, ?)").run(timestamp);
-  database.prepare("INSERT OR IGNORE INTO library_meta (key, value, updated_at) VALUES ('schema_version', '1', ?)").run(timestamp);
-  database.prepare("INSERT OR IGNORE INTO library_meta (key, value, updated_at) VALUES ('migration_state', 'unmigrated', ?)").run(timestamp);
+  database.transaction(() => {
+    database.prepare("INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (1, ?)").run(timestamp);
+    database.exec("CREATE INDEX IF NOT EXISTS asset_versions_parent_idx ON asset_versions(project_id, parent_asset_id, created_at, asset_id)");
+    database.prepare("INSERT OR IGNORE INTO schema_migrations (version, applied_at) VALUES (2, ?)").run(timestamp);
+    database.prepare(`
+      INSERT INTO library_meta (key, value, updated_at) VALUES ('schema_version', ?, ?)
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+      WHERE library_meta.value != excluded.value
+    `).run(String(CURRENT_SCHEMA_VERSION), timestamp);
+    database.prepare("INSERT OR IGNORE INTO library_meta (key, value, updated_at) VALUES ('migration_state', 'unmigrated', ?)").run(timestamp);
+  })();
 }
 
 function saveAsset(database, metadata, options = {}) {
@@ -446,6 +546,15 @@ function saveAsset(database, metadata, options = {}) {
   const unknownMetadata = unknownFields(metadata);
   const write = database.transaction(() => {
     database.prepare("INSERT OR IGNORE INTO projects (id, created_at) VALUES (?, ?)").run(metadata.project_id, metadata.created_at);
+    const updateOnConflict = options.insertOnly ? "" : `
+      ON CONFLICT(project_id, id) DO UPDATE SET
+        prompt = excluded.prompt, skill = excluded.skill, style = excluded.style, ratio = excluded.ratio,
+        business_fields_json = excluded.business_fields_json, theme = excluded.theme, favorite = excluded.favorite,
+        archived = excluded.archived, group_name = excluded.group_name, category = excluded.category, rating = excluded.rating,
+        parent_asset_id = excluded.parent_asset_id, version_change = excluded.version_change, source_type = excluded.source_type,
+        source_json = excluded.source_json, metadata_json = excluded.metadata_json, search_text = excluded.search_text,
+        updated_at = excluded.updated_at
+    `;
     database.prepare(`
       INSERT INTO assets (
         project_id, id, asset, original_path, preview_path, thumbnail_path, content_sha256, prompt, skill, style, ratio,
@@ -456,13 +565,7 @@ function saveAsset(database, metadata, options = {}) {
         @business_fields_json, @theme, @favorite, @archived, @group_name, @category, @rating, @parent_asset_id, @version_change,
         @source_type, @source_json, @metadata_json, @search_text, @created_at, @updated_at
       )
-      ON CONFLICT(project_id, id) DO UPDATE SET
-        prompt = excluded.prompt, skill = excluded.skill, style = excluded.style, ratio = excluded.ratio,
-        business_fields_json = excluded.business_fields_json, theme = excluded.theme, favorite = excluded.favorite,
-        archived = excluded.archived, group_name = excluded.group_name, category = excluded.category, rating = excluded.rating,
-        parent_asset_id = excluded.parent_asset_id, version_change = excluded.version_change, source_type = excluded.source_type,
-        source_json = excluded.source_json, metadata_json = excluded.metadata_json, search_text = excluded.search_text,
-        updated_at = excluded.updated_at
+      ${updateOnConflict}
     `).run({
       project_id: metadata.project_id,
       id: metadata.id,
@@ -622,7 +725,7 @@ function normalizeAssetMetadata(input) {
     group: String(input.group || ""),
     category: String(input.category || ""),
     rating: Number.isFinite(input.rating) ? Math.min(5, Math.max(0, Math.round(input.rating))) : 0,
-    parent_asset_id: input.parent_asset_id || input.parentAssetId || null,
+    parent_asset_id: normalizeParentAssetId(input.parent_asset_id ?? input.parentAssetId),
     version_change: String(input.version_change || input.changeSummary || ""),
     child_asset_ids: uniqueArray(input.child_asset_ids || []),
     created_at: input.created_at || now(),
@@ -672,19 +775,27 @@ function parseCursor(value) {
   }
 }
 
-async function resolveReadableImagePath(store, value) {
+async function resolveReadableImagePath(store, value, trustedSourceRoots = []) {
   const requestedPath = resolveRequiredPath(value, "imagePath");
   if (!IMAGE_EXTENSIONS.has(extname(requestedPath).toLowerCase())) throw new Error(`Unsupported image type: ${requestedPath}`);
   const requestedStat = await lstat(requestedPath);
   if (requestedStat.isSymbolicLink()) throw new Error(`Refusing to import symbolic links: ${requestedPath}`);
   if (!requestedStat.isFile()) throw new Error(`imagePath is not a file: ${requestedPath}`);
   const readablePath = await realpath(requestedPath);
-  await assertWithinReadableProject(store, readablePath);
+  await assertWithinReadableProject(store, readablePath, trustedSourceRoots);
   return { sourcePath: requestedPath, readablePath };
 }
 
-async function assertWithinReadableProject(store, filePath) {
-  const allowedRoots = [store.projectRoot, store.generatedImagesDir, store.codexImagesDir, store.assetsRoot, store.cowartPageAssetsDir, store.legacyAssetsRoot].filter(Boolean);
+async function assertWithinReadableProject(store, filePath, trustedSourceRoots = []) {
+  const allowedRoots = [
+    store.projectRoot,
+    store.generatedImagesDir,
+    store.codexImagesDir,
+    store.assetsRoot,
+    store.cowartPageAssetsDir,
+    store.legacyAssetsRoot,
+    ...(Array.isArray(trustedSourceRoots) ? trustedSourceRoots : []),
+  ].filter((root) => typeof root === "string" && root);
   const roots = (await Promise.all(allowedRoots.map(async (root) => {
     try { return await realpath(root); } catch (error) { if (error?.code === "ENOENT") return null; throw error; }
   }))).filter(Boolean);
@@ -711,9 +822,13 @@ async function hardLinkOrCopy(sourcePath, targetPath) {
   try { await link(sourcePath, targetPath); return "hard-link"; }
   catch (error) {
     if (!["EXDEV", "EPERM", "EOPNOTSUPP", "ENOTSUP", "EMLINK"].includes(error?.code)) throw error;
-    await copyFile(sourcePath, targetPath);
+    await copyFile(sourcePath, targetPath, fsConstants.COPYFILE_EXCL);
     return "copy";
   }
+}
+
+function isSqliteDuplicateError(error) {
+  return ["SQLITE_CONSTRAINT_PRIMARYKEY", "SQLITE_CONSTRAINT_UNIQUE"].includes(error?.code);
 }
 
 function parseBusinessFields(value) {
@@ -728,11 +843,41 @@ function parseJson(value, fallback) {
   try { return value ? JSON.parse(value) : fallback; } catch { return fallback; }
 }
 
+function assertSqliteVersionParent(database, projectId, assetId, parentAssetId) {
+  if (!parentAssetId) return;
+  if (parentAssetId === assetId) throw assetStoreError("VERSION_CYCLE", `Asset cannot be its own version parent: ${assetId}`);
+  if (database.prepare("SELECT 1 FROM assets WHERE project_id = ? AND id = ?").get(projectId, parentAssetId)) return;
+  const foreignProjects = database.prepare("SELECT project_id FROM assets WHERE id = ? AND project_id != ? ORDER BY project_id").all(parentAssetId, projectId).map((row) => row.project_id);
+  throw versionParentError(parentAssetId, foreignProjects);
+}
+
+function findSqliteVersionRoot(database, projectId, assetId) {
+  const visited = new Set();
+  let currentAssetId = assetId;
+  while (currentAssetId) {
+    if (visited.has(currentAssetId)) throw assetStoreError("VERSION_CYCLE", `Version cycle detected at asset: ${currentAssetId}`);
+    visited.add(currentAssetId);
+    const row = database.prepare("SELECT id, parent_asset_id FROM assets WHERE project_id = ? AND id = ?").get(projectId, currentAssetId);
+    if (!row) {
+      if (currentAssetId === assetId) throw assetNotFoundError(assetId);
+      const foreignProjects = database.prepare("SELECT project_id FROM assets WHERE id = ? AND project_id != ? ORDER BY project_id").all(currentAssetId, projectId).map((item) => item.project_id);
+      throw versionParentError(currentAssetId, foreignProjects);
+    }
+    if (!row.parent_asset_id) return row.id;
+    currentAssetId = row.parent_asset_id;
+  }
+  throw assetStoreError("VERSION_CYCLE", `Version cycle detected at asset: ${assetId}`);
+}
+
+function normalizeParentAssetId(value) {
+  return value ? sanitizeId(value, "asset") : null;
+}
+
 function sanitizeProjectId(value) { return sanitizeId(value || DEFAULT_PROJECT_ID, DEFAULT_PROJECT_ID); }
 function sanitizeId(value, fallback) { return String(value || fallback).replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 96) || fallback; }
 function sanitizeFileName(value) { const raw = basename(String(value || "asset.png")); const extension = extname(raw) || ".png"; const base = raw.slice(0, raw.length - extname(raw).length).replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, ""); return `${base || "asset"}${extension}`; }
 function slugName(value) { return sanitizeId(String(value || "asset").replace(/\.[^.]+$/, ""), "asset").slice(0, 56); }
-function shortStamp() { return Date.now().toString(36); }
+function shortStamp() { return `${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`; }
 function uniqueArray(values) { return [...new Set((Array.isArray(values) ? values : []).filter(Boolean).map(String))]; }
 function normalizeGroupName(value) { return String(value || "").trim().replace(/\s+/g, " ").slice(0, 80); }
 function resolveRequiredPath(value, label) { if (!value || typeof value !== "string") throw new Error(`${label} is required.`); return resolve(value); }

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -16,6 +16,8 @@ const TOOL_ASSET_UPDATE_METADATA = "asset_update_metadata";
 const TOOL_ASSET_ATTACH_PROMPT = "asset_attach_prompt";
 const TOOL_ASSET_ARCHIVE = "asset_archive";
 const TOOL_ASSET_DUPLICATE = "asset_duplicate";
+const TOOL_ASSET_VERSION_CREATE = "asset_version_create";
+const TOOL_ASSET_VERSION_HISTORY = "asset_version_history";
 
 function send(message) {
   process.stdout.write(`${JSON.stringify(message)}\n`);
@@ -89,10 +91,53 @@ function toolDefinitions() {
     },
     {
       name: TOOL_ASSET_DUPLICATE,
-      description: "Create an independent editable copy of an asset while retaining duplicate provenance.",
+      description: "Create an independent editable copy that starts a new version root while retaining duplicate provenance.",
       inputSchema: {
         type: "object",
-        properties: { projectId: { type: "string" }, assetId: { type: "string" }, assetIdNew: { type: "string" }, version_change: { type: "string" } },
+        properties: { projectId: { type: "string" }, assetId: { type: "string" }, assetIdNew: { type: "string" } },
+        required: ["assetId"],
+        additionalProperties: false
+      }
+    },
+    {
+      name: TOOL_ASSET_VERSION_CREATE,
+      description: "Save a new recipe version as a child of an existing asset without overwriting the parent.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          projectId: { type: "string" },
+          assetId: { type: "string", description: "Existing parent asset ID." },
+          assetIdNew: { type: "string", description: "Optional ID for the new version." },
+          imagePath: { type: "string", description: "Optional new image path. When omitted, the parent image is copied for a recipe-only version." },
+          version_change: { type: "string", minLength: 1, description: "Required summary of what changed from the parent." },
+          prompt: { type: "string" },
+          skill: { type: "string" },
+          style: { type: "string" },
+          ratio: { type: "string" },
+          theme: { type: "string" },
+          business_fields: { type: "object" },
+          tags: { type: "array", items: { type: "string" } },
+          favorite: { type: "boolean" },
+          group: { type: "string" },
+          category: { type: "string" },
+          rating: { type: "integer", minimum: 0, maximum: 5 },
+          sourceType: { type: "string" },
+          source: {
+            type: "object",
+            description: "Optional provenance for a replacement image, such as generation_tool, model, or codex_session_id.",
+            additionalProperties: true
+          }
+        },
+        required: ["assetId", "version_change"],
+        additionalProperties: false
+      }
+    },
+    {
+      name: TOOL_ASSET_VERSION_HISTORY,
+      description: "Read the complete root-to-descendant recipe version tree for an asset, including archived versions.",
+      inputSchema: {
+        type: "object",
+        properties: { projectId: { type: "string" }, assetId: { type: "string" } },
         required: ["assetId"],
         additionalProperties: false
       }
@@ -156,8 +201,19 @@ async function handleToolCall(id, params) {
     return;
   }
   if (params?.name === TOOL_ASSET_DUPLICATE) {
-    const asset = await store.duplicateAsset(args.projectId || "default", args.assetId, { assetId: args.assetIdNew, version_change: args.version_change });
+    const asset = await store.duplicateAsset(args.projectId || "default", args.assetId, { assetId: args.assetIdNew });
     sendResult(id, { content: [{ type: "text", text: `Duplicated asset ${asset.id}` }], structuredContent: { asset } });
+    return;
+  }
+  if (params?.name === TOOL_ASSET_VERSION_CREATE) {
+    const { projectId = "default", assetId, assetIdNew, ...input } = args;
+    const asset = await store.createAssetVersion(projectId, assetId, { ...input, assetId: assetIdNew });
+    sendResult(id, { content: [{ type: "text", text: `Created version ${asset.id} from ${assetId}` }], structuredContent: { asset } });
+    return;
+  }
+  if (params?.name === TOOL_ASSET_VERSION_HISTORY) {
+    const history = await store.getAssetVersionHistory(args.projectId || "default", args.assetId);
+    sendResult(id, { content: [{ type: "text", text: `${history.versions.length} versions rooted at ${history.root_asset_id}` }], structuredContent: { history } });
     return;
   }
   sendError(id, -32602, `Unknown tool: ${params?.name || ""}`);
@@ -170,7 +226,7 @@ async function handleRequest(message) {
       protocolVersion: params?.protocolVersion || "2025-11-25",
       capabilities: { tools: {} },
       serverInfo: { name: "MOSA MCP", version: "0.1.0" },
-      instructions: "Save generated images with full prompts and recipe metadata. Images from Codex's default ~/.codex/generated_images task folders are accepted and their source path is recorded. List and retrieve saved assets for reuse."
+      instructions: "Save generated images with full prompts and recipe metadata. Use asset_version_create with the generated imagePath and a version_change summary when creating a child recipe version. Images from Codex's default ~/.codex/generated_images task folders are accepted and their source path is recorded."
     });
     return;
   }
@@ -186,7 +242,13 @@ async function handleRequest(message) {
     try {
       await handleToolCall(id, params);
     } catch (error) {
-      sendError(id, -32603, error.message);
+      if (error?.statusCode && error?.code) {
+        sendResult(id, {
+          content: [{ type: "text", text: error.message }],
+          isError: true,
+          structuredContent: { error: { code: error.code, message: error.message } },
+        });
+      } else sendError(id, -32603, error.message);
     }
     return;
   }

--- a/server.mjs
+++ b/server.mjs
@@ -82,7 +82,10 @@ const server = createServer(async (req, res) => {
 
     await handleStatic(res, url.pathname);
   } catch (error) {
-    sendJson(res, 500, { error: error.message });
+    const statusCode = Number(error?.statusCode) || 500;
+    const payload = { error: error instanceof Error ? error.message : String(error) };
+    if (error?.statusCode && error?.code) payload.code = error.code;
+    sendJson(res, statusCode, payload);
   }
 });
 
@@ -308,14 +311,31 @@ async function handleApi(req, res, url) {
     derivativeWorker.wake();
     return;
   }
+  const versionsMatch = /^\/api\/assets\/([^/]+)\/([^/]+)\/versions$/.exec(url.pathname);
+  if (versionsMatch && req.method === "GET") {
+    if (typeof store.getAssetVersionHistory !== "function") throw new Error("Asset version history is unavailable.");
+    const projectId = decodeURIComponent(versionsMatch[1]);
+    const assetId = decodeURIComponent(versionsMatch[2]);
+    sendJson(res, 200, { history: await store.getAssetVersionHistory(projectId, assetId) });
+    return;
+  }
+  if (versionsMatch && req.method === "POST") {
+    if (typeof store.createAssetVersion !== "function") throw new Error("Asset version creation is unavailable.");
+    const projectId = decodeURIComponent(versionsMatch[1]);
+    const assetId = decodeURIComponent(versionsMatch[2]);
+    const body = await readJson(req);
+    sendJson(res, 201, { asset: await store.createAssetVersion(projectId, assetId, body) });
+    derivativeWorker.wake();
+    return;
+  }
   if (assetMatch && req.method === "GET") {
-    sendJson(res, 200, { asset: await store.getAsset(assetMatch[1], assetMatch[2]) });
+    sendJson(res, 200, { asset: await store.getAsset(decodeURIComponent(assetMatch[1]), decodeURIComponent(assetMatch[2])) });
     return;
   }
 
   if (assetMatch && req.method === "PATCH") {
     const body = await readJson(req);
-    sendJson(res, 200, { asset: await store.updateMetadata(assetMatch[1], assetMatch[2], body) });
+    sendJson(res, 200, { asset: await store.updateMetadata(decodeURIComponent(assetMatch[1]), decodeURIComponent(assetMatch[2]), body) });
     return;
   }
 

--- a/test/accessibility-contract.test.mjs
+++ b/test/accessibility-contract.test.mjs
@@ -107,3 +107,37 @@ test("uses a single language chosen from system, Chinese, or English", async () 
   assert.doesNotMatch(app, /data-remove-cowart-canvas/);
   assert.match(app, /\/api\/cowart-canvases/);
 });
+
+test("keeps recipe version history navigable without replacing active edits", async () => {
+  const [app, css] = await Promise.all([
+    readFile(resolve(root, "app/app.js"), "utf8"),
+    readFile(resolve(root, "app/styles.css"), "utf8"),
+  ]);
+
+  assert.match(app, /versionHistory: "版本历史"/);
+  assert.match(app, /versionHistory: "Version history"/);
+  assert.match(app, /data-version-history aria-live="polite"/);
+  assert.match(app, /<ol class="version-timeline" aria-label=/);
+  assert.match(app, /<time datetime=/);
+  assert.match(app, /aria-current="true"/);
+  assert.match(app, /<label class="field version-change-field">/);
+  assert.match(app, /data-action="save-version"/);
+  assert.match(app, /function readRecipeDraft\(panel\)/);
+  assert.match(app, /body: \{ \.\.\.readRecipeDraft\(panel\), version_change: versionChange \}/);
+  assert.match(app, /`assetId: \$\{asset\.id\}`/);
+  assert.match(app, /imagePath: <path returned by image generation>/);
+  assert.match(app, /requestId !== versionHistoryRequestSequence/);
+  assert.match(app, /function renderVersionHistoryRegion\(history, selectedId, error = null\)/);
+  const regionRenderer = /function renderVersionHistoryRegion[\s\S]*?\n}\n\nfunction versionHistoryMarkup/.exec(app)?.[0] || "";
+  assert.doesNotMatch(regionRenderer, /renderDetail\(/);
+  assert.match(app, /state\.detailAsset = asset/);
+  assert.match(app, /if \(index < 0\) return;/);
+  assert.match(app, /function confirmDetailNavigation\(nextAssetId\)/);
+  assert.match(app, /window\.confirm\(t\("discardVersionChanges"\)\)/);
+  assert.match(app, /function isCurrentDetailAction\(renderId, projectId, assetId\)/);
+  assert.match(app, /renderId === detailRenderSequence/);
+  assert.match(app, /\[data-edit="rating"\] button/);
+  assert.match(css, /\.version-timeline-item\.selected > button/);
+  assert.match(css, /\.recipe-save-actions \{[^}]*grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/);
+  assert.match(css, /\.recipe-save-btn \{[^}]*white-space: normal;/);
+});

--- a/test/asset-store.test.mjs
+++ b/test/asset-store.test.mjs
@@ -82,6 +82,31 @@ test("JSON pagination remains stable when the cursor asset is archived", async (
   await assert.rejects(store.listAssetPage({ projectId: "default", cursor: Buffer.from("{}").toString("base64url") }), /Invalid asset cursor/);
 });
 
+test("corrupt canonical JSON metadata cannot be hidden or overwritten", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-corrupt-metadata-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const projectRoot = join(root, "project");
+  const managerDir = join(projectRoot, "mosa");
+  const sourcePath = join(projectRoot, "generated-images", "fixture.png");
+  const store = createAssetStore({ projectRoot, managerDir });
+  await Promise.all([
+    mkdir(join(projectRoot, "generated-images"), { recursive: true }),
+    store.ensureProject("default"),
+  ]);
+  await writeFile(sourcePath, "fixture image", "utf8");
+  const metadataPath = join(managerDir, "assets", "default", "metadata", "broken.json");
+  const corruptMetadata = "{ not valid json\n";
+  await writeFile(metadataPath, corruptMetadata, "utf8");
+
+  await assert.rejects(store.getAsset("default", "broken"), SyntaxError);
+  await assert.rejects(store.getAssetVersionHistory("default", "broken"), SyntaxError);
+  await assert.rejects(
+    store.createAsset({ assetId: "broken", imagePath: sourcePath }),
+    (error) => error?.code === "ASSET_ALREADY_EXISTS",
+  );
+  assert.equal(await readFile(metadataPath, "utf8"), corruptMetadata);
+});
+
 test("persists manually created groups, including empty groups", async (t) => {
   const root = await mkdtemp(join(tmpdir(), "mosa-"));
   t.after(() => rm(root, { recursive: true, force: true }));

--- a/test/asset-version-history.test.mjs
+++ b/test/asset-version-history.test.mjs
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import sharp from "sharp";
+import { buildAssetVersionHistory } from "../lib/asset-version-history.mjs";
+import { createJsonAssetStore, mimeTypeForFile } from "../lib/asset-store.mjs";
+import { createSqliteAssetStore } from "../lib/sqlite-asset-store.mjs";
+
+const ONE_PIXEL_PNG = Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+1CBR3wAAAABJRU5ErkJggg==", "base64");
+
+for (const implementation of [
+  ["JSON", createJsonAssetStore],
+  ["SQLite", createSqliteAssetStore],
+]) {
+  test(`${implementation[0]} store creates and reads deterministic recipe version trees`, async (t) => {
+    const root = await mkdtemp(join(tmpdir(), `mosa-version-${implementation[0].toLowerCase()}-`));
+    const projectRoot = join(root, "project");
+    const managerDir = join(projectRoot, "mosa");
+    const sourcePath = join(projectRoot, "generated-images", "fixture.png");
+    const replacementPath = join(projectRoot, "generated-images", "replacement.webp");
+    await mkdir(join(projectRoot, "generated-images"), { recursive: true });
+    await writeFile(sourcePath, ONE_PIXEL_PNG);
+    await sharp({ create: { width: 2, height: 2, channels: 4, background: "#2456d8" } }).webp({ lossless: true }).toFile(replacementPath);
+    const replacementImage = await readFile(replacementPath);
+    const store = implementation[1]({ projectRoot, managerDir, libraryDir: join(root, "library") });
+    t.after(async () => {
+      store.close?.();
+      await rm(root, { recursive: true, force: true });
+    });
+
+    const parent = await store.createAsset({
+      assetId: "root",
+      imagePath: sourcePath,
+      prompt: "Original prompt",
+      skill: "imagegen",
+      style: "editorial",
+      ratio: "4:5",
+      theme: "Original theme",
+      group: "Campaign",
+      category: "concept",
+      rating: 4,
+      tags: ["launch"],
+      business_fields: { audience: "designers" },
+      source: { model: "gpt-5.6", generation_tool: "imagegen" },
+      created_at: "2026-01-01T00:00:00.000Z",
+    });
+    const parentBeforeVersion = await store.getAsset("default", parent.id);
+
+    const firstChild = await store.createAssetVersion("default", parent.id, {
+      assetId: "child-a",
+      version_change: "Warmer palette",
+      prompt: "Warm prompt",
+      theme: "Warm theme",
+    });
+    await delay(2);
+    const grandchild = await store.createAssetVersion("default", firstChild.id, {
+      assetId: "grandchild",
+      version_change: "Tighter crop",
+      ratio: "1:1",
+    });
+    await delay(2);
+    const secondChild = await store.createAssetVersion("default", parent.id, {
+      assetId: "child-b",
+      version_change: "Alternate typography",
+    });
+
+    assert.equal(firstChild.parent_asset_id, parent.id);
+    assert.equal(firstChild.version_change, "Warmer palette");
+    assert.equal(firstChild.prompt, "Warm prompt");
+    assert.equal(firstChild.style, parent.style);
+    assert.equal(firstChild.source.model, "gpt-5.6");
+    assert.equal(firstChild.source.versioned_from, parent.id);
+    assert.deepEqual(firstChild.child_asset_ids, []);
+    assert.notEqual(firstChild.image_path, parent.image_path);
+    assert.deepEqual(await readFile(firstChild.image_path), await readFile(parent.image_path));
+
+    const parentAfterVersion = await store.getAsset("default", parent.id);
+    assert.equal(parentAfterVersion.prompt, parentBeforeVersion.prompt);
+    assert.equal(parentAfterVersion.updated_at, parentBeforeVersion.updated_at);
+    assert.deepEqual(parentAfterVersion.child_asset_ids, [firstChild.id, secondChild.id]);
+
+    await store.archiveAsset("default", parent.id);
+    const fromRoot = await store.getAssetVersionHistory("default", parent.id);
+    const fromGrandchild = await store.getAssetVersionHistory("default", grandchild.id);
+    assert.equal(fromRoot.root_asset_id, parent.id);
+    assert.equal(fromGrandchild.root_asset_id, parent.id);
+    assert.equal(fromGrandchild.selected_asset_id, grandchild.id);
+    assert.deepEqual(fromRoot.versions.map((asset) => asset.id), [parent.id, firstChild.id, grandchild.id, secondChild.id]);
+    assert.deepEqual(fromGrandchild.versions.map((asset) => asset.id), fromRoot.versions.map((asset) => asset.id));
+    assert.deepEqual(fromRoot.versions.map((asset) => asset.version_depth), [0, 1, 2, 1]);
+    assert.equal(fromRoot.versions[0].archived, true);
+
+    const imageChild = await store.createAssetVersion("default", parent.id, {
+      assetId: "child-image",
+      imagePath: replacementPath,
+      version_change: "Regenerated composition",
+      source: {
+        model: "gpt-5.6",
+        generation_tool: "imagegen",
+        versioned_from: "stale-parent",
+        duplicated_from: "stale-copy",
+        storage_mode: "stale-storage",
+      },
+    });
+    assert.equal(imageChild.parent_asset_id, parent.id);
+    assert.equal(imageChild.source.versioned_from, parent.id);
+    assert.equal(imageChild.source.duplicated_from, undefined);
+    assert.notEqual(imageChild.source.storage_mode, "stale-storage");
+    assert.equal(imageChild.source.path, replacementPath);
+    assert.match(imageChild.asset, /\.webp$/);
+    assert.match(imageChild.image_path, /\.webp$/);
+    assert.equal(mimeTypeForFile(imageChild.asset), "image/webp");
+    assert.deepEqual(await readFile(imageChild.image_path), replacementImage);
+    assert.notDeepEqual(await readFile(imageChild.image_path), await readFile(parent.image_path));
+    const historyWithReplacement = await store.getAssetVersionHistory("default", imageChild.id);
+    assert.deepEqual(historyWithReplacement.versions.map((asset) => asset.id), [parent.id, firstChild.id, grandchild.id, secondChild.id, imageChild.id]);
+
+    const duplicate = await store.duplicateAsset("default", firstChild.id, { assetId: "independent-copy" });
+    assert.equal(duplicate.parent_asset_id, null);
+    assert.equal(duplicate.version_change, "");
+    assert.deepEqual(duplicate.child_asset_ids, []);
+    assert.equal(duplicate.archived, false);
+    assert.equal(duplicate.source.duplicated_from, firstChild.id);
+    assert.equal(duplicate.source.versioned_from, undefined);
+    assert.notEqual(duplicate.created_at, parent.created_at);
+    const duplicateHistory = await store.getAssetVersionHistory("default", duplicate.id);
+    assert.deepEqual(duplicateHistory.versions.map((asset) => asset.id), [duplicate.id]);
+
+    await assert.rejects(
+      store.createAssetVersion("default", parent.id, { version_change: "   " }),
+      errorWithCode("INVALID_VERSION_CHANGE"),
+    );
+    await assert.rejects(
+      store.createAsset({ assetId: "child-without-summary", imagePath: sourcePath, parent_asset_id: parent.id }),
+      errorWithCode("INVALID_VERSION_CHANGE"),
+    );
+    await assert.rejects(
+      store.createAssetVersion("default", parent.id, { assetId: firstChild.id, version_change: "collision" }),
+      errorWithCode("ASSET_ALREADY_EXISTS"),
+    );
+    await assert.rejects(
+      store.updateMetadata("default", firstChild.id, { parent_asset_id: secondChild.id }),
+      errorWithCode("VERSION_RELATION_IMMUTABLE"),
+    );
+
+    await store.createAsset({ projectId: "other", assetId: "foreign-parent", imagePath: sourcePath });
+    await assert.rejects(
+      store.createAsset({ assetId: "orphan", imagePath: sourcePath, parent_asset_id: "missing" }),
+      errorWithCode("VERSION_PARENT_NOT_FOUND"),
+    );
+    await assert.rejects(
+      store.createAsset({ assetId: "cross-project", imagePath: sourcePath, parent_asset_id: "foreign-parent" }),
+      errorWithCode("VERSION_PROJECT_MISMATCH"),
+    );
+    await assert.rejects(
+      store.createAsset({ assetId: "self-parent", imagePath: sourcePath, parent_asset_id: "self-parent" }),
+      errorWithCode("VERSION_CYCLE"),
+    );
+
+    const concurrentCreates = await Promise.allSettled([
+      store.createAsset({ assetId: "concurrent-id", imagePath: sourcePath, prompt: "first contender" }),
+      store.createAsset({ assetId: "concurrent-id", imagePath: replacementPath, prompt: "second contender" }),
+    ]);
+    assert.equal(concurrentCreates.filter((result) => result.status === "fulfilled").length, 1);
+    const conflict = concurrentCreates.find((result) => result.status === "rejected");
+    assert.equal(conflict.reason.code, "ASSET_ALREADY_EXISTS");
+  });
+}
+
+test("shared history builder rejects corrupt parent graphs", () => {
+  const base = { project_id: "default", child_asset_ids: [], created_at: "2026-01-01T00:00:00.000Z" };
+  assert.throws(
+    () => buildAssetVersionHistory({
+      projectId: "default",
+      selectedAssetId: "orphan",
+      assets: [{ ...base, id: "orphan", parent_asset_id: "missing" }],
+    }),
+    errorWithCode("VERSION_PARENT_NOT_FOUND"),
+  );
+  assert.throws(
+    () => buildAssetVersionHistory({
+      projectId: "default",
+      selectedAssetId: "orphan",
+      assets: [{ ...base, id: "orphan", parent_asset_id: "foreign" }],
+      foreignProjectsByAssetId: new Map([["foreign", ["other"]]]),
+    }),
+    errorWithCode("VERSION_PROJECT_MISMATCH"),
+  );
+  assert.throws(
+    () => buildAssetVersionHistory({
+      projectId: "default",
+      selectedAssetId: "a",
+      assets: [
+        { ...base, id: "a", parent_asset_id: "b" },
+        { ...base, id: "b", parent_asset_id: "a" },
+      ],
+    }),
+    errorWithCode("VERSION_CYCLE"),
+  );
+});
+
+function errorWithCode(code) {
+  return (error) => error?.code === code;
+}
+
+function delay(milliseconds) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+}

--- a/test/cowart-bridge-manager.test.mjs
+++ b/test/cowart-bridge-manager.test.mjs
@@ -11,7 +11,8 @@ test("archives registered project-local Cowart canvases", async (t) => {
   const root = await mkdtemp(join(tmpdir(), "mosa-cowart-manager-"));
   t.after(() => rm(root, { recursive: true, force: true }));
 
-  const managerDir = join(root, "mosa");
+  const projectRoot = join(root, "workspace");
+  const managerDir = join(projectRoot, "mosa");
   const firstProject = join(root, "first-project");
   const secondProject = join(root, "second-project");
   await Promise.all([
@@ -20,10 +21,14 @@ test("archives registered project-local Cowart canvases", async (t) => {
   ]);
 
   const store = createAssetStore({
-    projectRoot: root,
+    projectRoot,
     managerDir,
     cowartCanvasDir: join(root, "cowart-data", "mosa"),
   });
+  await assert.rejects(
+    store.createAsset({ imagePath: join(firstProject, "canvas", "pages", "page", "assets", "first-project-image.png") }),
+    /Refusing to import outside the project roots/,
+  );
   const registry = createCowartProjectRegistry({
     managerDir,
     registryPath: join(root, "state", "cowart-projects.json"),

--- a/test/cowart-bridge.test.mjs
+++ b/test/cowart-bridge.test.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { createAssetStore } from "../lib/asset-store.mjs";
+import { createSqliteAssetStore } from "../lib/sqlite-asset-store.mjs";
 import { createCowartAssetBridge, reconcileCowartAssets } from "../lib/cowart-bridge.mjs";
 
 test("archives Cowart page assets once and keeps MOSA-origin images out", async (t) => {
@@ -68,6 +69,40 @@ test("watches a Cowart page directory and archives a later image", async (t) => 
   const assets = await store.listAssets({ projectId: "default" });
   assert.equal(assets.length, 1);
   assert.equal(assets[0].source.cowart_shape_id, "shape:watch-bear");
+});
+
+test("archives a registered external Cowart canvas through the SQLite store only within its pages root", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-cowart-sqlite-external-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const projectRoot = join(root, "workspace");
+  const managerDir = join(projectRoot, "mosa");
+  const cowartProjectDir = join(root, "external-project");
+  const canvasDir = join(cowartProjectDir, "canvas");
+  const pageDir = join(canvasDir, "pages", "page");
+  const imagePath = join(pageDir, "assets", "external.png");
+  await mkdir(join(pageDir, "assets"), { recursive: true });
+  await writeFile(imagePath, "fixture external Cowart image", "utf8");
+  await writeFile(join(pageDir, "cowart-canvas.json"), JSON.stringify({
+    store: {
+      "asset:external": { id: "asset:external", typeName: "asset", type: "image", props: { name: "external.png", src: "/page-assets/page/external.png" }, meta: {} },
+      "shape:external": { id: "shape:external", typeName: "shape", type: "image", props: { assetId: "asset:external", w: 1200, h: 800, altText: "External Cowart image" }, meta: {} },
+    },
+  }), "utf8");
+
+  const store = createSqliteAssetStore({ projectRoot, managerDir, libraryDir: join(root, "library") });
+  t.after(() => store.close());
+  await assert.rejects(store.createAsset({ imagePath }), /Refusing to import outside the project roots/);
+
+  const result = await reconcileCowartAssets({
+    store,
+    canvasDir,
+    cowartProjectDir,
+    sourceId: "registered-external-project",
+  });
+  assert.equal(result.imported.length, 1);
+  assert.equal(result.imported[0].source.cowart_project_dir, cowartProjectDir);
+  assert.equal(result.imported[0].source.cowart_source_id, "registered-external-project");
 });
 
 async function waitFor(condition, timeoutMs = 2000) {

--- a/test/library-migration.test.mjs
+++ b/test/library-migration.test.mjs
@@ -83,3 +83,142 @@ test("corrupt groups JSON blocks migration and identifies the exact file", async
   assert.deepEqual(report.issues.map((issue) => issue.kind), ["corrupt-groups-json"]);
   assert.equal(report.issues[0].path, groupsPath);
 });
+
+test("migration orders version parents before children and preserves the tree", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-migrate-versions-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const managerDir = join(root, "mosa");
+  const metadataDir = join(managerDir, "assets", "default", "metadata");
+  const imagesDir = join(managerDir, "assets", "default", "images");
+  await mkdir(metadataDir, { recursive: true });
+  await mkdir(imagesDir, { recursive: true });
+  await writeFile(join(imagesDir, "parent.png"), PNG);
+  await writeFile(join(imagesDir, "child.png"), PNG);
+  await writeFile(join(metadataDir, "a-child.json"), JSON.stringify({
+    id: "child",
+    project_id: "default",
+    asset: "child.png",
+    prompt: "child prompt",
+    parent_asset_id: "parent",
+    version_change: "palette pass",
+  }));
+  await writeFile(join(metadataDir, "z-parent.json"), JSON.stringify({
+    id: "parent",
+    project_id: "default",
+    asset: "parent.png",
+    prompt: "parent prompt",
+  }));
+
+  const libraryDir = join(root, "library");
+  const report = await migrateLegacyLibrary({ managerDir, projectRoot: root, libraryDir });
+  assert.equal(report.completed, true);
+  assert.equal(report.imported, 2);
+  const store = createSqliteAssetStore({ managerDir, projectRoot: root, libraryDir });
+  const history = await store.getAssetVersionHistory("default", "child");
+  store.close();
+  assert.deepEqual(history.versions.map((asset) => asset.id), ["parent", "child"]);
+  assert.equal(history.versions[1].version_change, "palette pass");
+});
+
+test("migration reports invalid legacy version relationships without writing SQLite assets", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-migrate-invalid-version-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const managerDir = join(root, "mosa");
+  const metadataDir = join(managerDir, "assets", "default", "metadata");
+  const imagesDir = join(managerDir, "assets", "default", "images");
+  await mkdir(metadataDir, { recursive: true });
+  await mkdir(imagesDir, { recursive: true });
+  await writeFile(join(imagesDir, "orphan.png"), PNG);
+  await writeFile(join(metadataDir, "orphan.json"), JSON.stringify({
+    id: "orphan",
+    project_id: "default",
+    asset: "orphan.png",
+    parent_asset_id: "missing",
+  }));
+
+  const report = await migrateLegacyLibrary({ managerDir, projectRoot: root, libraryDir: join(root, "library") });
+  assert.equal(report.completed, false);
+  assert.deepEqual(report.issues.map((issue) => issue.kind), ["version-parent-missing"]);
+  assert.equal(report.backupPath, null);
+});
+
+test("migration blocks duplicate asset IDs before and after normalization", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-migrate-duplicate-ids-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const cases = [
+    ["same", "same"],
+    ["same value", "same@value"],
+  ];
+
+  for (const [index, ids] of cases.entries()) {
+    const managerDir = join(root, `case-${index}`, "mosa");
+    const metadataDir = join(managerDir, "assets", "default", "metadata");
+    const imagesDir = join(managerDir, "assets", "default", "images");
+    await mkdir(metadataDir, { recursive: true });
+    await mkdir(imagesDir, { recursive: true });
+    await Promise.all([
+      writeFile(join(imagesDir, "first.png"), PNG),
+      writeFile(join(imagesDir, "second.png"), PNG),
+      writeFile(join(metadataDir, "first.json"), JSON.stringify({ id: ids[0], project_id: "default", asset: "first.png" })),
+      writeFile(join(metadataDir, "second.json"), JSON.stringify({ id: ids[1], project_id: "default", asset: "second.png" })),
+    ]);
+
+    const inspection = await inspectLegacyLibrary({ managerDir });
+    assert.equal(inspection.records.length, 2);
+    assert.deepEqual(inspection.issues.map((issue) => issue.kind), ["duplicate-asset-id"]);
+    assert.match(inspection.issues[0].detail, /after normalization/);
+    const report = await migrateLegacyLibrary({ managerDir, projectRoot: join(root, `case-${index}`), libraryDir: join(root, `library-${index}`) });
+    assert.equal(report.completed, false);
+    assert.equal(report.backupPath, null);
+  }
+});
+
+test("migration allows the same asset ID in distinct projects", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-migrate-cross-project-ids-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const managerDir = join(root, "mosa");
+  for (const projectId of ["alpha", "beta"]) {
+    const metadataDir = join(managerDir, "assets", projectId, "metadata");
+    const imagesDir = join(managerDir, "assets", projectId, "images");
+    await mkdir(metadataDir, { recursive: true });
+    await mkdir(imagesDir, { recursive: true });
+    await writeFile(join(imagesDir, "shared.png"), PNG);
+    await writeFile(join(metadataDir, "shared.json"), JSON.stringify({ id: "shared", project_id: projectId, asset: "shared.png" }));
+  }
+  const inspection = await inspectLegacyLibrary({ managerDir });
+  assert.equal(inspection.records.length, 2);
+  assert.deepEqual(inspection.issues, []);
+});
+
+test("migration reports cross-project parents and multi-node cycles", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-migrate-invalid-graphs-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const managerDir = join(root, "mosa");
+  const records = [
+    ["default", "a", "b"],
+    ["default", "b", "a"],
+    ["default", "cross", "foreign"],
+    ["other", "foreign", null],
+  ];
+  for (const [projectId, assetId, parentAssetId] of records) {
+    const metadataDir = join(managerDir, "assets", projectId, "metadata");
+    const imagesDir = join(managerDir, "assets", projectId, "images");
+    await mkdir(metadataDir, { recursive: true });
+    await mkdir(imagesDir, { recursive: true });
+    await writeFile(join(imagesDir, `${assetId}.png`), PNG);
+    await writeFile(join(metadataDir, `${assetId}.json`), JSON.stringify({
+      id: assetId,
+      project_id: projectId,
+      asset: `${assetId}.png`,
+      ...(parentAssetId ? { parent_asset_id: parentAssetId } : {}),
+    }));
+  }
+
+  const inspection = await inspectLegacyLibrary({ managerDir });
+  const kinds = inspection.issues.map((issue) => issue.kind);
+  assert.ok(kinds.includes("version-project-mismatch"));
+  assert.ok(kinds.includes("version-cycle"));
+  const report = await migrateLegacyLibrary({ managerDir, projectRoot: root, libraryDir: join(root, "library") });
+  assert.equal(report.completed, false);
+  assert.equal(report.backupPath, null);
+});

--- a/test/mcp-version-history.test.mjs
+++ b/test/mcp-version-history.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+import sharp from "sharp";
+import { createSqliteAssetStore } from "../lib/sqlite-asset-store.mjs";
+
+test("MCP exposes recipe version creation, history, and structured errors", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-mcp-versions-"));
+  const libraryDir = join(root, "library");
+  const imagePath = join(root, "generated-images", "fixture.png");
+  const replacementPath = join(root, "generated-images", "replacement.png");
+  await mkdir(join(root, "generated-images"), { recursive: true });
+  await sharp({ create: { width: 8, height: 8, channels: 4, background: "#243047" } }).png().toFile(imagePath);
+  await sharp({ create: { width: 8, height: 8, channels: 4, background: "#c43d38" } }).png().toFile(replacementPath);
+
+  const store = createSqliteAssetStore({ projectRoot: root, managerDir: process.cwd(), libraryDir });
+  await store.createAsset({ assetId: "root", imagePath, prompt: "original", style: "editorial" });
+  await store.setMigrationState("completed", { test: true });
+  store.close();
+
+  const server = spawn(process.execPath, ["mcp/server.mjs"], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      MOSA_PROJECT_DIR: root,
+      MOSA_LIBRARY_DIR: libraryDir,
+      CODEX_GENERATED_IMAGES_DIR: join(root, "generated-images"),
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  t.after(async () => {
+    if (server.exitCode === null) {
+      const exited = once(server, "exit");
+      server.kill("SIGTERM");
+      await exited;
+    }
+    await rm(root, { recursive: true, force: true });
+  });
+
+  const definitions = await callMcp(server, { jsonrpc: "2.0", id: 1, method: "tools/list" });
+  const tools = definitions.result.tools;
+  const createDefinition = tools.find((tool) => tool.name === "asset_version_create");
+  assert.deepEqual(createDefinition.inputSchema.required, ["assetId", "version_change"]);
+  assert.ok(createDefinition.inputSchema.properties.imagePath);
+  assert.ok(tools.some((tool) => tool.name === "asset_version_history"));
+
+  const created = await callMcp(server, {
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "asset_version_create",
+      arguments: {
+        projectId: "default",
+        assetId: "root",
+        assetIdNew: "child",
+        imagePath: replacementPath,
+        version_change: "Warmer palette",
+        prompt: "updated prompt",
+        source: { generation_tool: "imagegen", model: "gpt-5.6" },
+      },
+    },
+  });
+  assert.equal(created.error, undefined);
+  assert.equal(created.result.structuredContent.asset.id, "child");
+  assert.equal(created.result.structuredContent.asset.parent_asset_id, "root");
+  assert.equal(created.result.structuredContent.asset.source.path, replacementPath);
+  assert.deepEqual(await readFile(created.result.structuredContent.asset.image_path), await readFile(replacementPath));
+  assert.notDeepEqual(await readFile(created.result.structuredContent.asset.image_path), await readFile(imagePath));
+
+  const history = await callMcp(server, {
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: { name: "asset_version_history", arguments: { projectId: "default", assetId: "child" } },
+  });
+  assert.equal(history.error, undefined);
+  assert.deepEqual(history.result.structuredContent.history.versions.map((asset) => asset.id), ["root", "child"]);
+
+  const invalid = await callMcp(server, {
+    jsonrpc: "2.0",
+    id: 4,
+    method: "tools/call",
+    params: { name: "asset_version_create", arguments: { projectId: "default", assetId: "root", version_change: " " } },
+  });
+  assert.equal(invalid.error, undefined);
+  assert.equal(invalid.result.isError, true);
+  assert.equal(invalid.result.structuredContent.error.code, "INVALID_VERSION_CHANGE");
+
+  const bypass = await callMcp(server, {
+    jsonrpc: "2.0",
+    id: 5,
+    method: "tools/call",
+    params: {
+      name: "asset_create",
+      arguments: { projectId: "default", assetId: "bypass", imagePath: replacementPath, parent_asset_id: "root" },
+    },
+  });
+  assert.equal(bypass.error, undefined);
+  assert.equal(bypass.result.isError, true);
+  assert.equal(bypass.result.structuredContent.error.code, "INVALID_VERSION_CHANGE");
+});
+
+function callMcp(server, request) {
+  return new Promise((resolveResponse, rejectResponse) => {
+    let buffer = "";
+    const timeout = setTimeout(() => finish(new Error("Timed out waiting for the MOSA MCP response.")), 5000);
+    const onData = (chunk) => {
+      buffer += chunk;
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || "";
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        const response = JSON.parse(line);
+        if (response.id === request.id) {
+          finish(null, response);
+          return;
+        }
+      }
+    };
+    const onExit = () => finish(new Error("MOSA MCP exited before responding."));
+    const finish = (error, response) => {
+      clearTimeout(timeout);
+      server.stdout.off("data", onData);
+      server.off("exit", onExit);
+      if (error) rejectResponse(error);
+      else resolveResponse(response);
+    };
+    server.stdout.setEncoding("utf8");
+    server.stdout.on("data", onData);
+    server.once("exit", onExit);
+    server.stdin.write(`${JSON.stringify(request)}\n`);
+  });
+}

--- a/test/server-routes.test.mjs
+++ b/test/server-routes.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { once } from "node:events";
-import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
@@ -114,8 +114,10 @@ test("SQLite HTTP surface paginates assets and serves durable derivatives", asyn
   const root = await mkdtemp(join(tmpdir(), "mosa-server-sqlite-"));
   const libraryDir = join(root, "library");
   const imagePath = join(root, "generated-images", "fixture.png");
+  const replacementPath = join(root, "replacement.png");
   await mkdir(join(root, "generated-images"), { recursive: true });
   await sharp({ create: { width: 8, height: 8, channels: 4, background: "#243047" } }).png().toFile(imagePath);
+  await sharp({ create: { width: 8, height: 8, channels: 4, background: "#c43d38" } }).png().toFile(replacementPath);
   const seeded = createSqliteAssetStore({ projectRoot: root, managerDir: process.cwd(), libraryDir });
   const asset = await seeded.createAsset({ assetId: "sqlite-fixture", imagePath, prompt: "red mechanical future city" });
   await seeded.setMigrationState("completed", { test: true });
@@ -157,6 +159,58 @@ test("SQLite HTTP surface paginates assets and serves durable derivatives", asyn
   const duplicate = await fetch(`http://127.0.0.1:${port}/api/assets/default/${asset.id}/duplicate`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ assetId: "sqlite-copy" }) });
   assert.equal(duplicate.status, 201);
   const copied = (await duplicate.json()).asset;
+  assert.equal(copied.parent_asset_id, null);
+
+  const bypassVersionContract = await fetch(`http://127.0.0.1:${port}/api/assets/create`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ projectId: "default", assetId: "bypass-version-contract", imagePath: replacementPath, parent_asset_id: asset.id }),
+  });
+  assert.equal(bypassVersionContract.status, 400);
+  assert.equal((await bypassVersionContract.json()).code, "INVALID_VERSION_CHANGE");
+
+  const invalidVersion = await fetch(`http://127.0.0.1:${port}/api/assets/default/${asset.id}/versions`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ version_change: " " }),
+  });
+  assert.equal(invalidVersion.status, 400);
+  assert.equal((await invalidVersion.json()).code, "INVALID_VERSION_CHANGE");
+
+  const versionResponse = await fetch(`http://127.0.0.1:${port}/api/assets/default/${asset.id}/versions`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ assetId: "sqlite-version", imagePath: replacementPath, version_change: "Brighter palette", theme: "Daylight" }),
+  });
+  assert.equal(versionResponse.status, 201);
+  const version = (await versionResponse.json()).asset;
+  assert.equal(version.parent_asset_id, asset.id);
+  assert.equal(version.version_change, "Brighter palette");
+  assert.equal(version.theme, "Daylight");
+  assert.equal(version.source.path, replacementPath);
+  const versionImage = await fetch(`http://127.0.0.1:${port}${version.image_url}`);
+  assert.equal(versionImage.status, 200);
+  assert.deepEqual(Buffer.from(await versionImage.arrayBuffer()), await readFile(replacementPath));
+
+  const historyResponse = await fetch(`http://127.0.0.1:${port}/api/assets/default/${version.id}/versions`);
+  assert.equal(historyResponse.status, 200);
+  const history = (await historyResponse.json()).history;
+  assert.equal(history.root_asset_id, asset.id);
+  assert.equal(history.selected_asset_id, version.id);
+  assert.deepEqual(history.versions.map((item) => item.id), [asset.id, version.id]);
+
+  const missingHistory = await fetch(`http://127.0.0.1:${port}/api/assets/default/missing/versions`);
+  assert.equal(missingHistory.status, 404);
+  assert.equal((await missingHistory.json()).code, "ASSET_NOT_FOUND");
+
+  const immutableRelation = await fetch(`http://127.0.0.1:${port}/api/assets/default/${version.id}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ parent_asset_id: null }),
+  });
+  assert.equal(immutableRelation.status, 400);
+  assert.equal((await immutableRelation.json()).code, "VERSION_RELATION_IMMUTABLE");
+
   const archived = await fetch(`http://127.0.0.1:${port}/api/assets/default/${copied.id}/archive`, { method: "POST" });
   assert.equal(archived.status, 200);
 });

--- a/test/sqlite-store.test.mjs
+++ b/test/sqlite-store.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import Database from "better-sqlite3";
 import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -58,6 +59,107 @@ test("runtime storage selection cannot bypass migration completion", async (t) =
   const afterMigration = createAssetStore({ projectRoot, managerDir, libraryDir, storage: "json" });
   assert.equal(afterMigration.storageKind, "sqlite");
   afterMigration.close();
+});
+
+test("SQLite schema v1 upgrades once without changing completed migration state", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-schema-upgrade-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const projectRoot = join(root, "project");
+  const libraryDir = join(root, "library");
+  const databasePath = join(libraryDir, "mosa.db");
+  const originalTimestamp = "2026-01-01T00:00:00.000Z";
+  await mkdir(libraryDir, { recursive: true });
+
+  const legacy = new Database(databasePath);
+  legacy.exec(`
+    CREATE TABLE library_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL);
+    CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
+  `);
+  legacy.prepare("INSERT INTO library_meta (key, value, updated_at) VALUES ('schema_version', '1', ?)").run(originalTimestamp);
+  legacy.prepare("INSERT INTO library_meta (key, value, updated_at) VALUES ('migration_state', 'completed', ?)").run(originalTimestamp);
+  legacy.prepare("INSERT INTO library_meta (key, value, updated_at) VALUES ('migration_details', '{\"verified\":true}', ?)").run(originalTimestamp);
+  legacy.prepare("INSERT INTO schema_migrations (version, applied_at) VALUES (1, ?)").run(originalTimestamp);
+  legacy.close();
+
+  createSqliteAssetStore({ projectRoot, managerDir: join(projectRoot, "mosa"), libraryDir }).close();
+  const upgraded = new Database(databasePath, { readonly: true });
+  const schemaAfterUpgrade = upgraded.prepare("SELECT value, updated_at FROM library_meta WHERE key = 'schema_version'").get();
+  const migrationState = upgraded.prepare("SELECT value, updated_at FROM library_meta WHERE key = 'migration_state'").get();
+  const migrationDetails = upgraded.prepare("SELECT value, updated_at FROM library_meta WHERE key = 'migration_details'").get();
+  const migrationVersions = upgraded.prepare("SELECT version FROM schema_migrations ORDER BY version").all().map((row) => row.version);
+  const parentIndex = upgraded.prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'asset_versions_parent_idx'").get();
+  upgraded.close();
+
+  assert.equal(schemaAfterUpgrade.value, "2");
+  assert.notEqual(schemaAfterUpgrade.updated_at, originalTimestamp);
+  assert.deepEqual(migrationState, { value: "completed", updated_at: originalTimestamp });
+  assert.deepEqual(migrationDetails, { value: '{"verified":true}', updated_at: originalTimestamp });
+  assert.deepEqual(migrationVersions, [1, 2]);
+  assert.equal(parentIndex.name, "asset_versions_parent_idx");
+
+  await new Promise((resolveDelay) => setTimeout(resolveDelay, 5));
+  createSqliteAssetStore({ projectRoot, managerDir: join(projectRoot, "mosa"), libraryDir }).close();
+  const reopened = new Database(databasePath, { readonly: true });
+  assert.deepEqual(
+    reopened.prepare("SELECT value, updated_at FROM library_meta WHERE key = 'schema_version'").get(),
+    schemaAfterUpgrade,
+  );
+  reopened.close();
+});
+
+test("SQLite refuses to downgrade a newer schema", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-schema-future-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const libraryDir = join(root, "library");
+  const databasePath = join(libraryDir, "mosa.db");
+  await mkdir(libraryDir, { recursive: true });
+  const future = new Database(databasePath);
+  future.exec(`
+    CREATE TABLE library_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at TEXT NOT NULL);
+    CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
+    INSERT INTO library_meta (key, value, updated_at) VALUES ('schema_version', '3', 'future');
+  `);
+  future.close();
+
+  assert.throws(
+    () => createSqliteAssetStore({ projectRoot: root, managerDir: join(root, "mosa"), libraryDir }),
+    /schema version 3 is newer than supported version 2/,
+  );
+  const inspected = new Database(databasePath, { readonly: true });
+  assert.deepEqual(inspected.prepare("SELECT value, updated_at FROM library_meta WHERE key = 'schema_version'").get(), { value: "3", updated_at: "future" });
+  inspected.close();
+});
+
+test("concurrent SQLite creates with the same ID cannot overwrite the winner", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-sqlite-create-race-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const projectRoot = join(root, "project");
+  const generatedDir = join(projectRoot, "generated-images");
+  const firstPath = join(generatedDir, "first.png");
+  const secondPath = join(generatedDir, "second.png");
+  await mkdir(generatedDir, { recursive: true });
+  await Promise.all([
+    sharp({ create: { width: 4, height: 4, channels: 4, background: "#c33c32" } }).png().toFile(firstPath),
+    sharp({ create: { width: 4, height: 4, channels: 4, background: "#2e6db4" } }).png().toFile(secondPath),
+  ]);
+  const store = createSqliteAssetStore({ projectRoot, managerDir: join(projectRoot, "mosa"), libraryDir: join(root, "library") });
+  t.after(() => store.close());
+
+  const results = await Promise.allSettled([
+    store.createAsset({ assetId: "same-id", imagePath: firstPath, prompt: "first" }),
+    store.createAsset({ assetId: "same-id", imagePath: secondPath, prompt: "second" }),
+  ]);
+  const fulfilled = results.filter((result) => result.status === "fulfilled");
+  const rejected = results.filter((result) => result.status === "rejected");
+  assert.equal(fulfilled.length, 1);
+  assert.equal(rejected.length, 1);
+  assert.equal(rejected[0].reason.code, "ASSET_ALREADY_EXISTS");
+
+  const winner = fulfilled[0].value;
+  const stored = await store.getAsset("default", "same-id");
+  assert.equal(stored.prompt, winner.prompt);
+  assert.equal(stored.source.path, winner.source.path);
+  assert.deepEqual(await readFile(stored.image_path), await readFile(winner.source.path));
 });
 
 test("derivative job writes WebP previews without changing the original", async (t) => {


### PR DESCRIPTION
## Summary

- model recipe versions as independent assets with stable root-first branching history across JSON and SQLite stores
- expose version creation and history through REST, MCP, and a bilingual keyboard-accessible Web timeline
- enforce immutable version relationships, validate legacy graphs, migrate SQLite to schema v2, and make duplicate-ID creates conflict-safe
- preserve replacement-image media types, prevent stale relation provenance, and protect corrupt canonical JSON metadata from overwrite
- keep duplicated assets as independent roots and scope registered Cowart imports to each canvas's `pages` directory

## Why

Recipe edits and regenerated images need durable, branchable provenance instead of overwriting the original asset. The shared history contract keeps JSON compatibility and SQLite behavior aligned while allowing users to inspect and branch from any historical node.

## Validation

- [x] `npm test` (`64 passed, 1 skipped`; includes both HTTP route tests)
- [x] version history + SQLite focused tests (`9 passed`)
- [x] migration tests (`8 passed`)
- [x] MCP + accessibility tests (`7 passed`)
- [x] asset/Codex/Cowart focused tests (`29 passed`)
- [x] `npm run lint`
- [x] `npm run check` (36 JavaScript files)
- [x] `git diff --check`

## Operational notes

- this branch has not been deployed to `43519`
- validation did not touch production ports `43517`/`43519` or `/Users/azhuilab/MOSA Library`
