### PR TITLE
fix: preserve inspector preview aspect ratios

### DIFF
--- a/app/inspector-markup.mjs
+++ b/app/inspector-markup.mjs
@@ -102,7 +102,11 @@ export function createInspectorMarkup({ state, t, referenceRightsMarkup }) {
     return `<button class="detail-fav-btn${favorite ? " is-fav" : ""}" type="button" data-action="toggle-favorite" aria-pressed="${favorite}" aria-label="${escapeHtml(actionLabel)}"><span aria-hidden="true">${favorite ? "★" : "☆"}</span><span>${escapeHtml(visibleLabel)}</span></button>`;
   }
 
-  const MAX_DETAIL_PREVIEW_ASPECT = 9 / 16;
+  // 9:16 is the tallest preview viewport we allow. Assets that are less tall
+  // than that (for example 2:3, 3:4, 1:1, 16:9) keep their real aspect ratio,
+  // so the thumbnail has no letterboxing. Assets taller than 9:16 are capped
+  // to a 9:16 viewport; object-fit: cover then fills the viewport by cropping.
+  const MIN_DETAIL_PREVIEW_ASPECT = 9 / 16;
 
   function detailPreviewAspectRatio(asset) {
     const width = persistedPositiveNumber(asset, "width");
@@ -111,7 +115,7 @@ export function createInspectorMarkup({ state, t, referenceRightsMarkup }) {
       return "9 / 16";
     }
     const assetAspect = width / height;
-    return assetAspect <= MAX_DETAIL_PREVIEW_ASPECT ? `${width} / ${height}` : "9 / 16";
+    return assetAspect >= MIN_DETAIL_PREVIEW_ASPECT ? `${width} / ${height}` : "9 / 16";
   }
 
   function detailFileSectionMarkup(asset) {

--- a/test/inspector-information-architecture-contract.test.mjs
+++ b/test/inspector-information-architecture-contract.test.mjs
@@ -153,9 +153,9 @@ test("7-10. file facts are honest — notRecorded fallbacks, no fabrication", as
   assert.equal(helpers.fileSizeText(capturedAsset), "584 KB");
   assert.equal(helpers.fileDimensionsText({ business_fields: { width: 0, height: 1376 } }), null);
 
-  // Preview geometry follows the real asset ratio up through 9:16. Wider
-  // assets are capped to a 9:16 viewport and fill that viewport with cover.
-  assert.match(inspector, /return assetAspect <= MAX_DETAIL_PREVIEW_ASPECT \? `\$\{width\} \/ \$\{height\}` : "9 \/ 16";/);
+  // Preview geometry keeps the real ratio for 2:3, 3:4 and wider assets. Only
+  // assets taller than 9:16 are capped to a 9:16 viewport and filled with cover.
+  assert.match(inspector, /return assetAspect >= MIN_DETAIL_PREVIEW_ASPECT \? `\$\{width\} \/ \$\{height\}` : "9 \/ 16";/);
   assert.match(css, /\.mosa-v2 \.detail \.detail-overview \.detail-image-wrap \{[\s\S]*?aspect-ratio: var\(--detail-preview-aspect, 9 \/ 16\);[\s\S]*?overflow: hidden;/);
   assert.match(css, /\.mosa-v2 \.detail \.detail-overview \.detail-image \{[\s\S]*?object-fit: cover;/);
 });


### PR DESCRIPTION
Fix the inspector preview aspect-ratio boundary so 2:3, 3:4, square, and landscape assets keep their real ratio while only taller-than-9:16 assets use the capped viewport. Validation: npm test; npm run lint; npm run check; npm run audit; git diff --check. Lint reports 0 errors and 3 existing coverage warnings.