### PR TITLE
chore: block Chrome Web Store build artifacts from source repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,11 @@ npm-debug.log*
 
 # Electron build output.
 /desktop/out/
+
+# Chrome Web Store extension packages are build artifacts, never source.
+# Listed explicitly so a typo in the /out/ rule cannot leak them upstream.
+/out/store/
+*.Chrome-Web-Store.zip
 /out/
 
 # Test coverage reports.

--- a/scripts/hooks/README.md
+++ b/scripts/hooks/README.md
@@ -1,0 +1,24 @@
+# MOSA Git Hooks
+
+Version-controlled git hooks. Hooks in this directory are tracked so they survive
+clones and can be reviewed, unlike `.git/hooks/` which is local-only.
+
+## Install
+
+```sh
+git config core.hooksPath scripts/hooks
+chmod +x scripts/hooks/pre-push
+```
+
+Or symlink a single hook:
+
+```sh
+ln -sf ../../scripts/hooks/pre-push .git/hooks/pre-push
+```
+
+## pre-push
+
+Blocks pushes that contain Chrome Web Store extension packages
+(`out/store/*`, `*.Chrome-Web-Store.zip`). These are build artifacts produced by
+`npm run pack:web-capture-store` and must never enter the source repository,
+even if `.gitignore` is bypassed with `git add -f`.

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,21 @@
+#!/bin/sh
+# MOSA pre-push hook: block Chrome Web Store build artifacts from the source repo.
+# Install with: git config core.hooksPath scripts/hooks && chmod +x scripts/hooks/pre-push
+# Or link manually: ln -sf ../../scripts/hooks/pre-push .git/hooks/pre-push
+set -eu
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+    range="$local_sha"
+  else
+    range="${remote_sha}..${local_sha}"
+  fi
+  offenders=$(git diff --name-only --diff-filter=ACM "$range" -- 'out/store/*' '*.Chrome-Web-Store.zip' 2>/dev/null || true)
+  if [ -n "$offenders" ]; then
+    echo "pre-push: refusing to push Chrome Web Store build artifacts:" >&2
+    echo "$offenders" | sed 's/^/  /' >&2
+    echo "These are build outputs and are gitignored. Remove them with:" >&2
+    echo "  git rm --cached <path>" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
## What

Confirm and harden that Chrome Web Store extension packages never enter the source repository.

## Findings on current state

- The store ZIPs in `out/store/MOSA-Web-Capture-0.14.x-Chrome-Web-Store.zip` were **never tracked** — `git ls-files out/` returns empty and `/out/` already ignores them.
- Source for the extension lives in `extensions/chatgpt-web-capture/` (with `key` for local dev); store packages are stripped of `key` by `scripts/pack-web-capture-store.mjs` into `out/store/` (gitignored build output).

## Changes

**Layer 1 — explicit .gitignore rules** (beyond the existing `/out/`):
- `/out/store/` — the store package directory itself
- `*.Chrome-Web-Store.zip` — the naming pattern anywhere in the tree

These catch a leak even if the `/out/` rule is later removed or mistyped.

**Layer 2 — version-controlled pre-push hook** at `scripts/hooks/pre-push`:
- Refuses pushes whose commits add/modify `out/store/*` or `*.Chrome-Web-Store.zip`
- Fires even when someone bypasses .gitignore with `git add -f`
- Tracked in the repo so it survives clones and can be reviewed (unlike `.git/hooks/`)

## Install the hook locally

```sh
git config core.hooksPath scripts/hooks
chmod +x scripts/hooks/pre-push
```

Or symlink only the pre-push hook:

```sh
ln -sf ../../scripts/hooks/pre-push .git/hooks/pre-push
```

## Notes

- No store ZIPs were removed (none were ever tracked).
- Root `build-identity.json` remains untracked (regenerated build artifact).