### PR TITLE
fix: harden group and Cowart workflows

### DIFF
--- a/app/context-menu-actions.mjs
+++ b/app/context-menu-actions.mjs
@@ -357,7 +357,7 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
         action: async () => {
           const assets = isMultiple ? selectedAssets : [asset];
           const confirmed = await requestConfirmation({
-            title: isMultiple ? t("archiveAssetsTitle") : t("archiveAssetTitle"),
+            title: isMultiple ? t("archiveAssetsTitle", { count: assets.length }) : t("archiveAssetTitle"),
             description: isMultiple ? t("archiveAssetsDescription") : t("archiveAssetDescription"),
             confirmLabel: t("archive"),
             tone: "danger",
@@ -382,7 +382,7 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
         action: async () => {
           const assets = isMultiple ? selectedAssets : [asset];
           const confirmed = await requestConfirmation({
-            title: isMultiple ? t("deleteAssetsTitle") : t("deleteAssetTitle"),
+            title: isMultiple ? t("deleteAssetsTitle", { count: assets.length }) : t("deleteAssetTitle"),
             description: isMultiple ? t("deleteAssetsDescription") : t("deleteAssetDescription"),
             confirmLabel: t("delete"),
             tone: "danger",

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Menu, dialog, ipcMain, clipboard, session, shell, Notification, globalShortcut } from "electron";
+import { app, BrowserWindow, Menu, dialog, ipcMain, clipboard, session, shell, Notification } from "electron";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve, isAbsolute } from "node:path";
@@ -92,7 +92,6 @@ let shuttingDown = false;
 let shutdownPromise = null;
 let windowPromise = null;
 let ipcRegistered = false;
-let shortcutsRegistered = false;
 let updatesChecked = false;
 let currentLocale = "zh"; // safe default matching original Chinese-only notifications
 const rendererConsoleErrors = new Set();
@@ -126,7 +125,6 @@ if (!app.requestSingleInstanceLock()) {
     event.preventDefault();
     shuttingDown = true;
     stopBridgeNotificationPoll();
-    globalShortcut.unregisterAll();
     void stopOwnedRuntime().catch(console.error).finally(() => app.exit(0));
   });
 }
@@ -335,13 +333,6 @@ function registerIPC() {
   });
 }
 
-function registerGlobalShortcuts() {
-  if (shortcutsRegistered) return;
-  shortcutsRegistered = true;
-  globalShortcut.register("CommandOrControl+N", () => sendToWindow("menu-import"));
-  globalShortcut.register("CommandOrControl+F", () => sendToWindow("menu-search"));
-}
-
 function openMainWindow() {
   if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.show();
@@ -431,7 +422,6 @@ async function createMainWindow() {
 
   buildMenu();
   registerIPC();
-  registerGlobalShortcuts();
   await mainWindow.loadURL(service.url);
   mainWindow.show();
 

--- a/lib/cowart-bridge.ts
+++ b/lib/cowart-bridge.ts
@@ -76,15 +76,19 @@ export async function reconcileCowartAssets(options: { store: Store; canvasDir: 
   const { store, canvasDir, projectId = DEFAULT_PROJECT_ID, cowartProjectDir = null, sourceId = null } = options;
   const candidates = await readCowartAssetCandidates(canvasDir);
   const trustedPagesRoot = join(resolve(canvasDir), "pages");
-  const currentAssets = await store.listAssets({ projectId });
-  const knownSourcePaths = new Set(currentAssets.map((a) => (a.source?.cowart_page_asset_path || a.source?.path) as string).filter(Boolean).map((v) => resolve(v)));
+  const [currentAssets, archivedAssets] = await Promise.all([store.listAssets({ projectId }), store.listAssets({ projectId, archived: true })]);
+  const knownSourcePaths = new Set([...currentAssets, ...archivedAssets].map((a) => (a.source?.cowart_page_asset_path || a.source?.path) as string).filter(Boolean).map((v) => resolve(v)));
   const imported: unknown[] = []; const skipped: Array<{ path: string; reason: string }> = [];
 
   for (const candidate of candidates) {
     if (candidate.mosaAssetId) { skipped.push({ path: candidate.imagePath, reason: "mosa-origin" }); continue; }
     if (knownSourcePaths.has(candidate.imagePath)) { skipped.push({ path: candidate.imagePath, reason: "already-archived" }); continue; }
-    const asset = await store.createAsset({ projectId, imagePath: candidate.imagePath, prompt: candidate.altText, skill: "Cowart automatic bridge", ratio: candidate.ratio, theme: candidate.altText, sourceType: "cowart-generated", business_fields: { auto_archived: true, prompt_status: "Cowart canvas only provides alt text" }, source: { generation_tool: "cowart", cowart_source_id: sourceId, cowart_project_dir: cowartProjectDir, cowart_canvas_dir: candidate.canvasDir, cowart_page_id: candidate.pageId, cowart_page_asset_path: candidate.imagePath, cowart_page_asset_url: candidate.assetUrl, cowart_asset_id: candidate.cowartAssetId, cowart_shape_id: candidate.shapeId, cowart_shape_meta: candidate.shapeMeta, cowart_annotation_source_shape_id: candidate.annotationSourceShapeId || null, replaced_ai_image_holder: candidate.replacedAiImageHolder || null, prompt_status: "canvas-alt-text-only" } }, { trustedSourceRoots: [trustedPagesRoot] });
-    knownSourcePaths.add(candidate.imagePath); imported.push(asset);
+    try {
+      const asset = await store.createAsset({ projectId, imagePath: candidate.imagePath, prompt: candidate.altText, skill: "Cowart automatic bridge", ratio: candidate.ratio, theme: candidate.altText, sourceType: "cowart-generated", business_fields: { auto_archived: true, prompt_status: "Cowart canvas only provides alt text" }, source: { generation_tool: "cowart", cowart_source_id: sourceId, cowart_project_dir: cowartProjectDir, cowart_canvas_dir: candidate.canvasDir, cowart_page_id: candidate.pageId, cowart_page_asset_path: candidate.imagePath, cowart_page_asset_url: candidate.assetUrl, cowart_asset_id: candidate.cowartAssetId, cowart_shape_id: candidate.shapeId, cowart_shape_meta: candidate.shapeMeta, cowart_annotation_source_shape_id: candidate.annotationSourceShapeId || null, replaced_ai_image_holder: candidate.replacedAiImageHolder || null, prompt_status: "canvas-alt-text-only" } }, { trustedSourceRoots: [trustedPagesRoot] });
+      knownSourcePaths.add(candidate.imagePath); imported.push(asset);
+    } catch {
+      skipped.push({ path: candidate.imagePath, reason: "import-failed" });
+    }
   }
   return { imported, skipped, candidates: candidates.length };
 }

--- a/lib/sqlite-asset-store.mjs
+++ b/lib/sqlite-asset-store.mjs
@@ -306,19 +306,31 @@ export function createSqliteAssetStore(options = {}) {
       const name = normalizeGroupName(groupName);
       if (!name) throw new Error("Group name is required.");
 
-      // First, remove the group assignment from all assets
-      // Use json_set to set group to NULL instead of json_remove to handle edge cases
-      database.prepare(`
+      const selectAssignedAssets = database.prepare("SELECT * FROM assets WHERE project_id = ? AND group_name = ?");
+      const clearAssignment = database.prepare(`
         UPDATE assets
-        SET asset = json_set(asset, '$.group', NULL)
-        WHERE project_id = ?
-          AND json_valid(asset)
-          AND json_extract(asset, '$.group') = ?
-      `).run(pid, name);
+        SET group_name = '', search_text = ?, updated_at = ?
+        WHERE project_id = ? AND id = ?
+      `);
+      const deleteFtsEntry = database.prepare("DELETE FROM asset_fts WHERE project_id = ? AND asset_id = ?");
+      const insertFtsEntry = database.prepare("INSERT INTO asset_fts (project_id, asset_id, content) VALUES (?, ?, ?)");
+      const deleteGroup = database.prepare("DELETE FROM groups WHERE project_id = ? AND name = ?");
+      const timestamp = now();
 
-      // Then delete the group
-      const result = database.prepare("DELETE FROM groups WHERE project_id = ? AND name = ?").run(pid, name);
-      if (!result.changes) throw new Error(`Group not found: ${name}`);
+      database.transaction(() => {
+        for (const row of selectAssignedAssets.all(pid, name)) {
+          const metadata = rowToAsset(database, row);
+          metadata.group = "";
+          const searchText = searchableText(metadata);
+          clearAssignment.run(searchText, timestamp, pid, row.id);
+          deleteFtsEntry.run(pid, row.id);
+          insertFtsEntry.run(pid, row.id, searchText);
+        }
+
+        const result = deleteGroup.run(pid, name);
+        if (!result.changes) throw new Error(`Group not found: ${name}`);
+      })();
+      invalidateFtsPageCache();
 
       return { success: true, name };
     },
@@ -464,10 +476,14 @@ export function createSqliteAssetStore(options = {}) {
           root: index === 0 ? this.imagesDir(cleanProjectId) : index === 1 ? this.previewsDir(cleanProjectId) : this.thumbnailsDir(cleanProjectId),
           filePath,
         }));
+      const filesToUnlink = [];
       for (const { root, filePath } of managedPaths) {
-        await assertStoredPath(root, filePath).then(() => unlink(filePath)).catch((error) => {
+        try {
+          await assertStoredPath(root, filePath);
+          filesToUnlink.push(filePath);
+        } catch (error) {
           if (error?.code !== "ENOENT") throw error;
-        });
+        }
       }
       database.transaction(() => {
         database.prepare("DELETE FROM asset_tags WHERE project_id = ? AND asset_id = ?").run(cleanProjectId, cleanAssetId);
@@ -477,6 +493,10 @@ export function createSqliteAssetStore(options = {}) {
         database.prepare("DELETE FROM assets WHERE project_id = ? AND id = ?").run(cleanProjectId, cleanAssetId);
       })();
       invalidateFtsPageCache();
+      // Row is committed; leftover originals are swept by verify/thumbnails repair.
+      for (const filePath of filesToUnlink) {
+        await unlink(filePath).catch(() => {});
+      }
       return { id: cleanAssetId, project_id: cleanProjectId, deleted: true };
     },
     async duplicateAsset(projectId, assetId, input = {}) {

--- a/test/confirm-dialog-contract.test.mjs
+++ b/test/confirm-dialog-contract.test.mjs
@@ -340,3 +340,17 @@ test("58. dialog styles without !important", async () => {
   assert.match(css, /:where\(\.action-btn\.danger, \.batch-bar-btn\.danger, \.btn-danger\):not\(:disabled\):not\(\[aria-disabled="true"\]\):hover/,
     "danger hover stays inside the precise-pointer media guard");
 });
+
+test("context-menu bulk archive and delete pass the selected count into titles", async () => {
+  const source = await readFile(resolve(root, "app/context-menu-actions.mjs"), "utf8");
+  const { default: translations } = await import(pathToFileURL(resolve(root, "app/i18n.mjs")).href);
+
+  assert.match(translations.zh.archiveAssetsTitle, /\{count\}/);
+  assert.match(translations.en.archiveAssetsTitle, /\{count\}/);
+  assert.match(translations.zh.deleteAssetsTitle, /\{count\}/);
+  assert.match(translations.en.deleteAssetsTitle, /\{count\}/);
+  assert.match(source, /t\("archiveAssetsTitle", \{ count: assets\.length \}\)/);
+  assert.match(source, /t\("deleteAssetsTitle", \{ count: assets\.length \}\)/);
+  assert.doesNotMatch(source, /t\("archiveAssetsTitle"\)/);
+  assert.doesNotMatch(source, /t\("deleteAssetsTitle"\)/);
+});

--- a/test/cowart-bridge.test.mjs
+++ b/test/cowart-bridge.test.mjs
@@ -35,9 +35,48 @@ test("archives Cowart page assets once and keeps MOSA-origin images out", async 
   assert.equal(first.imported[0].source.cowart_annotation_source_shape_id, "shape:source");
   assert.equal(first.imported[0].ratio, "1:1");
 
+  await store.archiveAsset("default", first.imported[0].id);
   const second = await reconcileCowartAssets({ store, canvasDir });
   assert.equal(second.imported.length, 0);
   assert.equal(second.skipped.filter((item) => item.reason === "already-archived").length, 1);
+});
+
+test("continues Cowart reconciliation after one asset import fails", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-cowart-import-failure-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  const canvasDir = join(root, "cowart-data", "mosa");
+  const pageDir = join(canvasDir, "pages", "page");
+  const pageAssetsDir = join(pageDir, "assets");
+  const failedPath = join(pageAssetsDir, "a-fails.png");
+  const succeedingPath = join(pageAssetsDir, "b-succeeds.png");
+  await mkdir(pageAssetsDir, { recursive: true });
+  await writeFile(failedPath, "fixture failed Cowart image", "utf8");
+  await writeFile(succeedingPath, "fixture succeeding Cowart image", "utf8");
+  await writeFile(join(pageDir, "cowart-canvas.json"), JSON.stringify({
+    store: {
+      "asset:a-fails": { id: "asset:a-fails", typeName: "asset", type: "image", props: { name: "a-fails.png", src: "/page-assets/page/a-fails.png" }, meta: {} },
+      "shape:a-fails": { id: "shape:a-fails", typeName: "shape", type: "image", props: { assetId: "asset:a-fails", w: 100, h: 100, altText: "失败候选" }, meta: {} },
+      "asset:b-succeeds": { id: "asset:b-succeeds", typeName: "asset", type: "image", props: { name: "b-succeeds.png", src: "/page-assets/page/b-succeeds.png" }, meta: {} },
+      "shape:b-succeeds": { id: "shape:b-succeeds", typeName: "shape", type: "image", props: { assetId: "asset:b-succeeds", w: 100, h: 100, altText: "继续归档候选" }, meta: {} },
+    },
+  }), "utf8");
+
+  const createCalls = [];
+  const store = {
+    cowartCanvasDir: canvasDir,
+    async listAssets() { return []; },
+    async createAsset(params) {
+      createCalls.push(params.imagePath);
+      if (params.imagePath === failedPath) throw new Error("fixture import failure");
+      return { id: "succeeded", image_path: params.imagePath };
+    },
+  };
+
+  const result = await reconcileCowartAssets({ store, canvasDir });
+  assert.deepEqual(createCalls, [failedPath, succeedingPath]);
+  assert.deepEqual(result.skipped, [{ path: failedPath, reason: "import-failed" }]);
+  assert.deepEqual(result.imported, [{ id: "succeeded", image_path: succeedingPath }]);
 });
 
 test("watches a Cowart page directory and archives a later image", async (t) => {

--- a/test/desktop-i18n-contract.test.mjs
+++ b/test/desktop-i18n-contract.test.mjs
@@ -99,6 +99,13 @@ test("main localizes custom menu labels without changing roles or accelerators",
   assert.match(menu, /setImmediate\(\(\) =>/);
 });
 
+test("main keeps MOSA shortcuts scoped to its application menu", async () => {
+  const main = await read("desktop/main.mjs");
+
+  assert.doesNotMatch(main, /\bglobalShortcut\b/);
+  assert.doesNotMatch(main, /registerGlobalShortcuts/);
+});
+
 test("set-locale validates sender and locale, rebuilds once, and is idempotent", async () => {
   const main = await read("desktop/main.mjs");
   const handler = sliceBetween(main, 'ipcMain.handle("set-locale"', "\n  });");

--- a/test/sqlite-store.test.mjs
+++ b/test/sqlite-store.test.mjs
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import Database from "better-sqlite3";
-import { copyFile, mkdtemp, mkdir, readFile, rm, stat, unlink, writeFile } from "node:fs/promises";
+import { chmod, copyFile, mkdtemp, mkdir, readFile, rm, stat, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import test from "node:test";
 import sharp from "sharp";
 import { createDerivativeWorker, processDerivativeJob } from "../lib/derivative-worker.js";
@@ -50,6 +50,61 @@ test("SQLite store keeps archive, duplicate, version, and cursor contracts", asy
   assert.deepEqual(active.map((asset) => asset.id).sort(), [child.id, parent.id].sort());
   const activeSearch = await store.listAssetPage({ projectId: "default", query: "mechanical", limit: 2 });
   assert.equal(activeSearch.page.total, 2, "an archived match invalidates the cached FTS count");
+});
+
+test("SQLite deleting a group clears asset assignments and its search index", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-sqlite-delete-group-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const projectRoot = join(root, "project");
+  const sourcePath = join(projectRoot, "generated-images", "fixture.png");
+  await mkdir(join(projectRoot, "generated-images"), { recursive: true });
+  await writeFile(sourcePath, ONE_PIXEL_PNG);
+  const store = createSqliteAssetStore({ projectRoot, managerDir: join(projectRoot, "mosa"), libraryDir: join(root, "library") });
+  t.after(() => store.close());
+
+  await store.createGroup({ projectId: "default", name: "Aurora" });
+  const asset = await store.createAsset({ assetId: "grouped-fixture", imagePath: sourcePath, prompt: "group deletion fixture", group: "Aurora" });
+  assert.equal((await store.listAssetPage({ projectId: "default", query: "Aurora", limit: 10 })).page.total, 1);
+
+  await store.deleteGroup("default", "Aurora");
+
+  assert.equal((await store.getAsset("default", asset.id)).group, "");
+  assert.equal((await store.listAssetPage({ projectId: "default", query: "Aurora", limit: 10 })).page.total, 0, "the removed group is no longer searchable");
+  assert.deepEqual((await store.listGroups("default")).groups, []);
+
+  await store.createGroup({ projectId: "default", name: "Aurora" });
+  assert.deepEqual((await store.listGroups("default")).groups, [["Aurora", 0]]);
+});
+
+test("SQLite deleteAsset commits the row before unlinking files", async (t) => {
+  const source = await readFile(new URL("../lib/sqlite-asset-store.mjs", import.meta.url), "utf8");
+  const start = source.indexOf("async deleteAsset(projectId, assetId)");
+  const end = source.indexOf("async duplicateAsset(projectId, assetId, input = {})", start);
+  assert.ok(start > -1 && end > start, "deleteAsset is present");
+  const body = source.slice(start, end);
+  const transactionAt = body.indexOf("database.transaction(");
+  const unlinkAt = body.lastIndexOf("unlink(filePath)");
+  assert.ok(transactionAt > -1 && unlinkAt > -1, "deleteAsset still deletes rows and files");
+  assert.ok(transactionAt < unlinkAt, "the asset row is removed before originals are unlinked");
+
+  const root = await mkdtemp(join(tmpdir(), "mosa-sqlite-delete-asset-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const projectRoot = join(root, "project");
+  const sourcePath = join(projectRoot, "generated-images", "fixture.png");
+  await mkdir(join(projectRoot, "generated-images"), { recursive: true });
+  await writeFile(sourcePath, ONE_PIXEL_PNG);
+  const store = createSqliteAssetStore({ projectRoot, managerDir: join(projectRoot, "mosa"), libraryDir: join(root, "library") });
+  t.after(() => store.close());
+
+  const asset = await store.createAsset({ assetId: "delete-row-first", imagePath: sourcePath, prompt: "delete order fixture" });
+  const imageDir = dirname(asset.image_path);
+  await chmod(imageDir, 0o555);
+  try {
+    await store.deleteAsset("default", asset.id);
+    await assert.rejects(store.getAsset("default", asset.id), /not found/i);
+  } finally {
+    await chmod(imageDir, 0o755);
+  }
 });
 
 test("SQLite recipe snapshots change only with generation inputs and remain immutable", async (t) => {


### PR DESCRIPTION
Fixes SQLite group deletion, Cowart archive dedupe, menu-scoped shortcuts, and bulk confirmation counts.\n\nValidated with npm test, npm run lint, npm run check, and git diff --check.