### PR TITLE
fix: harden interaction state and asset mutations

### DIFF
--- a/app/api-client.mjs
+++ b/app/api-client.mjs
@@ -23,7 +23,14 @@ export function createApiClient(deps) {
     const response = await fetch(path, { method: options.method || "GET", headers: options.body ? { "content-type": "application/json" } : undefined, body: options.body ? JSON.stringify(options.body) : undefined });
     const raw = await response.text();
     let payload = {};
-    try { payload = raw ? JSON.parse(raw) : {}; } catch { if (!response.ok) throw new Error(response.statusText); }
+    try { payload = raw ? JSON.parse(raw) : {}; }
+    catch {
+      // 200 + 非法 JSON（反代/网关错误页）不得伪装成空结果——否则画廊会渲染
+      // “没有找到匹配的素材”空态而非错误态。HTTP/2 下 statusText 恒为空串，
+      // 错误消息退回状态码文本。
+      if (!response.ok) throw new Error(response.statusText || `HTTP ${response.status}`);
+      throw new Error(`Invalid JSON response (HTTP ${response.status})`);
+    }
     if (!response.ok) {
       // Carry the server's machine-readable code so callers can attribute a
       // failure to a specific form field instead of matching on prose.

--- a/app/app.mjs
+++ b/app/app.mjs
@@ -62,9 +62,6 @@ const state = {
   detailReturnFocusAssetId: null, previewReturnFocusAssetId: null,
   imageZoom: 1, imagePanX: 0, imagePanY: 0, imageDragging: false,
   // Bulk-selection gate. The viewer short-circuits while batch mode is active so
-  // selected cards never auto-open the asset view mid-selection; this defaults to
-  // false because batch UI isn't yet wired up (see Bug D in the audit report).
-  batchMode: false,
   // Phase 3A / D4：专用大图查看模式最小状态——viewMode 二值（library/asset）+ 进入时的
   // 画廊返回快照。不复刻搜索/筛选/排序状态、不深拷贝 state、无第二套 selectedAsset、无平行 Router。
   viewMode: "library", libraryReturnSnapshot: null,
@@ -95,7 +92,7 @@ const els = {
   typeFilters: document.querySelector(".topbar-type-filters"),
   sidebar: document.querySelector("#appSidebar"), mobileNavToggle: document.querySelector("#mobileNavToggle"), mobileNavClose: document.querySelector("#mobileNavClose"), mobileNavScrim: document.querySelector("#mobileNavScrim"),
   activeFilters: document.querySelector("#activeFilters"), filterPanel: document.querySelector("#filterPanel"), filterToggle: document.querySelector("#filterToggle"), sortSelect: document.querySelector("#sortSelect"), themeToggle: document.querySelector("#themeToggle"),
-  accountToggle: document.querySelector("#accountToggle"), accountModal: document.querySelector("#accountModal"), closeAccountModal: document.querySelector("#closeAccountModal"), accountAssetCount: document.querySelector("#accountAssetCount"), accountCollectionCount: document.querySelector("#accountCollectionCount"), settingsToggle: document.querySelector("#settingsToggle"), settingsMenu: document.querySelector("#settingsMenu"), addGroupBtn: document.querySelector("#addGroupBtn"), sidebarGroupList: document.querySelector("#sidebarGroupList"), newAssetTopBtn: document.querySelector("#newAssetTopBtn"), importModal: document.querySelector("#importModal"), closeImportModal: document.querySelector("#closeImportModal"), cancelImportBtn: document.querySelector("#cancelImportBtn"), groupModal: document.querySelector("#groupModal"), closeGroupModal: document.querySelector("#closeGroupModal"), cancelGroupBtn: document.querySelector("#cancelGroupBtn"), saveGroupBtn: document.querySelector("#saveGroupBtn"), groupNameInput: document.querySelector("#groupNameInput"), imagePreviewModal: document.querySelector("#imagePreviewModal"), imagePreviewStage: document.querySelector("#imagePreviewStage"), imagePreviewImage: document.querySelector("#imagePreviewImage"), imagePreviewVideo: document.querySelector("#imagePreviewVideo"), imagePreviewTitle: document.querySelector("#imagePreviewTitle"), closeImagePreview: document.querySelector("#closeImagePreview"), imagePathInput: document.querySelector("#imagePathInput"), codexSourceHint: document.querySelector("#codexSourceHint"), importFormatList: document.querySelector("#importFormatList"), importPathExample: document.querySelector("#importPathExample"), imagePathError: document.querySelector("#imagePathError"), businessFieldsError: document.querySelector("#businessFieldsError"), importAdvanced: document.querySelector("#importAdvanced"), promptInput: document.querySelector("#promptInput"), skillInput: document.querySelector("#skillInput"), styleInput: document.querySelector("#styleInput"), ratioInput: document.querySelector("#ratioInput"), themeInput: document.querySelector("#themeInput"), groupInput: document.querySelector("#groupInput"), categoryInput: document.querySelector("#categoryInput"), businessInput: document.querySelector("#businessInput"), saveAssetBtn: document.querySelector("#saveAssetBtn"),
+  accountToggle: document.querySelector("#accountToggle"), accountModal: document.querySelector("#accountModal"), closeAccountModal: document.querySelector("#closeAccountModal"), accountAssetCount: document.querySelector("#accountAssetCount"), accountCollectionCount: document.querySelector("#accountCollectionCount"), settingsToggle: document.querySelector("#settingsToggle"), settingsMenu: document.querySelector("#settingsMenu"), sidebarGroupList: document.querySelector("#sidebarGroupList"), newAssetTopBtn: document.querySelector("#newAssetTopBtn"), importModal: document.querySelector("#importModal"), closeImportModal: document.querySelector("#closeImportModal"), cancelImportBtn: document.querySelector("#cancelImportBtn"), groupModal: document.querySelector("#groupModal"), closeGroupModal: document.querySelector("#closeGroupModal"), cancelGroupBtn: document.querySelector("#cancelGroupBtn"), saveGroupBtn: document.querySelector("#saveGroupBtn"), groupNameInput: document.querySelector("#groupNameInput"), imagePreviewModal: document.querySelector("#imagePreviewModal"), imagePreviewStage: document.querySelector("#imagePreviewStage"), imagePreviewImage: document.querySelector("#imagePreviewImage"), imagePreviewVideo: document.querySelector("#imagePreviewVideo"), imagePreviewTitle: document.querySelector("#imagePreviewTitle"), closeImagePreview: document.querySelector("#closeImagePreview"), imagePathInput: document.querySelector("#imagePathInput"), codexSourceHint: document.querySelector("#codexSourceHint"), importFormatList: document.querySelector("#importFormatList"), importPathExample: document.querySelector("#importPathExample"), imagePathError: document.querySelector("#imagePathError"), businessFieldsError: document.querySelector("#businessFieldsError"), importAdvanced: document.querySelector("#importAdvanced"), promptInput: document.querySelector("#promptInput"), skillInput: document.querySelector("#skillInput"), styleInput: document.querySelector("#styleInput"), ratioInput: document.querySelector("#ratioInput"), themeInput: document.querySelector("#themeInput"), groupInput: document.querySelector("#groupInput"), categoryInput: document.querySelector("#categoryInput"), businessInput: document.querySelector("#businessInput"), saveAssetBtn: document.querySelector("#saveAssetBtn"),
   viewTitle: document.querySelector("#viewTitle"), assetCount: document.querySelector("#assetCount"), statusText: document.querySelector("#statusText"), bridgeStatus: document.querySelector("#bridgeStatus"), bridgeStatusLabel: document.querySelector("#bridgeStatusLabel"), bridgeStatusMeta: document.querySelector("#bridgeStatusMeta"), appShell: document.querySelector("#appShell"), assetGrid: document.querySelector("#assetGrid"), detailPanel: document.querySelector("#detailPanel"), toastContainer: document.querySelector("#toastContainer"), toastErrorContainer: document.querySelector("#toastErrorContainer")
 };
 
@@ -372,6 +369,10 @@ function setupKeyboardShortcuts() {
     // Phase 5B：ConfirmDialog 打开时页面背景不接收任何键盘操作（Escape 由
     // trapConfirmDialogFocus 消费；不新增第二套全局 Escape 路由）。
     if (confirmDialogState.pending) return;
+    // M1 兜底：右键菜单打开期间键盘归菜单独占（菜单本身以捕获阶段消费并阻断
+    // 冒泡）。一次 Escape 只关菜单，方向键只移动菜单焦点，不连带关 Inspector
+    // 或切换画廊选中。
+    if (contextMenu.isOpen()) return;
     // Disabled context-menu shortcuts (pasteFromClipboard / selectAll) advertise
     // ⌘V / ⌘A but never implement them. Block the browser defaults so users
     // don't accidentally select all DOM text or trip paste-handlers that the
@@ -452,6 +453,7 @@ function setupKeyboardShortcuts() {
       && els.imagePreviewModal?.hidden
       && !els.importModal?.classList.contains("open")
       && !els.groupModal?.classList.contains("open")
+      && !els.accountModal?.classList.contains("open")
       && els.settingsMenu?.hidden
       && !event.target.closest?.("[contenteditable]")) {
       if (event.target.matches?.("input, textarea, select")) return; // 输入控件一律不触发 Viewer 快捷键
@@ -615,16 +617,6 @@ async function init() {
     }
   }
 
-function addVoiceOverLabel(element, id, text) {
-  if (!element || !text) return;
-  const label = document.createElement("span");
-  label.className = "visually-hidden";
-  label.id = id;
-  label.textContent = text;
-  element.setAttribute("aria-labelledby", id);
-  element.prepend(label);
-}
-
 function renderSettingsMenu() {
   if (!els.settingsMenu) return;
   const settingIcon = (path) => `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true"><path d="${path}"/></svg>`;
@@ -658,15 +650,6 @@ async function fetchDiagnostics() {
   } catch {
     content.innerHTML = `<p class="diag-error">${t("diagError")}</p>`;
   }
-}
-
-function renderCowartCanvasSettings() {
-  const entries = state.cowartCanvases.map((canvas) => {
-    const label = cowartCanvasLabel(canvas);
-    const status = canvas.lastError ? "error" : canvas.enabled ? "ok" : "off";
-    return `<div class="settings-cowart-entry" title="${escapeHtml(canvas.canvasDir || canvas.projectDir || "")}"><span class="settings-cowart-status" data-state="${status}" aria-hidden="true"></span><span class="settings-cowart-name">${escapeHtml(label)}</span></div>`;
-  }).join("");
-  return `<section class="settings-section settings-cowart-section"><p>${t("cowartCanvases")}</p><div class="settings-cowart-list">${entries}</div></section>`;
 }
 
 function cowartCanvasLabel(canvas = {}) {
@@ -731,7 +714,7 @@ function handleLibraryKeyboardNavigation(event) {
 // router. The name is retained for the Phase 3 contract seam; it does not add a
 // second document listener or a second shortcut manager.
 function bindKeyboardNav(event) {
-  if (confirmDialogState.pending || els.importModal?.classList.contains("open") || els.groupModal?.classList.contains("open")) return;
+  if (confirmDialogState.pending || els.importModal?.classList.contains("open") || els.groupModal?.classList.contains("open") || els.accountModal?.classList.contains("open")) return;
   if (!els.imagePreviewModal?.hidden || !els.settingsMenu?.hidden) return;
   if (event.target.closest?.("[contenteditable]")) return;
   if (event.target.closest?.("[role='tab']")) return;
@@ -767,6 +750,7 @@ const contextMenuActions = createContextMenuActions({
   requestConfirmation,
   confirmDetailNavigation,
   discardDetailDraft,
+  openGroupModal,
   getGroupColor: colorForGroup,
   saveGroupColor,
 });
@@ -781,11 +765,14 @@ function latestAssetSnapshot(projectId, assetId, fallback = null) {
   return state.assets.find((item) => item.project_id === projectId && item.id === assetId) || fallback;
 }
 
-const bridgeStatusPoller = createBridgeStatusPoller({
-  fetchStatus: () => apiFetch("/api/bridges"),
-  onSuccess: applyBridgeStatus,
-  onError: applyBridgeStatusFailure,
-});
+function createBridgeStatusPolling() {
+  return createBridgeStatusPoller({
+    fetchStatus: () => apiFetch("/api/bridges"),
+    onSuccess: applyBridgeStatus,
+    onError: applyBridgeStatusFailure,
+  });
+}
+let bridgeStatusPoller = createBridgeStatusPolling();
 
 // Stop polling when the page goes away and drop any response that lands afterwards.
 window.addEventListener("pagehide", () => {
@@ -793,6 +780,26 @@ window.addEventListener("pagehide", () => {
   if (libraryRefreshTimer) {
     clearInterval(libraryRefreshTimer);
     libraryRefreshTimer = null;
+  }
+});
+// M6：隐藏标签页暂停轮询（与 refreshLibraryInBackground 的 document.hidden 守卫
+// 对齐）；重新可见时恢复并立即刷新一次，指示灯不落后于真实桥接状态。
+document.addEventListener("visibilitychange", () => {
+  if (document.hidden) bridgeStatusPoller.pause();
+  else { bridgeStatusPoller.resume(); void refreshBridgeStatus(); }
+});
+// bfcache 恢复（浏览器“后退”）：pagehide 已终止旧轮询实例（stop 是不可逆的
+// teardown 守卫），pageshow(persisted) 后页面重新可见，重建新实例继续轮询并
+// 恢复库刷新间隔，桥接指示灯不再永久冻结在旧值。
+window.addEventListener("pageshow", (event) => {
+  if (!event.persisted) return;
+  bridgeStatusPoller = createBridgeStatusPolling();
+  void bridgeStatusPoller.refresh();
+  bridgeStatusPoller.start();
+  if (!libraryRefreshTimer) {
+    libraryRefreshTimer = setInterval(() => {
+      if (!isLoadingMore) void refreshLibraryInBackground();
+    }, LIBRARY_REFRESH_INTERVAL);
   }
 });
 
@@ -1017,7 +1024,6 @@ function bindEvents() {
     const id = selectButton.closest(".asset-card")?.dataset.id;
     if (id) openImagePreview(id, selectButton);
   });
-  els.addGroupBtn?.addEventListener("click", openGroupModal);
   els.newAssetTopBtn?.addEventListener("click", openImportModal);
   els.quickFilters?.addEventListener("click", (event) => { const button = event.target.closest("[data-filter]"); if (button) void setFilter(button.dataset.filter); });
   els.sidebarGroupList?.addEventListener("click", (event) => {
@@ -1129,6 +1135,11 @@ function bindEvents() {
     if (event.target === els.imagePreviewStage) closeImagePreview();
   });
   els.imagePreviewImage?.addEventListener("load", fitImagePreview);
+  // L：灯箱此前完全没有加载失败处理——图片 404 时舞台空白且无任何提示。
+  // src 被移除（关闭预览）触发的 error 不属于真失败，需排除。
+  els.imagePreviewImage?.addEventListener("error", () => {
+    if (!els.imagePreviewModal?.hidden && els.imagePreviewImage?.getAttribute("src")) showToast(t("imageLoadFailed"), "error");
+  });
   els.assetViewBack?.addEventListener("click", () => { void closeDetailSurface(); });
   // Phase 3A 运行时修复（双击进入路径）：第一次 click 已打开查看模式并同步聚焦返回按钮，
   // 紧随的第二次 mousedown 落在同坐标的舞台/主图上——浏览器默认动作会把焦点清到 BODY，
@@ -1370,7 +1381,9 @@ function showImportError(field, message) {
   target.input?.setAttribute("aria-invalid", "true");
   // A collapsed advanced section would otherwise hide the field the error names.
   if (target.disclosure) target.disclosure.open = true;
-  target.input?.focus();
+  // 控件在保存期间是 disabled（focus 对其是 no-op）；rAF 晚于调用方的 finally，
+  // 到那时按钮已恢复可用，焦点才能真正落到出错字段上。
+  requestAnimationFrame(() => target.input?.focus());
 }
 
 function setImportBusy(busy) {
@@ -1395,9 +1408,12 @@ async function saveAsset() {
   const originProjectId = state.project;
   const originAssetId = state.selectedId;
   const hadDetailDraft = state.detailDirty;
-  if (hadDetailDraft && !await confirmDetailNavigation(null)) return;
+  // 防重窗口必须先于 confirmDetailNavigation 的网络级冲刷打开（PATCH + 两次
+  // 刷新，数百毫秒）--否则冲刷期间的双击会重复走到 POST /api/assets/create，
+  // 同一文件被导入两份。
   setImportBusy(true);
   try {
+    if (hadDetailDraft && !await confirmDetailNavigation(null)) return;
     const result = await apiFetch("/api/assets/create", { method: "POST", body: { projectId: originProjectId, imagePath: els.imagePathInput.value, prompt: els.promptInput.value, skill: els.skillInput.value, style: els.styleInput.value, ratio: els.ratioInput.value, theme: els.themeInput.value, group: els.groupInput.value, category: els.categoryInput.value, tags: uniqueTags([...(derivePromptTags({ prompt: els.promptInput.value, skill: els.skillInput.value, style: els.styleInput.value, theme: els.themeInput.value, category: els.categoryInput.value }))]), business_fields: businessFields } });
     if (hadDetailDraft && originProjectId === state.project && originAssetId === state.selectedId) discardDetailDraft();
     state.selectedId = result.asset.id;
@@ -1795,6 +1811,8 @@ function setInspectorAutosaveStatus(panel, kind) {
   panel?.querySelectorAll("[data-autosave-status]").forEach((node) => {
     if (kind === "saving") node.textContent = t("saving");
     else if (kind === "saved") node.textContent = t("autoSaved");
+    // L1：失败必须落在面板状态位上（不只靠一闪而过的 Toast），dirty 仍保留可重试。
+    else if (kind === "error") node.textContent = t("autoSaveFailed");
     else node.textContent = "";
   });
 }
@@ -1816,29 +1834,40 @@ async function persistInspectorDraft(panel, asset, renderId) {
     try {
       const currentAsset = latestAssetSnapshot(originProjectId, originAssetId, asset);
       const body = {};
+      let sentRecipeSnapshot = null;
+      let sentReferencesSnapshot = null;
       if (recipeDirty) {
         const recipeDraft = readRecipeDraft(panel);
         // 配方保存只读 [data-recipe-change]；说明为空时省略 recipe_change_summary
         //（服务端缺省 "Recipe updated"），不硬编码英文、不创建新版本。
         const changeSummary = panel.querySelector("[data-recipe-change]")?.value.trim() || "";
         Object.assign(body, recipeDraft, { tags: uniqueTags([...assetTags(currentAsset), ...derivePromptTags(recipeDraft)]) }, changeSummary ? { recipe_change_summary: changeSummary } : {});
+        sentRecipeSnapshot = JSON.stringify([recipeDraft, changeSummary]);
       }
       if (referenceDirty) {
         const section = panel.querySelector("[data-reference-rights-section]");
         body.references = readReferenceRightsDraft(section, currentAsset);
+        sentReferencesSnapshot = JSON.stringify(body.references);
       }
       const result = await apiFetch(`/api/assets/${encodeURIComponent(originProjectId)}/${encodeURIComponent(originAssetId)}`, { method: "PATCH", body });
       if (!isCurrentDetailAction(renderId, originProjectId, originAssetId)) return true;
       state.detailAsset = result.asset;
       const index = state.assets.findIndex((item) => item.id === originAssetId && item.project_id === originProjectId);
       if (index >= 0) state.assets[index] = result.asset;
-      if (recipeDirty) clearDetailDirtyScope(panel, "recipe");
-      if (referenceDirty) {
-        const section = panel.querySelector("[data-reference-rights-section]");
-        if (section) delete section.dataset.referenceDirty;
-        state.detailDirty = panelHasDirtyDraft(panel);
+      // PATCH 在途期间的新输入不在请求体里：只有当前草稿与发出时完全一致才清脏；
+      // 有飞行期编辑则保留 dirty 标志并立即补存，否则导航冲刷会把可见编辑当
+      // “无草稿”静默丢弃（面板显示已保存，服务器却缺最后几笔输入）。
+      const flightEdits = draftChangedDuringFlight(panel, sentRecipeSnapshot, sentReferencesSnapshot);
+      if (!flightEdits) {
+        if (recipeDirty) clearDetailDirtyScope(panel, "recipe");
+        if (referenceDirty) {
+          const section = panel.querySelector("[data-reference-rights-section]");
+          if (section) delete section.dataset.referenceDirty;
+          state.detailDirty = panelHasDirtyDraft(panel);
+        }
       }
       setInspectorAutosaveStatus(panel, "saved");
+      if (flightEdits) scheduleInspectorSave();
       await loadStats();
       await loadAssets({ background: true });
       return true;
@@ -1865,7 +1894,26 @@ async function flushInspectorSave() {
 
 async function confirmDetailNavigation() {
   // 自动保存：导航/切换前冲刷挂起的草稿；失败则返回 false 阻断导航（不静默丢数据）。
+  // version/tags 作用域是手动保存语义（没有自动保存兜底）：存在未提交草稿时先显式
+  // 确认丢弃，避免点开另一张卡片/关掉 Inspector 就无声清掉已写的变更说明或新标签。
+  if (hasManualSaveDraft()) {
+    const confirmed = await requestConfirmation({
+      title: t("discardChangesTitle"),
+      description: t("discardChangesDescription"),
+      confirmLabel: t("discardChangesAction"),
+      tone: "danger",
+    });
+    if (!confirmed) return false;
+  }
   return flushInspectorSave();
+}
+
+// 手动保存作用域（version=另存为新版本的变更说明，tags=标签编辑器输入）的未提交
+// 草稿。recipe/reference 由自动保存冲刷兜底，不在此弹确认。
+function hasManualSaveDraft() {
+  const panel = els.detailPanel;
+  if (!panel?.isConnected || !state.detailOpen) return false;
+  return Boolean(panel.querySelector('[data-detail-dirty="true"][data-detail-dirty-scope="version"], [data-detail-dirty="true"][data-detail-dirty-scope="tags"]'));
 }
 
 function discardDetailDraft() {
@@ -2099,9 +2147,10 @@ async function saveGroup() {
   const originProjectId = state.project;
   const originAssetId = state.selectedId;
   const hadDetailDraft = state.detailDirty;
-  if (hadDetailDraft && !await confirmDetailNavigation(null)) return;
+  // 同 saveAsset：防重窗口先于草稿冲刷的网络往返打开，冲刷期间双击不重复建组。
   setGroupBusy(true);
   try {
+    if (hadDetailDraft && !await confirmDetailNavigation(null)) return;
     await runAction(async () => {
       const result = await apiFetch("/api/groups", { method: "POST", body: { projectId: originProjectId, name } });
       if (hadDetailDraft && originProjectId === state.project && originAssetId === state.selectedId) discardDetailDraft();
@@ -2109,10 +2158,11 @@ async function saveGroup() {
       closeGroupModal({ force: true });
       await loadStats();
       showToast(`${t("groupCreated")}${result.group.name}`, "success");
-      state.facets.group = result.group.name;
-      state.nextCursor = null;
+      // “来源”已是当前侧栏的唯一自动分组入口；创建自定义分组不应把用户瞬间
+      // 导航到一个尚无素材的空分组。保留当前画廊上下文，新分组会立即出现在
+      // 素材右键的“移动到分组”子菜单中。
       clearDetailSelection();
-      renderQuickFilters(); renderActiveFilters(); await loadAssets();
+      renderQuickFilters();
     });
   } finally {
     setGroupBusy(false);
@@ -2259,8 +2309,10 @@ function renderDetail() {
   if (hadPanelFocus) els.detailPanel.querySelector("#detailTitle")?.focus();
   // Phase 3A：详情内容变化（版本切换/后台刷新/语言切换）时同步查看模式舞台主图。
   if (state.viewMode === "asset") renderAssetView();
-  void loadVersionHistory(asset);
-  void loadRecipeHistory(asset);
+  // P2：该素材的历史已有缓存（同素材重渲染：收藏切换/自动保存后的后台刷新/
+  // 语言切换）时不重发两个历史请求；导航换素材时缓存已被清空，照常拉取。
+  if (!cachedHistory) void loadVersionHistory(asset);
+  if (!cachedRecipeHistory) void loadRecipeHistory(asset);
 }
 
 let versionHistoryRequestSequence = 0;
@@ -2503,13 +2555,20 @@ function bindDetailEvents(asset, renderId) {
       // never throws away edits as a side effect.
       if (!await confirmDetailNavigation(null)) return;
       if (!isCurrentDetailSelection(asset.project_id, asset.id)) return;
-      await apiFetch(`/api/assets/${encodeURIComponent(asset.project_id)}/${encodeURIComponent(asset.id)}/archive`, { method: "POST" });
-      discardDetailDraft();
-      showToast(t("archived"), "success");
-      setDetailOpen(false);
-      state.selectedId = null;
-      await loadStats();
-      await loadAssets();
+      // POST 在途防重：确认框本身有单 pending 守卫，但在确认通过到请求完成之间
+      // 按钮仍是活的；禁用它避免二次归档提交。
+      trigger.disabled = true;
+      try {
+        await apiFetch(`/api/assets/${encodeURIComponent(asset.project_id)}/${encodeURIComponent(asset.id)}/archive`, { method: "POST" });
+        discardDetailDraft();
+        showToast(t("archived"), "success");
+        setDetailOpen(false);
+        state.selectedId = null;
+        await loadStats();
+        await loadAssets();
+      } finally {
+        trigger.disabled = false;
+      }
     });
   });
   panel.querySelectorAll('[data-edit="rating"] button').forEach((button) => button.addEventListener("click", () => {
@@ -2576,7 +2635,8 @@ function bindReferenceRightsEvents(panel, asset, renderId) {
   // thumbnail 404s and leaves an empty box; the strict CSP rules out an inline
   // onerror attribute, so the fallback is bound here.
   section.querySelectorAll(".reference-thumb img").forEach((image) => image.addEventListener("error", () => {
-    const initials = escapeHtml(String(image.dataset.referenceLabel || "?").slice(0, 2).toUpperCase());
+    // textContent 不做 HTML 解析，直接赋原始缩写；先 escapeHtml 会双重转义成 &amp; 之类。
+    const initials = String(image.dataset.referenceLabel || "?").slice(0, 2).toUpperCase();
     image.replaceWith(Object.assign(document.createElement("span"), { className: "reference-thumb-empty", ariaHidden: "true", textContent: initials }));
   }));
 
@@ -2614,6 +2674,26 @@ function clearDetailDirtyScope(panel, scope) {
     delete field.dataset.detailDirtyScope;
   });
   state.detailDirty = panelHasDirtyDraft(panel);
+}
+
+// C1：比较“发出时的请求体快照”与当前 DOM 草稿。不一致说明 PATCH 在途期间用户
+// 又编辑了（这些值不在已发出的请求体里），成功返回后不得清脏。读取异常（如
+// business_fields 的 JSON 正在写一半、面板已被重建）一律保守视为“已变化”，保数据。
+function draftChangedDuringFlight(panel, sentRecipeSnapshot, sentReferencesSnapshot) {
+  try {
+    if (sentRecipeSnapshot !== null) {
+      const changeSummary = panel.querySelector("[data-recipe-change]")?.value.trim() || "";
+      if (JSON.stringify([readRecipeDraft(panel), changeSummary]) !== sentRecipeSnapshot) return true;
+    }
+    if (sentReferencesSnapshot !== null) {
+      const section = panel.querySelector("[data-reference-rights-section]");
+      if (!section) return false;
+      if (JSON.stringify(readReferenceRightsDraft(section, state.detailAsset)) !== sentReferencesSnapshot) return true;
+    }
+  } catch {
+    return true;
+  }
+  return false;
 }
 
 /** Keep one row's status chip in step with its own selects while editing. */

--- a/app/asset-view.mjs
+++ b/app/asset-view.mjs
@@ -42,10 +42,15 @@ export function createAssetViewer({
     if (els.assetViewScope) els.assetViewScope.textContent = currentScopeTitle();
     if (els.assetViewTitle) els.assetViewTitle.textContent = t("viewingAsset", { title });
     if (els.assetViewError) els.assetViewError.hidden = true;
-    // Phase 3B：切换素材即重置为 fit（不继承上一张的缩放位置）；同一素材的重渲染
-    // （后台刷新/语言切换）保持当前 transform 不动。
+    // Phase 3B：切换素材即重置为 fit（不继承上一张的缩放位置）；同一素材仅元数据
+    // 重渲染（收藏/语言切换）保持 transform。若同一 ID 的底层文件被替换、image_url
+    // 发生变化，则它已是新的媒体几何，必须重新加载并 fit，不能继续显示旧 src。
     if (asset.id !== assetViewStageAssetId) {
       assetViewStageAssetId = asset.id;
+      assetViewStageAssetUrl = asset.image_url;
+      resetAssetViewTransform();
+    } else if (asset.image_url !== assetViewStageAssetUrl) {
+      assetViewStageAssetUrl = asset.image_url;
       resetAssetViewTransform();
     }
     if (isVideoAsset(asset)) {
@@ -60,10 +65,11 @@ export function createAssetViewer({
     els.assetViewVideo.hidden = true;
     els.assetViewImage.hidden = false;
     els.assetViewImage.alt = title;
-    if (els.assetViewImage.dataset.assetId !== asset.id) {
+    if (els.assetViewImage.dataset.assetId !== asset.id || els.assetViewImage.dataset.assetUrl !== asset.image_url) {
       // Phase 3C 竞态防护：以素材 ID 为唯一会话键（同 URL 重复变体间导航也算切换）——
-      // src 与 ID 守卫/结算标记同步切换，晚到的旧 load/error 事件据此被识别并丢弃。
+      // src、ID 与 URL 守卫/结算标记同步切换，晚到的旧 load/error 事件据此被识别并丢弃。
       els.assetViewImage.dataset.assetId = asset.id;
+      els.assetViewImage.dataset.assetUrl = asset.image_url;
       els.assetViewImage.dataset.loadSettled = "";
       if (els.assetViewImage.getAttribute("src") !== asset.image_url) els.assetViewImage.src = asset.image_url;
       // 缓存命中时 load 事件可能不再派发，同步完成初始 fit（handleAssetViewImageLoad 幂等）；
@@ -86,7 +92,7 @@ export function createAssetViewer({
   }
 
   async function openAssetView(id, trigger) {
-    if (!id || state.batchMode || state.viewMode === "asset") return;
+    if (!id || state.viewMode === "asset") return;
     const originProjectId = state.project;
     const originAssetId = state.selectedId;
     if (!await confirmDetailNavigation(id)) return;
@@ -131,6 +137,7 @@ export function createAssetViewer({
     // Phase 3B：先清理舞台交互（wheel/pointer 监听、拖拽会话、ResizeObserver），再切回 Library。
     teardownAssetViewInteraction();
     assetViewStageAssetId = null;
+    assetViewStageAssetUrl = null;
     // Phase 3C：Viewer session 结束，清理导航序列（不落盘、不带回 Library）。
     // BUG-10：连同总数/游标/查询快照一并清空并推进 generation，晚到的分页响应据此丢弃。
     assetViewSequence.ids = [];
@@ -189,21 +196,44 @@ export function createAssetViewer({
   const ASSET_VIEW_SCALE_EPSILON = 1e-6;
   const assetViewTransform = { mode: "fit", scale: 1, offsetX: 0, offsetY: 0, isPanning: false };
   let assetViewStageAssetId = null;
+  let assetViewStageAssetUrl = null;
   let assetViewInteractionActive = false;
   let assetViewStageObserver = null;
+  let assetViewStageGeometry = null;
   let assetViewPanSession = null;
   const assetViewActivePointers = new Map();
   let assetViewPinchSession = null;
 
   // ----- 集中式纯几何 helper：事件处理器只组装输入，不复制公式 -----
   // 舞台可用几何 = content box（clientWidth/Height 去掉 padding），与 contain 语义一致。
-  function assetViewStageSize() {
+  function refreshAssetViewStageGeometry() {
     const stage = els.assetViewStage;
-    if (!stage) return { width: 0, height: 0 };
+    if (!stage) {
+      assetViewStageGeometry = { left: 0, top: 0, width: 0, height: 0 };
+      return assetViewStageGeometry;
+    }
+    const rect = stage.getBoundingClientRect();
     const styles = getComputedStyle(stage);
-    const width = stage.clientWidth - parseFloat(styles.paddingLeft) - parseFloat(styles.paddingRight);
-    const height = stage.clientHeight - parseFloat(styles.paddingTop) - parseFloat(styles.paddingBottom);
-    return { width: Math.max(0, width), height: Math.max(0, height) };
+    const paddingLeft = parseFloat(styles.paddingLeft) || 0;
+    const paddingRight = parseFloat(styles.paddingRight) || 0;
+    const paddingTop = parseFloat(styles.paddingTop) || 0;
+    const paddingBottom = parseFloat(styles.paddingBottom) || 0;
+    assetViewStageGeometry = {
+      left: rect.left + paddingLeft,
+      top: rect.top + paddingTop,
+      width: Math.max(0, stage.clientWidth - paddingLeft - paddingRight),
+      height: Math.max(0, stage.clientHeight - paddingTop - paddingBottom),
+    };
+    return assetViewStageGeometry;
+  }
+
+  function currentAssetViewStageGeometry() {
+    return assetViewStageGeometry || refreshAssetViewStageGeometry();
+  }
+
+  function assetViewStageSize() {
+    const geometry = currentAssetViewStageGeometry();
+    return { width: geometry.width, height: geometry.height };
   }
 
   function assetViewNaturalSize() {
@@ -262,16 +292,10 @@ export function createAssetViewer({
 
   // 事件坐标 → 舞台 content box 中心坐标系（transform 锚点坐标系）。
   function assetViewStagePointer(clientX, clientY) {
-    const stage = els.assetViewStage;
-    if (!stage) return { x: 0, y: 0 };
-    const rect = stage.getBoundingClientRect();
-    const styles = getComputedStyle(stage);
-    const paddingLeft = parseFloat(styles.paddingLeft);
-    const paddingTop = parseFloat(styles.paddingTop);
-    const size = assetViewStageSize();
+    const geometry = currentAssetViewStageGeometry();
     return {
-      x: clientX - rect.left - paddingLeft - size.width / 2,
-      y: clientY - rect.top - paddingTop - size.height / 2,
+      x: clientX - geometry.left - geometry.width / 2,
+      y: clientY - geometry.top - geometry.height / 2,
     };
   }
 
@@ -404,6 +428,7 @@ export function createAssetViewer({
     if (image.dataset.assetId !== state.selectedId) return;
     if (image.dataset.loadSettled === "error") return;
     image.dataset.loadSettled = "load";
+    refreshAssetViewStageGeometry();
     // 元素几何=自然尺寸，transform scale 以此为唯一基准（rendered = natural × scale）。
     image.style.width = `${image.naturalWidth}px`;
     image.style.height = `${image.naturalHeight}px`;
@@ -429,6 +454,9 @@ export function createAssetViewer({
     if (event.pointerType === "mouse" && (!event.isPrimary || event.button !== 0)) return;
     if (event.target.closest(".asset-view-controls")) return;
     if (assetViewActivePointers.has(event.pointerId)) return;
+    // Cache the content-box geometry once per gesture. Pointer moves then stay
+    // on the pure-math path instead of repeatedly forcing style/layout reads.
+    refreshAssetViewStageGeometry();
     if (!assetViewActivePointers.size) cancelAssetViewPan();
     const pointer = { pointerId: event.pointerId, pointerType: event.pointerType, clientX: event.clientX, clientY: event.clientY };
     assetViewActivePointers.set(event.pointerId, pointer);
@@ -607,6 +635,7 @@ export function createAssetViewer({
   // 仅重新 clamp，不自动跳回 fit。回调只写 transform，不改变舞台尺寸，不自触发循环。
   function handleAssetViewStageResize() {
     if (state.viewMode !== "asset" || !assetViewImageReady()) return;
+    refreshAssetViewStageGeometry();
     if (assetViewTransform.mode === "fit") {
       assetViewTransform.scale = currentAssetFitScale();
       assetViewTransform.offsetX = 0;
@@ -625,6 +654,7 @@ export function createAssetViewer({
     const stage = els.assetViewStage;
     if (assetViewInteractionActive || !stage) return;
     assetViewInteractionActive = true;
+    refreshAssetViewStageGeometry();
     stage.addEventListener("wheel", handleAssetViewWheel, { passive: false });
     stage.addEventListener("pointerdown", handleAssetViewPointerDown);
     stage.addEventListener("pointermove", handleAssetViewPointerMove);
@@ -646,6 +676,7 @@ export function createAssetViewer({
     stage.removeEventListener("pointercancel", handleAssetViewPointerEnd);
     assetViewStageObserver?.disconnect();
     assetViewStageObserver = null;
+    assetViewStageGeometry = null;
   }
 
   // ===== 专用大图素材导航（Phase 3C / F-04） =====

--- a/app/bridge-status-poller.mjs
+++ b/app/bridge-status-poller.mjs
@@ -74,5 +74,19 @@ export function createBridgeStatusPoller(options = {}) {
     }
   }
 
-  return { refresh, start, stop };
+  // M6：隐藏标签页暂停定时触发（在途请求照常完成并提交，commit 的代际守卫不变）。
+  // stop 的 teardown 语义保持不可逆——resume 不复活已 stop 的实例；bfcache 恢复
+  // 由 app.mjs 重建新实例。
+  function pause() {
+    if (stopped || timer === null) return;
+    clearTimer(timer);
+    timer = null;
+  }
+
+  function resume() {
+    if (stopped) return;
+    start();
+  }
+
+  return { refresh, start, stop, pause, resume };
 }

--- a/app/context-menu-actions.mjs
+++ b/app/context-menu-actions.mjs
@@ -3,7 +3,7 @@
  * Defines all context menu items and their actions
  */
 
-export function createContextMenuActions({ state, els, t, apiClient, showToast, runAction, requestConfirmation, confirmDetailNavigation, discardDetailDraft, getGroupColor, saveGroupColor }) {
+export function createContextMenuActions({ state, els, t, apiClient, showToast, runAction, requestConfirmation, confirmDetailNavigation, discardDetailDraft, openGroupModal, getGroupColor, saveGroupColor }) {
   const { apiFetch } = apiClient;
   // getGroupColor falls back to the deterministic palette so call sites can rely
   // on a single source of truth for group colors (mirrors app.mjs colorForGroup).
@@ -226,10 +226,19 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
       action: async () => {
         const assets = isMultiple ? selectedAssets : [asset];
         await runAction(async () => {
-          for (const a of assets) {
-            await apiFetch(`/api/assets/${encodeURIComponent(a.project_id)}/${encodeURIComponent(a.id)}`, {
-              method: "PATCH",
-              body: { favorite: !a.favorite },
+          if (isMultiple) {
+            await apiFetch("/api/assets/batch", {
+              method: "POST",
+              body: {
+                action: "favorite",
+                projectId: state.project,
+                assetIds: assets.map((entry) => entry.id),
+                favorite: !asset.favorite,
+              },
+            });
+          } else {
+            await apiFetch(`/api/assets/${encodeURIComponent(asset.project_id)}/${encodeURIComponent(asset.id)}/favorite`, {
+              method: "POST",
             });
           }
           showToast(
@@ -246,6 +255,13 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
       label: t("moveToGroup"),
       icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></svg>',
       submenu: [
+        {
+          label: t("createGroup"),
+          action: async () => {
+            openGroupModal?.();
+          },
+        },
+        { separator: true },
         {
           label: t("noGroup"),
           action: async () => {
@@ -357,8 +373,13 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
           if (!await confirmSelectedAssetMutation(assets)) return;
 
           await runAction(async () => {
-            for (const a of assets) {
-              await apiFetch(`/api/assets/${encodeURIComponent(a.project_id)}/${encodeURIComponent(a.id)}/archive`, {
+            if (isMultiple) {
+              await apiFetch("/api/assets/batch", {
+                method: "POST",
+                body: { action: "archive", projectId: state.project, assetIds: assets.map((entry) => entry.id) },
+              });
+            } else {
+              await apiFetch(`/api/assets/${encodeURIComponent(asset.project_id)}/${encodeURIComponent(asset.id)}/archive`, {
                 method: "POST",
               });
             }
@@ -410,6 +431,13 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
         icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M12 5v14M5 12h14"/></svg>',
         action: async () => {
           els.newAssetTopBtn?.click();
+        },
+      },
+      {
+        label: t("createGroup"),
+        icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 6h6l2 2h10v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z"/><path d="M12 11v6M9 14h6"/></svg>',
+        action: async () => {
+          openGroupModal?.();
         },
       },
       {

--- a/app/context-menu.mjs
+++ b/app/context-menu.mjs
@@ -111,7 +111,7 @@ export function createContextMenu() {
     // Focus the first enabled item
     requestAnimationFrame(() => {
       const firstItem = menu.querySelector(".context-menu-item:not(.disabled)");
-      firstItem?.focus();
+      firstItem?.focus({ preventScroll: true });
     });
 
     // Setup event listeners
@@ -122,20 +122,32 @@ export function createContextMenu() {
     };
 
     const keyHandler = (e) => {
+      // M1：菜单打开期间键盘语义归菜单独占。捕获阶段先于应用级路由（冒泡）执行，
+      // stopPropagation 阻断后者——一次 Escape 只关菜单（不再连带关 Inspector），
+      // 方向键只移动菜单焦点（不再同时切换画廊选中素材）。
+      e.stopPropagation();
       const activeMenu = document.activeElement?.closest?.(".context-menu") || menu;
       handleKeyDown(e, activeMenu);
     };
 
+    // M4：菜单为 fixed 定位，锚点滚动/视口缩放后位置与所指目标脱节，直接关闭。
+    // scroll 事件不冒泡，window 捕获阶段监听才能覆盖画廊内部滚动容器。
+    const dismissOnAnchorShift = () => hide();
+
     setTimeout(() => {
       document.addEventListener("click", closeHandler);
       document.addEventListener("contextmenu", closeHandler);
-      document.addEventListener("keydown", keyHandler);
+      document.addEventListener("keydown", keyHandler, { capture: true });
+      window.addEventListener("scroll", dismissOnAnchorShift, { capture: true });
+      window.addEventListener("resize", dismissOnAnchorShift);
     }, 0);
 
     menu._cleanup = () => {
       document.removeEventListener("click", closeHandler);
       document.removeEventListener("contextmenu", closeHandler);
-      document.removeEventListener("keydown", keyHandler);
+      document.removeEventListener("keydown", keyHandler, { capture: true });
+      window.removeEventListener("scroll", dismissOnAnchorShift, { capture: true });
+      window.removeEventListener("resize", dismissOnAnchorShift);
       if (onClose) onClose();
     };
   }
@@ -291,6 +303,11 @@ export function createContextMenu() {
     if (restoreFocus) focusContextTarget(returnTarget);
   }
 
+  // M1：菜单是否打开。应用级键盘路由以此让位（见 app.mjs setupKeyboardShortcuts）。
+  function isOpen() {
+    return currentMenu !== null && currentMenu.isConnected;
+  }
+
   function focusContextTarget(target) {
     if (!(target instanceof HTMLElement) || !target.isConnected) return false;
     const focusTarget = target.matches("button, input, select, textarea, [tabindex]")
@@ -301,5 +318,5 @@ export function createContextMenu() {
     return true;
   }
 
-  return { show, hide };
+  return { show, hide, isOpen };
 }

--- a/app/image-preview.mjs
+++ b/app/image-preview.mjs
@@ -14,23 +14,44 @@ export function createImagePreviewViewer({ els, state, t, announceGalleryStatus 
   let imagePreviewPanSession = null;
   let imagePreviewPinchSession = null;
   let imagePreviewSuppressStageClick = false;
+  let imagePreviewStageGeometry = null;
+
+  function refreshImagePreviewStageGeometry() {
+    const stage = els.imagePreviewStage;
+    if (!stage) {
+      imagePreviewStageGeometry = { left: 0, top: 0, width: 0, height: 0 };
+      return imagePreviewStageGeometry;
+    }
+    const rect = stage.getBoundingClientRect();
+    const styles = getComputedStyle(stage);
+    const paddingLeft = parseFloat(styles.paddingLeft) || 0;
+    const paddingRight = parseFloat(styles.paddingRight) || 0;
+    const paddingTop = parseFloat(styles.paddingTop) || 0;
+    const paddingBottom = parseFloat(styles.paddingBottom) || 0;
+    imagePreviewStageGeometry = {
+      left: rect.left + paddingLeft,
+      top: rect.top + paddingTop,
+      width: Math.max(0, stage.clientWidth - paddingLeft - paddingRight),
+      height: Math.max(0, stage.clientHeight - paddingTop - paddingBottom),
+    };
+    return imagePreviewStageGeometry;
+  }
+
+  function currentImagePreviewStageGeometry() {
+    return imagePreviewStageGeometry || refreshImagePreviewStageGeometry();
+  }
 
   function imagePreviewStageSize() {
-    const stage = els.imagePreviewStage;
-    if (!stage) return { width: 0, height: 0 };
-    const styles = getComputedStyle(stage);
-    return {
-      width: Math.max(0, stage.clientWidth - parseFloat(styles.paddingLeft) - parseFloat(styles.paddingRight)),
-      height: Math.max(0, stage.clientHeight - parseFloat(styles.paddingTop) - parseFloat(styles.paddingBottom)),
-    };
+    const geometry = currentImagePreviewStageGeometry();
+    return { width: geometry.width, height: geometry.height };
   }
 
   function imagePreviewBaseSize() {
     const image = els.imagePreviewImage;
     if (!image) return { width: 0, height: 0 };
     return {
-      width: image.offsetWidth || Number.parseFloat(image.style.width) || 0,
-      height: image.offsetHeight || Number.parseFloat(image.style.height) || 0,
+      width: Number.parseFloat(image.style.width) || image.offsetWidth || 0,
+      height: Number.parseFloat(image.style.height) || image.offsetHeight || 0,
     };
   }
 
@@ -84,6 +105,7 @@ export function createImagePreviewViewer({ els, state, t, announceGalleryStatus 
   }
 
   function reconcileImagePreviewTransform() {
+    refreshImagePreviewStageGeometry();
     const offsets = clampImagePreviewOffsets(state.imageZoom, state.imagePanX, state.imagePanY);
     state.imagePanX = offsets.offsetX;
     state.imagePanY = offsets.offsetY;
@@ -133,16 +155,10 @@ export function createImagePreviewViewer({ els, state, t, announceGalleryStatus 
   }
 
   function imagePreviewStagePointer(clientX, clientY) {
-    const stage = els.imagePreviewStage;
-    if (!stage) return { x: 0, y: 0 };
-    const rect = stage.getBoundingClientRect();
-    const styles = getComputedStyle(stage);
-    const paddingLeft = parseFloat(styles.paddingLeft) || 0;
-    const paddingTop = parseFloat(styles.paddingTop) || 0;
-    const size = imagePreviewStageSize();
+    const geometry = currentImagePreviewStageGeometry();
     return {
-      x: clientX - rect.left - paddingLeft - size.width / 2,
-      y: clientY - rect.top - paddingTop - size.height / 2,
+      x: clientX - geometry.left - geometry.width / 2,
+      y: clientY - geometry.top - geometry.height / 2,
     };
   }
 
@@ -281,6 +297,7 @@ export function createImagePreviewViewer({ els, state, t, announceGalleryStatus 
     if (event.pointerType === "mouse" && (!event.isPrimary || event.button !== 0)) return;
     if (event.target.closest?.("video")) return;
     if (imagePreviewActivePointers.has(event.pointerId)) return;
+    refreshImagePreviewStageGeometry();
     const pointer = {
       pointerId: event.pointerId,
       pointerType: event.pointerType,
@@ -354,6 +371,7 @@ export function createImagePreviewViewer({ els, state, t, announceGalleryStatus 
 
   function setupImageZoomPan() {
     const stage = els.imagePreviewStage; if (!stage) return;
+    refreshImagePreviewStageGeometry();
     stage.addEventListener("wheel", (e) => { if (state.imagePreviewId) { e.preventDefault(); zoomImage(e.deltaY < 0 ? IMAGE_PREVIEW_ZOOM_STEP : -IMAGE_PREVIEW_ZOOM_STEP, { announce: false }); } }, { passive: false });
     stage.addEventListener("pointerdown", handleImagePreviewPointerDown);
     stage.addEventListener("pointermove", handleImagePreviewPointerMove);

--- a/app/styles.css
+++ b/app/styles.css
@@ -1611,13 +1611,17 @@ html.electron-shell body.mosa-v2 .brand-info h1 { margin-left: 76px; }
   z-index: 10000;
   min-width: 220px;
   max-width: 320px;
+  /* M4：超高菜单（如几十个分组的“移动到分组”子菜单）在视口内自行滚动，
+     底部项不再溢出不可达；positionMenu 的钳位将其钉在距顶 8px 处。 */
+  max-height: calc(100vh - 16px);
   padding: 6px;
   background: var(--app-menu);
   border: 1px solid var(--border-menu);
   border-radius: 12px;
   box-shadow: var(--shadow-popover);
   outline: none;
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .context-menu-item {

--- a/app/toast-manager.mjs
+++ b/app/toast-manager.mjs
@@ -218,14 +218,13 @@ export function createToastManager(deps) {
       clearTimeout(entry.leaveTimer);
       entry.timer = null;
       entry.leaveTimer = null;
-      // Drop any pending transitionend listener so a CSS glitch doesn't fire
-      // finalize() against an entry that the manager no longer tracks.
-      if (entry.element) {
-        entry.element.replaceWith(entry.element.cloneNode(true));
-      }
       entry.state = "removed";
       entry.dismissedReason = entry.dismissedReason || reason;
+      // Removing the live node is sufficient: its transition listener lives on
+      // that node and becomes collectible with it. Replacing it with a clone and
+      // then removing the detached original leaves the clone behind as a zombie.
       entry.element?.remove();
+      entry.element = null;
     }
     entries.clear();
     for (const laneName of Object.keys(lanes)) { lanes[laneName].visible = []; lanes[laneName].pending = []; }

--- a/lib/api/asset-routes.mjs
+++ b/lib/api/asset-routes.mjs
@@ -162,12 +162,17 @@ export async function handleAssetRoute({ req, res, url, context }) {
   const uniqueAssetIds = [...new Set(assetIds)];
   // Resolve every asset before mutating one, so a malformed selection cannot
   // report a complete-looking batch after only its first few rows changed.
-  await Promise.all(uniqueAssetIds.map((assetId) => store.getAsset(projectId, assetId)));
+  const currentAssets = await Promise.all(uniqueAssetIds.map((assetId) => store.getAsset(projectId, assetId)));
+  const favoriteValue = action === "favorite" && typeof body.favorite === "boolean" ? body.favorite : true;
   const results = [];
-  for (const assetId of uniqueAssetIds) {
+  for (let index = 0; index < uniqueAssetIds.length; index += 1) {
+    const assetId = uniqueAssetIds[index];
     if (action === "favorite") {
-      const updated = await store.updateMetadata(projectId, assetId, { favorite: true });
-      results.push({ id: assetId, favorite: updated.favorite });
+      const current = currentAssets[index];
+      const updated = Boolean(current.favorite) === favoriteValue
+        ? current
+        : await store.toggleFavorite(projectId, assetId);
+      results.push({ id: assetId, favorite: Boolean(updated.favorite) });
     } else {
       await store.archiveAsset(projectId, assetId);
       results.push({ id: assetId, archived: true });

--- a/test/frontend-interaction-regressions.test.mjs
+++ b/test/frontend-interaction-regressions.test.mjs
@@ -32,7 +32,7 @@ test("recipe save merges prompt tags with the latest asset tags, not the render-
 
 test("tag editor participates in dirty-state protection until its save commits", async () => {
   const app = await readApp();
-  const editorActive = sliceBetween(app, "function isDetailEditorActive()", "const bridgeStatusPoller");
+  const editorActive = sliceBetween(app, "function isDetailEditorActive()", "function latestAssetSnapshot");
   const tagEditor = sliceBetween(app, "function openTagEditor(panel, asset, renderId)", "function refreshDetailTagsSection");
 
   assert.match(editorActive, /\[data-tag-editor\]/);

--- a/test/import-flow.test.mjs
+++ b/test/import-flow.test.mjs
@@ -131,6 +131,9 @@ test("import rejections reach the client as 400 with a code, and the format list
   const favoriteAgain = await batch({ action: "favorite", projectId: "default", assetIds: [asset.id] });
   assert.equal(favoriteAgain.status, 200);
   assert.deepEqual((await favoriteAgain.json()).results, [{ id: asset.id, favorite: true }]);
+  const unfavorite = await batch({ action: "favorite", favorite: false, projectId: "default", assetIds: [asset.id] });
+  assert.equal(unfavorite.status, 200);
+  assert.deepEqual((await unfavorite.json()).results, [{ id: asset.id, favorite: false }]);
 
   const invalidBatch = await batch({ action: "delete", projectId: "default", assetIds: [asset.id] });
   assert.equal(invalidBatch.status, 400);


### PR DESCRIPTION
## Summary
- keep context-menu and viewer keyboard/focus interactions isolated
- preserve in-flight Inspector edits and surface autosave failures
- stabilize preview geometry, bridge polling, image-load errors, and bulk asset mutations

## Verification
- npm test (801 passed, 2 skipped)
- npm run lint (0 errors; 3 existing coverage warnings)
- npm run check
- npm run test:performance (50k SQLite performance)
- git diff --check