### PR TITLE
Fix collapsed Stack single-click behavior

### DIFF
--- a/app/app.mjs
+++ b/app/app.mjs
@@ -643,15 +643,18 @@ function setupKeyboardShortcuts() {
       if (event.key === "f" || event.key === "F") { event.preventDefault(); fitAssetView(true); return; }
     }
     const galleryEnterTarget = event.target === els.assetGrid || Boolean(event.target.closest?.(".asset-card-select"));
+    const galleryEnterCardId = event.target.closest?.(".asset-card")?.dataset.id || "";
+    const galleryEnterAssetId = galleryEnterCardId || state.selectedId || "";
     if (event.key === "Enter"
       && galleryEnterTarget
       && state.viewMode === "library"
-      && state.selectedId
+      && galleryEnterAssetId
       && !state.selectedIds?.size
       && els.imagePreviewModal?.hidden
       && !hasBlockingOverlay()
       && els.settingsMenu?.hidden) {
-      const asset = selectedAsset();
+      const asset = state.assets.find((item) => item.id === galleryEnterAssetId)
+        || (galleryEnterAssetId === state.selectedId ? selectedAsset() : null);
       if (asset) {
         event.preventDefault();
         if (!state.activeStackId && asset.stack?.id) void assetStacks.enterStack(asset.stack.id, asset.stack);
@@ -1466,7 +1469,14 @@ function bindEvents() {
         gallerySelection.clear();
         const asset = state.assets.find((item) => item.id === id);
         if (!state.activeStackId && asset?.stack?.id) {
-          void assetStacks.enterStack(asset.stack.id, asset.stack);
+          // A collapsed Stack is a logical gallery node. Single-click only
+          // selects it; navigation is reserved for double-click (or Enter),
+          // which prevents accidental entry while browsing or marqueeing.
+          if (!state.detailOpen && state.viewMode === "library") {
+            clearDetailSelection();
+            state.selectedId = id;
+            updateSelectedCard();
+          }
           return;
         }
         void selectAsset(id);

--- a/scripts/e2e-ui-flow.mjs
+++ b/scripts/e2e-ui-flow.mjs
@@ -167,6 +167,9 @@ export function createStackUiFlowSource() {
   function ctrlClick(element) {
     element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, ctrlKey: true }));
   }
+  function doubleClick(element) {
+    element.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, cancelable: true, detail: 2 }));
+  }
   function pointer(target, type, x, y, pointerId = 91) {
     target.dispatchEvent(new PointerEvent(type, {
       bubbles: true,
@@ -214,7 +217,7 @@ export function createStackUiFlowSource() {
   );
   const stackId = stackCard.dataset.stackId;
   const rootCountAfterStack = document.querySelectorAll('#assetGrid > .asset-card').length;
-  stackCard.querySelector('.asset-card-select').click();
+  doubleClick(stackCard.querySelector('.asset-card-select'));
   await waitFor(
     () => !document.querySelector('#stackBack')?.hidden
       && document.querySelector('#assetGrid')?.getAttribute('aria-busy') === 'false'

--- a/test/asset-stack-ui.test.mjs
+++ b/test/asset-stack-ui.test.mjs
@@ -30,6 +30,20 @@ test("visual stack behavior is wired into the shared web and desktop renderer", 
   assert.match(app, /assetStacks\.bind\(\)/);
   assert.match(app, /asset\?\.stack\?\.id/);
   assert.match(app, /assetStacks\.enterStack\(asset\.stack\.id, asset\.stack\)/);
+  const singleClick = app.slice(
+    app.indexOf('els.assetGrid?.addEventListener("click"'),
+    app.indexOf('els.assetGrid?.addEventListener("dblclick"'),
+  );
+  const doubleClick = app.slice(
+    app.indexOf('els.assetGrid?.addEventListener("dblclick"'),
+    app.indexOf('els.newAssetTopBtn?.addEventListener'),
+  );
+  assert.doesNotMatch(singleClick, /assetStacks\.enterStack/,
+    "collapsed Stack single-click must not navigate");
+  assert.match(singleClick, /state\.selectedId = id;[\s\S]*?updateSelectedCard\(\)/,
+    "collapsed Stack single-click keeps a lightweight logical selection");
+  assert.match(doubleClick, /assetStacks\.enterStack\(asset\.stack\.id, asset\.stack\)/,
+    "collapsed Stack double-click opens the Stack");
   assert.match(app, /asset-stack-count/);
   assert.match(app, /galleryEntryAssetCount/);
   assert.match(app, /stackMatchAccessibleName/);

--- a/test/large-view-mode-contract.test.mjs
+++ b/test/large-view-mode-contract.test.mjs
@@ -141,19 +141,26 @@ test("9. compact 960–1120 keeps three columns (no detail drop)", async () => {
   assert.doesNotMatch(rail, /\.detail \{[^}]*position: static/, "detail must not re-enter the document flow in the rail band");
 });
 
-// 10. Ordinary assets keep the V2 inspector as their single-click destination,
-// while a collapsed Stack is a logical node and opens its member view instead
-// of leaking the cover asset into the Inspector.
-test("10. single click opens an asset inspector or enters a logical Stack", async () => {
+// 10. Ordinary assets keep the V2 inspector as their single-click destination.
+// A collapsed Stack is a logical node: single-click selects it without
+// navigating or leaking its cover into the Inspector, while double-click opens
+// the Stack member view.
+test("10. single click selects a logical Stack and double click enters it", async () => {
   const app = await readApp();
   const cards = sliceBetween(app, 'const selectButton = event.target.closest(".asset-card-select")', 'const loadMoreButton = event.target.closest');
   assert.match(cards, /const id = selectButton\.closest\("\.asset-card"\)\?\.dataset\.id;/,
     "card click resolves the asset id");
   assert.match(cards, /if \(id\) \{\s+gallerySelection\.clear\(\);[\s\S]*?void selectAsset\(id\);\s+\}/,
     "ordinary asset click clears batch selection before opening the V2 detail inspector");
-  assert.match(cards, /if \(!state\.activeStackId && asset\?\.stack\?\.id\) \{\s+void assetStacks\.enterStack\(asset\.stack\.id, asset\.stack\);\s+return;\s+\}/,
-    "collapsed Stack click enters the Stack rather than opening its cover asset");
+  assert.match(cards, /if \(!state\.activeStackId && asset\?\.stack\?\.id\) \{[\s\S]*?state\.selectedId = id;[\s\S]*?updateSelectedCard\(\);[\s\S]*?return;/,
+    "collapsed Stack click only selects the logical Stack card");
+  assert.doesNotMatch(cards, /assetStacks\.enterStack/,
+    "single-click must not enter a collapsed Stack");
   assert.doesNotMatch(cards, /openAssetView/, "card click does not enter the retired canvas viewer");
+
+  const doubleClick = sliceBetween(app, 'els.assetGrid?.addEventListener("dblclick"', 'els.newAssetTopBtn?.addEventListener');
+  assert.match(doubleClick, /assetStacks\.enterStack\(asset\.stack\.id, asset\.stack\)/,
+    "double-click enters a collapsed Stack");
 });
 
 // 11. The card favourite quick action does not bubble.


### PR DESCRIPTION
## Summary
- keep collapsed Stack single-click as a lightweight logical selection
- open the Stack on double-click or Enter
- add contract coverage for the interaction boundary

## Verification
- npm test: 954 passed, 2 skipped
- npm run lint
- npm run check
- npm run check:web-capture-store
- git diff --check