### PR TITLE
release: publish MOSA 0.2.1

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # MOSA 系统架构
 
 本文档描述仓库当前实现，而不是未来重构方案。产品版本以根目录
-`package.json` 的 `version` 字段为准（当前为 `0.2.0`）。运行时要求 Node.js
+`package.json` 的 `version` 字段为准（当前为 `0.2.1`）。运行时要求 Node.js
 22 或更高版本；桌面层共享同一套 Electron/Renderer/Runtime 代码，目前明确支持
 `darwin-arm64` 与 `win32-x64` 两个打包目标，其中 Windows 10/11 x64 处于 Preview/Testing 阶段。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 This file records user-visible changes. Internal deployment notes, local paths, and development handoffs are intentionally not tracked in the public repository.
 
-## 0.2.0 — Unreleased / 待发布
+## 0.2.1 — 2026-09-02
+
+### Reliability and privacy / 可靠性与隐私
+
+- Packaged desktop builds now report the same minimal anonymous install/activity UUID regardless of whether the app package came from the MOSA website, GitHub, or a directly shared copy.
+- Anonymous usage reporting is independent from update-manifest parsing, retries with the same installation UUID after transient failures, and persists the local UUID/profile atomically.
+- Development and QA launches remain excluded from production usage metrics.
+
+## 0.2.0 — 2026-08-28
 
 > **Local visual memory for AI creation.**
 > 把 Codex、ChatGPT、Grok 与 Cowart 中的创作结果，连同可用的 Prompt、来源和版本，留在自己的电脑上。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mosa",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mosa",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "better-sqlite3": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mosa",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",
   "type": "module",

--- a/test/card-action-contract.test.mjs
+++ b/test/card-action-contract.test.mjs
@@ -220,7 +220,7 @@ test("17. no API, data-structure or persistence changes", async () => {
   // leave the hash table; their security-relevant behaviour is asserted
   // structurally below. The lockfile stays hash-pinned.
   const expected = {
-    "package-lock.json": "ecf0fdc199de87ccd30ffe6a7da4624c2f632700cd8348194a30b79dd2e2a69f",
+    "package-lock.json": "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec",
   };
   for (const [file, hash] of Object.entries(expected)) {
     const text = await readFile(resolve(root, file), "utf8");

--- a/test/confirm-dialog-contract.test.mjs
+++ b/test/confirm-dialog-contract.test.mjs
@@ -319,7 +319,7 @@ test("56-57. package manifest and lockfile unchanged", async () => {
   const manifest = JSON.parse(pkg);
   assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies frozen");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies frozen");
-  assert.equal(sha256(lock), "ecf0fdc199de87ccd30ffe6a7da4624c2f632700cd8348194a30b79dd2e2a69f", "package-lock.json frozen");
+  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json frozen");
 });
 
 // 58. The stylesheet stays free of !important while hosting the dialog styles.

--- a/test/desktop-i18n-contract.test.mjs
+++ b/test/desktop-i18n-contract.test.mjs
@@ -25,7 +25,7 @@ const DESKTOP_TEXT = {
   // approved scope) added qa:web/qa:electron/qa:packaged launcher scripts.
   // Its dependency sections are still frozen via the structural assertions in
   // the package metadata test below.
-  "package-lock.json": "ecf0fdc199de87ccd30ffe6a7da4624c2f632700cd8348194a30b79dd2e2a69f",
+  "package-lock.json": "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec",
 };
 
 function sliceBetween(source, startMarker, endMarker) {

--- a/test/electron-preload-runtime-contract.test.mjs
+++ b/test/electron-preload-runtime-contract.test.mjs
@@ -32,7 +32,7 @@ const EXPECTED_API_KEYS = [
 // R1 isolation fix (2026-08-09, approved scope) added qa:web/qa:electron/
 // qa:packaged launcher scripts to package.json, so only its dependency
 // sections stay hash-pinned (see the dependency assertions below).
-const LOCKFILE_SHA256 = "ecf0fdc199de87ccd30ffe6a7da4624c2f632700cd8348194a30b79dd2e2a69f";
+const LOCKFILE_SHA256 = "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec";
 
 const read = (relativePath) => readFile(resolve(root, relativePath), "utf8");
 const sha256 = (value) => createHash("sha256").update(value).digest("hex");

--- a/test/gallery-empty-state-contract.test.mjs
+++ b/test/gallery-empty-state-contract.test.mjs
@@ -243,7 +243,7 @@ test("41-43. styles stay inside the token boundary; dependencies stay frozen", a
   const manifest = JSON.parse(pkg);
   assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies must stay untouched");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies must stay untouched");
-  assert.equal(sha256(lock), "ecf0fdc199de87ccd30ffe6a7da4624c2f632700cd8348194a30b79dd2e2a69f", "package-lock.json must stay untouched");
+  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json must stay untouched");
 });
 
 test("44. Phase 1–4C neighbouring contracts and anchors stay intact", async () => {

--- a/test/inspector-cowart-original-actions-contract.test.mjs
+++ b/test/inspector-cowart-original-actions-contract.test.mjs
@@ -160,7 +160,7 @@ test("59-60. dependency freeze: manifest, lockfile, and app.js imports unchanged
   const manifest = JSON.parse(pkg);
   assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies must stay untouched");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies must stay untouched");
-  assert.equal(sha256(lock), "ecf0fdc199de87ccd30ffe6a7da4624c2f632700cd8348194a30b79dd2e2a69f", "package-lock.json must stay untouched");
+  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json must stay untouched");
   assert.deepEqual([...app.matchAll(/^import .* from "(.*)";$/gm)].map((match) => match[1]).sort(),
     ["./api-client.mjs", "./asset-stacks.mjs", "./asset-view.mjs", "./bridge-status-poller.mjs", "./confirm-dialog.mjs", "./context-menu-actions.mjs", "./context-menu-bindings.mjs", "./context-menu.mjs", "./gallery-selection.mjs", "./i18n-runtime.mjs", "./image-preview.mjs", "./inspector-markup.mjs", "./tag-utils.mjs", "./toast-manager.mjs"], "app.js imports only approved local helpers");
 });

--- a/test/inspector-information-architecture-contract.test.mjs
+++ b/test/inspector-information-architecture-contract.test.mjs
@@ -494,7 +494,7 @@ test("48-51. hygiene: no !important, no undefined tokens, manifest and dependenc
   const manifest = JSON.parse(pkg);
   assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies must stay untouched");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies must stay untouched");
-  assert.equal(sha256(lock), "ecf0fdc199de87ccd30ffe6a7da4624c2f632700cd8348194a30b79dd2e2a69f", "package-lock.json must stay untouched");
+  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json must stay untouched");
 
   // 51. app.js gains no new imports (no new runtime dependencies).
   assert.deepEqual([...app.matchAll(/^import .* from "(.*)";$/gm)].map((match) => match[1]).sort(),

--- a/test/inspector-version-workflow-contract.test.mjs
+++ b/test/inspector-version-workflow-contract.test.mjs
@@ -321,7 +321,7 @@ test("39-48. layout order, neighbouring contracts, and dependency freeze", async
   const manifest = JSON.parse(pkg);
   assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies must stay untouched");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies must stay untouched");
-  assert.equal(sha256(lock), "ecf0fdc199de87ccd30ffe6a7da4624c2f632700cd8348194a30b79dd2e2a69f", "package-lock.json must stay untouched");
+  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json must stay untouched");
 
   // 48. app.js gains no new imports (no new runtime dependencies, no
   // third-party Select component).

--- a/test/large-view-mode-contract.test.mjs
+++ b/test/large-view-mode-contract.test.mjs
@@ -405,7 +405,7 @@ test("34. package files stay untouched", async () => {
   assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies must stay untouched");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies must stay untouched");
   const lock = await readFile(resolve(root, "package-lock.json"), "utf8");
-  assert.equal(sha256(lock), "ecf0fdc199de87ccd30ffe6a7da4624c2f632700cd8348194a30b79dd2e2a69f", "package-lock.json must stay untouched");
+  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json must stay untouched");
 });
 
 // 35. Runtime-verified fix: the shortcuts Escape chain must bail when an

--- a/test/minimum-window-responsive-contract.test.mjs
+++ b/test/minimum-window-responsive-contract.test.mjs
@@ -280,7 +280,7 @@ test("40-41. package 与 lockfile 不变、无新依赖", async () => {
   const manifest = JSON.parse(pkg);
   assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac");
-  assert.equal(sha256(lock), "ecf0fdc199de87ccd30ffe6a7da4624c2f632700cd8348194a30b79dd2e2a69f");
+  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec");
 });
 
 test("42. styles.css 不使用 !important", async () => {

--- a/test/search-location-contract.test.mjs
+++ b/test/search-location-contract.test.mjs
@@ -164,7 +164,7 @@ test("12. no new dependencies", async () => {
   assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies must stay untouched");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies must stay untouched");
   const lock = await readFile(resolve(root, "package-lock.json"), "utf8");
-  assert.equal(sha256(lock), "ecf0fdc199de87ccd30ffe6a7da4624c2f632700cd8348194a30b79dd2e2a69f", "package-lock.json must stay untouched");
+  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json must stay untouched");
 });
 
 // 13. No !important anywhere in the stylesheet (comments stripped).

--- a/test/test-environment-isolation.test.mjs
+++ b/test/test-environment-isolation.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { join, resolve } from "node:path";
@@ -8,6 +8,7 @@ import test from "node:test";
 
 const root = resolve(import.meta.dirname, "..");
 const cleanEnvPath = join(root, "test", "clean-test-env.mjs");
+const initialPackageLock = readFileSync(join(root, "package-lock.json"), "utf8");
 
 const POLLUTED = {
   MOSA_LIBRARY_DIR: "/private/tmp/mosa-polluted-library",
@@ -125,9 +126,12 @@ test("no new third-party dependencies are introduced", async () => {
   }
 });
 
-test("package-lock.json is unchanged", () => {
-  const result = spawnSync("git", ["diff", "--exit-code", "--", "package-lock.json"], { cwd: root, encoding: "utf8" });
-  assert.equal(result.status, 0, `package-lock.json must stay untouched: ${result.stdout}${result.stderr}`);
+test("package-lock.json is unchanged by the test environment hook", () => {
+  assert.equal(
+    readFileSync(join(root, "package-lock.json"), "utf8"),
+    initialPackageLock,
+    "the test environment hook must not mutate package-lock.json",
+  );
 });
 
 test("polluted library path is never created by the hook itself", () => {

--- a/test/toast-manager-contract.test.mjs
+++ b/test/toast-manager-contract.test.mjs
@@ -287,7 +287,7 @@ test("57-58. package manifest and lockfile unchanged", async () => {
   const manifest = JSON.parse(pkg);
   assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies frozen");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies frozen");
-  assert.equal(sha256(lock), "ecf0fdc199de87ccd30ffe6a7da4624c2f632700cd8348194a30b79dd2e2a69f", "package-lock.json frozen");
+  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json frozen");
 });
 
 // 59. The stylesheet stays free of !important while hosting toast styles.

--- a/test/ui-component-contract.test.mjs
+++ b/test/ui-component-contract.test.mjs
@@ -299,7 +299,7 @@ test("out-of-scope files stay locked and the Phase 1C card contract is stable", 
   // leave the hash table; their security-relevant behaviour is asserted
   // structurally below. The lockfile stays hash-pinned.
   const expected = {
-    "package-lock.json": "ecf0fdc199de87ccd30ffe6a7da4624c2f632700cd8348194a30b79dd2e2a69f",
+    "package-lock.json": "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec",
   };
   for (const [file, hash] of Object.entries(expected)) {
     const text = await readFile(resolve(root, file), "utf8");

--- a/test/viewer-pagination-navigation.test.mjs
+++ b/test/viewer-pagination-navigation.test.mjs
@@ -366,5 +366,5 @@ test("26. transform resets on switch", async () => {
 // 27. The lockfile is untouched by Batch 2A.
 test("27. package-lock unchanged", async () => {
   const lock = await readLock();
-  assert.equal(sha256(lock), "ecf0fdc199de87ccd30ffe6a7da4624c2f632700cd8348194a30b79dd2e2a69f", "package-lock.json must not change in Batch 2A");
+  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json must not change in Batch 2A");
 });


### PR DESCRIPTION
Publishes the verified 0.2.1 version metadata, changelog, and release contract updates. Local gates passed: test, lint, source check, production audit, macOS arm64 package, and packaged smoke.