### PR TITLE
test: avoid exposing internal design note names

### DIFF
--- a/test/shell-layout-contract.test.mjs
+++ b/test/shell-layout-contract.test.mjs
@@ -184,7 +184,6 @@ test("22. O2 compact desktop behavior stays locked in public CSS", async () => {
   assert.match(mq1120, /\.shell\.details-open \{ grid-template-columns: var\(--sidebar-width-compact\) minmax\(0, 1fr\) var\(--inspector-width-compact\); \}/);
   assert.match(mqCompact, /\.shell\.details-open \.nav-item-text,[\s\S]*?clip: rect\(0,0,0,0\)/);
   assert.match(css, /@media \(max-width: 700px\) \{[\s\S]*?\.shell, \.shell\.details-open \{ display: flex; min-height: 100vh; flex-direction: column; \}/);
-  assert.doesNotMatch(css, /MOSA-UI-实施决策-v1\.md/);
 });
 
 // 23. The search-location contract keeps holding (sidebar, not topbar).


### PR DESCRIPTION
## Summary

Remove the negative assertion that exposed the filename of an internal product-design note. The public shell contract remains covered by executable CSS assertions, without retaining the internal document name in the public source tree.

## Validation

- npm run lint
- npm run check
- npm test — 763 passed, 2 skipped
- npm run test:performance — passed
- npm run audit — 0 production vulnerabilities
- git diff --check