### PR TITLE
Release candidate 0.2.1-rc.3: desktop handoff reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file records user-visible changes. Internal deployment notes, local paths, and development handoffs are intentionally not tracked in the public repository.
 
-## 0.2.1 — 2026-09-02
+## 0.2.1-rc.1 — 2026-09-02 / Release Candidate
 
 ### Reliability and privacy / 可靠性与隐私
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file records user-visible changes. Internal deployment notes, local paths, and development handoffs are intentionally not tracked in the public repository.
 
+## 0.2.1-rc.3 — 2026-09-02 / Release Candidate
+
+### Desktop upgrade reliability / 桌面升级可靠性
+
+- A packaged desktop upgrade now waits for a KeepAlive-managed local MOSA service to finish restarting and report the exact new build identity, then opens directly instead of requiring a second manual launch.
+- The handoff continues to fail closed if a different, same-version, newer, unverified, QA, development, or explicit-port runtime is encountered.
+
 ## 0.2.1-rc.2 — 2026-09-02 / Release Candidate
 
 ### Desktop upgrade reliability / 桌面升级可靠性

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file records user-visible changes. Internal deployment notes, local paths, and development handoffs are intentionally not tracked in the public repository.
 
+## 0.2.1-rc.2 — 2026-09-02 / Release Candidate
+
+### Desktop upgrade reliability / 桌面升级可靠性
+
+- A newer packaged MOSA build can now take over a verified, strictly older local runtime for the same library, then reconnect only after the replacement reports the new build identity.
+- Development, QA, explicit-port, same-version, newer-version, and unverified local runtimes remain fail-closed and are never stopped automatically.
+- Startup errors no longer expose internal build fingerprints or Git identifiers to users.
+
 ## 0.2.1-rc.1 — 2026-09-02 / Release Candidate
 
 ### Reliability and privacy / 可靠性与隐私

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -8,7 +8,7 @@ import { DEFAULT_MOSA_DESKTOP_PORT, MOSA_RESERVED_PRODUCTION_PORTS } from "../li
 import { validateRuntimeIsolation } from "../lib/runtime-isolation-guard.mjs";
 import { parseDisabledBridges } from "../lib/runtime-bridges.mjs";
 import { cleanupOrphanStagedFiles, importStagingDir, writeStagedPng } from "../lib/import-staging.mjs";
-import { startMosaService } from "./service-manager.mjs";
+import { shouldAllowStaleServiceUpgrade, startMosaService } from "./service-manager.mjs";
 import { getDesktopText, getNotificationTextForAssetsImported, getUpdateNotificationText } from "./notification-i18n.mjs";
 import { loadOrCreateWebCaptureToken, MOSA_WEB_CAPTURE_DEFAULT_ORIGINS } from "./web-capture-pairing.mjs";
 import { desktopPlatformAdapter } from "./platform/index.mjs";
@@ -573,7 +573,11 @@ async function createMainWindow() {
       // that owns this exact library. QA, source development, and explicit
       // port launches stay fail-closed so test tooling never terminates an
       // unrelated local process.
-      allowStaleServiceUpgrade: app.isPackaged && !isolationContext.qaRun && !process.env.MOSA_DESKTOP_PORT,
+      allowStaleServiceUpgrade: shouldAllowStaleServiceUpgrade({
+        isPackaged: app.isPackaged,
+        qaRun: isolationContext.qaRun,
+        explicitPort: Boolean(process.env.MOSA_DESKTOP_PORT),
+      }),
       expectedIdentity: expectedServiceIdentity,
       importStagingRoot,
       isolationContext,

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -150,6 +150,12 @@ if (!app.requestSingleInstanceLock()) {
     stopBridgeNotificationPoll();
     void stopOwnedRuntime().catch(console.error).finally(() => app.exit(0));
   });
+
+  // A newer packaged MOSA may ask this process to yield the shared local
+  // runtime with SIGTERM. Route that signal through Electron's normal quit
+  // lifecycle so bridge work drains, SQLite closes, and the runtime lock is
+  // released before the process exits.
+  process.once("SIGTERM", () => app.quit());
 }
 
 function loadBounds() {
@@ -563,6 +569,11 @@ async function createMainWindow() {
       port: desktopPort,
       libraryDir,
       allowPortFallback: !process.env.MOSA_DESKTOP_PORT,
+      // Normal packaged launches may replace a strictly older MOSA runtime
+      // that owns this exact library. QA, source development, and explicit
+      // port launches stay fail-closed so test tooling never terminates an
+      // unrelated local process.
+      allowStaleServiceUpgrade: app.isPackaged && !isolationContext.qaRun && !process.env.MOSA_DESKTOP_PORT,
       expectedIdentity: expectedServiceIdentity,
       importStagingRoot,
       isolationContext,

--- a/desktop/service-manager.mjs
+++ b/desktop/service-manager.mjs
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { startMosaRuntime } from "../lib/mosa-runtime.mjs";
@@ -11,6 +12,9 @@ import { validateRuntimeIsolation } from "../lib/runtime-isolation-guard.mjs";
 
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_PROBE_TIMEOUT_MS = 1500;
+const DEFAULT_UPGRADE_STOP_TIMEOUT_MS = 5000;
+const DEFAULT_UPGRADE_STOP_POLL_MS = 100;
+const RUNTIME_LOCK_FILE_NAME = ".mosa-runtime.lock";
 
 export class MosaServiceConflictError extends Error {
   constructor(message, options = {}) {
@@ -19,9 +23,26 @@ export class MosaServiceConflictError extends Error {
   }
 }
 
+export class MosaServiceBuildMismatchError extends MosaServiceConflictError {
+  constructor({ details, expectedIdentity, mismatches }) {
+    const runningVersion = normalizedIdentityValue(details?.productVersion);
+    const expectedVersion = normalizedIdentityValue(expectedIdentity?.productVersion);
+    const runningLabel = runningVersion === "unknown" ? "another build" : `v${runningVersion}`;
+    const expectedLabel = expectedVersion === "unknown" ? "This MOSA build" : `MOSA v${expectedVersion}`;
+    super(`${expectedLabel} found ${runningLabel} of the local MOSA service using the same library. Quit the previous MOSA instance and reopen this version.`);
+    this.name = "MosaServiceBuildMismatchError";
+    this.code = "MOSA_SERVICE_BUILD_MISMATCH";
+    this.service = Object.freeze({ ...details });
+    this.expectedIdentity = Object.freeze({ ...expectedIdentity });
+    this.mismatches = Object.freeze(mismatches.map((item) => Object.freeze({ ...item })));
+    this.upgradeEligible = compareMosaVersions(expectedVersion, runningVersion) === 1;
+  }
+}
+
 /**
  * Attaches to a verified local MOSA service or starts one that this process
- * owns. It deliberately never terminates a process that already owns a port.
+ * owns. Existing processes are left alone by default; the packaged desktop
+ * may explicitly opt into the narrow older-version retirement path below.
  *
  * `options.isolationContext` carries the QA runtime parameters that
  * desktop/main.mjs resolved once (runtimeMode, qaRun, expected/actual
@@ -88,9 +109,21 @@ export async function startMosaService(options = {}) {
   }
 
   // A verified MOSA for this exact library is already alive, but it does not
-  // match the desktop build. Starting a second runtime on another port would
-  // race the same library lock and, worse, conceal the stale-service problem.
-  if (identityMismatch) throw identityMismatch;
+  // match the desktop build. A packaged upgrade may retire an *older* verified
+  // MOSA owner for this same library, then retry once. QA/dev callers stay
+  // fail-closed unless they explicitly opt in, and same/newer builds are never
+  // terminated automatically.
+  if (identityMismatch) {
+    if (options.allowStaleServiceUpgrade === true && identityMismatch.upgradeEligible === true) {
+      const upgradeService = options.upgradeService || retireOlderMosaService;
+      const retired = await upgradeService(identityMismatch, {
+        host,
+        probeTimeoutMs: options.probeTimeoutMs,
+      });
+      if (retired) return startMosaService({ ...options, allowStaleServiceUpgrade: false });
+    }
+    throw identityMismatch;
+  }
 
   for (const candidatePort of availablePorts) {
     const probeOptions = {
@@ -181,6 +214,68 @@ export async function probeMosaService(options = {}) {
   }
 }
 
+/**
+ * Retire a verified older MOSA runtime so a packaged desktop upgrade can take
+ * ownership of the same library. The compatibility path is intentionally
+ * narrow: the live service, semantic version, and library lock must all agree
+ * before SIGTERM is sent, and we never escalate to SIGKILL.
+ */
+export async function retireOlderMosaService(conflict, options = {}) {
+  if (!(conflict instanceof MosaServiceBuildMismatchError) || conflict.upgradeEligible !== true) return false;
+  const service = conflict.service;
+  if (!service || !Number.isInteger(service.port) || typeof service.libraryDir !== "string") return false;
+
+  const readFileImpl = options.readFileImpl || readFile;
+  const lockPath = join(service.libraryDir, RUNTIME_LOCK_FILE_NAME);
+  const owner = await readRuntimeLockOwner(lockPath, readFileImpl);
+  if (!owner || owner.pid === process.pid) return false;
+
+  const probeImpl = options.probeImpl || probeMosaService;
+  const probeOptions = {
+    host: options.host || DEFAULT_HOST,
+    port: service.port,
+    libraryDir: service.libraryDir,
+    timeoutMs: options.probeTimeoutMs,
+  };
+  const current = await probeImpl(probeOptions);
+  if (current.state !== "attached" || !sameReportedServiceIdentity(current, service)) return false;
+  const currentConflict = serviceIdentityConflict(current, conflict.expectedIdentity);
+  if (!(currentConflict instanceof MosaServiceBuildMismatchError) || currentConflict.upgradeEligible !== true) return false;
+
+  const isProcessAlive = options.isProcessAlive || defaultIsProcessAlive;
+  if (!isProcessAlive(owner.pid)) return false;
+  const terminateProcess = options.terminateProcess || ((pid) => process.kill(pid, "SIGTERM"));
+  try {
+    terminateProcess(owner.pid);
+  } catch {
+    return false;
+  }
+
+  const timeoutMs = positiveInteger(options.timeoutMs, DEFAULT_UPGRADE_STOP_TIMEOUT_MS);
+  const pollMs = positiveInteger(options.pollMs, DEFAULT_UPGRADE_STOP_POLL_MS);
+  const maxChecks = Math.max(1, Math.ceil(timeoutMs / pollMs));
+  const sleepImpl = options.sleepImpl || ((delayMs) => new Promise((resolveSleep) => setTimeout(resolveSleep, delayMs)));
+
+  for (let check = 0; check < maxChecks; check += 1) {
+    const alive = isProcessAlive(owner.pid);
+    const status = await probeImpl(probeOptions);
+    if (!alive && status.state === "unavailable") return true;
+    if (status.state === "conflict") return false;
+    if (status.state === "attached") {
+      // A KeepAlive launch agent can restart the local source runtime as soon
+      // as the older owner exits. That is safe to accept only when the
+      // replacement already reports this desktop build's complete identity;
+      // the caller will probe again and attach to it on the retry.
+      if (!serviceIdentityConflict(status, conflict.expectedIdentity)) return true;
+      // Any other new owner is not the service we verified before signaling.
+      // Never continue polling or signal a second process in that case.
+      if (!sameReportedServiceIdentity(status, service)) return false;
+    }
+    if (check + 1 < maxChecks) await sleepImpl(pollMs);
+  }
+  return false;
+}
+
 async function probeLegacyMosaIdentity({ url, fetchImpl, signal }) {
   const [libraryResponse, bridgesResponse] = await Promise.all([
     fetchImpl(`${url}/api/library-path`, { signal }),
@@ -246,19 +341,91 @@ function serviceIdentityConflict(details, expectedIdentity) {
   const fields = ["productVersion", "gitSha", "uiFingerprint", "runtimeFingerprint"];
   const mismatches = [];
   for (const field of fields) {
-    const expected = String(expectedIdentity[field] || "unknown");
-    const actual = String(details[field] || "unknown");
+    const expected = normalizedIdentityValue(expectedIdentity[field]);
+    const actual = normalizedIdentityValue(details[field]);
     if (expected === "unknown") continue;
     if (actual === "unknown") {
-      mismatches.push(`${field} expected ${expected} but the running service cannot report it`);
+      mismatches.push({ field, expected, actual });
       continue;
     }
-    if (expected !== actual) mismatches.push(`${field} expected ${expected} but found ${actual}`);
+    if (expected !== actual) mismatches.push({ field, expected, actual });
   }
   if (!mismatches.length) return null;
-  return new MosaServiceConflictError(
-    `A MOSA service for this library is already running with a different build identity (${mismatches.join("; ")}). Restart MOSA so the service and desktop app use the same build.`,
-  );
+  return new MosaServiceBuildMismatchError({ details, expectedIdentity, mismatches });
+}
+
+export function compareMosaVersions(left, right) {
+  const leftVersion = parseMosaVersion(left);
+  const rightVersion = parseMosaVersion(right);
+  if (!leftVersion || !rightVersion) return null;
+  for (const key of ["major", "minor", "patch"]) {
+    if (leftVersion[key] > rightVersion[key]) return 1;
+    if (leftVersion[key] < rightVersion[key]) return -1;
+  }
+  return comparePrerelease(leftVersion.prerelease, rightVersion.prerelease);
+}
+
+function parseMosaVersion(value) {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(String(value || "").trim());
+  if (!match) return null;
+  const [major, minor, patch] = match.slice(1, 4).map(Number);
+  if (![major, minor, patch].every(Number.isSafeInteger)) return null;
+  const prerelease = match[4] ? match[4].split(".") : [];
+  if (prerelease.some((part) => !part || (/^\d+$/.test(part) && !Number.isSafeInteger(Number(part))))) return null;
+  return { major, minor, patch, prerelease };
+}
+
+function comparePrerelease(left, right) {
+  if (!left.length && !right.length) return 0;
+  if (!left.length) return 1;
+  if (!right.length) return -1;
+  const length = Math.max(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    if (index >= left.length) return -1;
+    if (index >= right.length) return 1;
+    const leftPart = left[index];
+    const rightPart = right[index];
+    if (leftPart === rightPart) continue;
+    const leftNumeric = /^\d+$/.test(leftPart);
+    const rightNumeric = /^\d+$/.test(rightPart);
+    if (leftNumeric && rightNumeric) return Number(leftPart) > Number(rightPart) ? 1 : -1;
+    if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+    return leftPart > rightPart ? 1 : -1;
+  }
+  return 0;
+}
+
+function normalizedIdentityValue(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : "unknown";
+}
+
+function sameReportedServiceIdentity(left, right) {
+  return ["productVersion", "gitSha", "uiFingerprint", "runtimeFingerprint"]
+    .every((field) => normalizedIdentityValue(left?.[field]) === normalizedIdentityValue(right?.[field]));
+}
+
+async function readRuntimeLockOwner(lockPath, readFileImpl) {
+  try {
+    const parsed = JSON.parse(await readFileImpl(lockPath, "utf8"));
+    if (typeof parsed?.token !== "string" || !parsed.token || !Number.isInteger(parsed?.pid) || parsed.pid <= 0) return null;
+    return { token: parsed.token, pid: parsed.pid };
+  } catch {
+    return null;
+  }
+}
+
+function defaultIsProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function positiveInteger(value, fallback) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : fallback;
 }
 
 function isConnectionRefused(error) {

--- a/desktop/service-manager.mjs
+++ b/desktop/service-manager.mjs
@@ -14,6 +14,8 @@ const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_PROBE_TIMEOUT_MS = 1500;
 const DEFAULT_UPGRADE_STOP_TIMEOUT_MS = 5000;
 const DEFAULT_UPGRADE_STOP_POLL_MS = 100;
+const DEFAULT_UPGRADE_READY_TIMEOUT_MS = 30_000;
+const DEFAULT_UPGRADE_READY_POLL_MS = 100;
 const RUNTIME_LOCK_FILE_NAME = ".mosa-runtime.lock";
 
 export class MosaServiceConflictError extends Error {
@@ -37,6 +39,10 @@ export class MosaServiceBuildMismatchError extends MosaServiceConflictError {
     this.mismatches = Object.freeze(mismatches.map((item) => Object.freeze({ ...item })));
     this.upgradeEligible = compareMosaVersions(expectedVersion, runningVersion) === 1;
   }
+}
+
+export function shouldAllowStaleServiceUpgrade({ isPackaged, qaRun, explicitPort } = {}) {
+  return isPackaged === true && !qaRun && !explicitPort;
 }
 
 /**
@@ -114,13 +120,30 @@ export async function startMosaService(options = {}) {
   // fail-closed unless they explicitly opt in, and same/newer builds are never
   // terminated automatically.
   if (identityMismatch) {
-    if (options.allowStaleServiceUpgrade === true && identityMismatch.upgradeEligible === true) {
+    if (
+      options.allowStaleServiceUpgrade === true
+      && identityMismatch.upgradeEligible === true
+      && hasCompleteServiceIdentity(identityMismatch.expectedIdentity)
+    ) {
       const upgradeService = options.upgradeService || retireOlderMosaService;
       const retired = await upgradeService(identityMismatch, {
         host,
+        fetchImpl: options.fetchImpl,
         probeTimeoutMs: options.probeTimeoutMs,
       });
-      if (retired) return startMosaService({ ...options, allowStaleServiceUpgrade: false });
+      if (retired) {
+        const replacement = await waitForUpgradedMosaService(identityMismatch, {
+          host,
+          fetchImpl: options.fetchImpl,
+          probeImpl: options.upgradeProbeImpl,
+          probeTimeoutMs: options.probeTimeoutMs,
+          timeoutMs: options.upgradeReadyTimeoutMs,
+          pollMs: options.upgradeReadyPollMs,
+          sleepImpl: options.upgradeReadySleepImpl,
+          nowImpl: options.upgradeReadyNowImpl,
+        });
+        return attachedService(replacement);
+      }
     }
     throw identityMismatch;
   }
@@ -184,7 +207,7 @@ export async function probeMosaService(options = {}) {
     } else if (response.status === 404) {
       health = await probeLegacyMosaIdentity({ url, fetchImpl, signal: controller.signal });
     } else {
-      return conflict(`Port ${port} is occupied by a service that is not a healthy MOSA runtime.`);
+      return conflict(`Port ${port} is occupied by a service that is not a healthy MOSA runtime.`, null, { retryable: true });
     }
     if (health?.product !== "mosa" || typeof health.libraryDir !== "string") {
       return conflict(`Port ${port} is occupied by a service that is not MOSA.`);
@@ -208,7 +231,7 @@ export async function probeMosaService(options = {}) {
     const reason = error?.name === "AbortError"
       ? `Port ${port} did not respond before the MOSA probe timed out.`
       : `Port ${port} is occupied but could not be verified as MOSA.`;
-    return conflict(reason, error);
+    return conflict(reason, error, { retryable: true });
   } finally {
     clearTimeout(timer);
   }
@@ -235,6 +258,7 @@ export async function retireOlderMosaService(conflict, options = {}) {
     host: options.host || DEFAULT_HOST,
     port: service.port,
     libraryDir: service.libraryDir,
+    fetchImpl: options.fetchImpl,
     timeoutMs: options.probeTimeoutMs,
   };
   const current = await probeImpl(probeOptions);
@@ -259,8 +283,8 @@ export async function retireOlderMosaService(conflict, options = {}) {
   for (let check = 0; check < maxChecks; check += 1) {
     const alive = isProcessAlive(owner.pid);
     const status = await probeImpl(probeOptions);
-    if (!alive && status.state === "unavailable") return true;
-    if (status.state === "conflict") return false;
+    if (!alive && (status.state === "unavailable" || (status.state === "conflict" && status.retryable === true))) return true;
+    if (status.state === "conflict" && status.retryable !== true) return false;
     if (status.state === "attached") {
       // A KeepAlive launch agent can restart the local source runtime as soon
       // as the older owner exits. That is safe to accept only when the
@@ -274,6 +298,48 @@ export async function retireOlderMosaService(conflict, options = {}) {
     if (check + 1 < maxChecks) await sleepImpl(pollMs);
   }
   return false;
+}
+
+async function waitForUpgradedMosaService(conflict, options = {}) {
+  const service = conflict?.service;
+  if (!(conflict instanceof MosaServiceBuildMismatchError) || !service) {
+    throw new MosaServiceConflictError("The local MOSA service could not be verified for upgrade handoff.");
+  }
+
+  const probeImpl = options.probeImpl || probeMosaService;
+  const probeOptions = {
+    host: options.host || DEFAULT_HOST,
+    port: service.port,
+    libraryDir: service.libraryDir,
+    fetchImpl: options.fetchImpl,
+    timeoutMs: options.probeTimeoutMs,
+  };
+  const timeoutMs = positiveInteger(options.timeoutMs, DEFAULT_UPGRADE_READY_TIMEOUT_MS);
+  const pollMs = positiveInteger(options.pollMs, DEFAULT_UPGRADE_READY_POLL_MS);
+  const sleepImpl = options.sleepImpl || ((delayMs) => new Promise((resolveSleep) => setTimeout(resolveSleep, delayMs)));
+  const nowImpl = options.nowImpl || Date.now;
+  const deadline = nowImpl() + timeoutMs;
+
+  while (true) {
+    const status = await probeImpl(probeOptions);
+    if (status.state === "attached") {
+      const identityConflict = serviceIdentityConflict(status, conflict.expectedIdentity);
+      if (!identityConflict) return status;
+      // After the verified old owner has been retired, any attached identity
+      // other than the exact target belongs to a new owner. Fail closed and
+      // never signal it or fall through to startRuntime.
+      throw identityConflict;
+    }
+    if (status.state === "conflict" && status.retryable !== true) throw status.error;
+
+    const remainingMs = deadline - nowImpl();
+    if (remainingMs <= 0) break;
+    await sleepImpl(Math.min(pollMs, remainingMs));
+  }
+
+  throw new MosaServiceConflictError(
+    "The local MOSA service did not finish restarting after the previous version exited. Reopen MOSA after the local service is ready.",
+  );
 }
 
 async function probeLegacyMosaIdentity({ url, fetchImpl, signal }) {
@@ -332,8 +398,8 @@ function ownedService(runtime) {
   };
 }
 
-function conflict(message, cause) {
-  return { state: "conflict", error: new MosaServiceConflictError(message, { cause }) };
+function conflict(message, cause, { retryable = false } = {}) {
+  return { state: "conflict", error: new MosaServiceConflictError(message, { cause }), retryable };
 }
 
 function serviceIdentityConflict(details, expectedIdentity) {
@@ -397,6 +463,11 @@ function comparePrerelease(left, right) {
 
 function normalizedIdentityValue(value) {
   return typeof value === "string" && value.trim() ? value.trim() : "unknown";
+}
+
+function hasCompleteServiceIdentity(identity) {
+  return ["productVersion", "gitSha", "uiFingerprint", "runtimeFingerprint"]
+    .every((field) => normalizedIdentityValue(identity?.[field]) !== "unknown");
 }
 
 function sameReportedServiceIdentity(left, right) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mosa",
-  "version": "0.2.1",
+  "version": "0.2.1-rc.1",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mosa",
-  "version": "0.2.1-rc.2",
+  "version": "0.2.1-rc.3",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mosa",
-  "version": "0.2.1-rc.1",
+  "version": "0.2.1-rc.2",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",
   "type": "module",

--- a/test/service-manager.test.mjs
+++ b/test/service-manager.test.mjs
@@ -6,7 +6,13 @@ import { join, resolve } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { startMosaRuntime } from "../lib/mosa-runtime.mjs";
-import { MosaServiceConflictError, startMosaService } from "../desktop/service-manager.mjs";
+import {
+  MosaServiceBuildMismatchError,
+  MosaServiceConflictError,
+  compareMosaVersions,
+  retireOlderMosaService,
+  startMosaService,
+} from "../desktop/service-manager.mjs";
 import { removeTestPath as rm } from "./test-cleanup.mjs";
 
 const repositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
@@ -106,7 +112,14 @@ test("rejects a same-library MOSA runtime whose build identity is stale", async 
         runtimeFingerprint: "new-runtime",
       },
     }),
-    /different build identity/,
+    (error) => {
+      assert.ok(error instanceof MosaServiceBuildMismatchError);
+      assert.equal(error.code, "MOSA_SERVICE_BUILD_MISMATCH");
+      assert.equal(error.upgradeEligible, false, "same product version is not an automatic upgrade target");
+      assert.match(error.message, /v0\.2\.0/);
+      assert.doesNotMatch(error.message, /sha|fingerprint|new-sha|old-sha/i, "startup copy does not expose internal build identifiers");
+      return true;
+    },
   );
   assert.equal(server.listening, true, "desktop must not kill a process it does not own");
 });
@@ -127,9 +140,164 @@ test("rejects unversioned same-library services when desktop has a verifiable bu
       libraryDir,
       expectedIdentity: { runtimeFingerprint: "expected-runtime" },
     }),
-    /cannot report it/,
+    (error) => {
+      assert.ok(error instanceof MosaServiceBuildMismatchError);
+      assert.equal(error.upgradeEligible, false, "an unversioned service is never terminated automatically");
+      assert.doesNotMatch(error.message, /runtimeFingerprint|expected-runtime/);
+      return true;
+    },
   );
   assert.equal(server.listening, true);
+});
+
+test("compares MOSA release and prerelease versions for upgrade eligibility", () => {
+  assert.equal(compareMosaVersions("0.2.1-rc.1", "0.2.0"), 1);
+  assert.equal(compareMosaVersions("0.2.1", "0.2.1-rc.1"), 1);
+  assert.equal(compareMosaVersions("0.2.1-rc.2", "0.2.1-rc.1"), 1);
+  assert.equal(compareMosaVersions("0.2.1-rc.1", "0.2.1"), -1);
+  assert.equal(compareMosaVersions("0.2.1", "0.2.1"), 0);
+  assert.equal(compareMosaVersions("unknown", "0.2.0"), null);
+});
+
+test("packaged upgrade path retires a strictly older verified service and retries once", async (t) => {
+  const root = await temporaryRoot(t, "mosa-service-upgrade-retry-");
+  const libraryDir = join(root, "library");
+  const port = await availablePort();
+  const oldServer = createServer((_req, res) => {
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({
+      product: "mosa",
+      libraryDir,
+      storage: "sqlite",
+      productVersion: "0.2.0",
+      gitSha: "old-sha",
+      uiFingerprint: "old-ui",
+      runtimeFingerprint: "unknown",
+    }));
+  });
+  await listen(oldServer, port);
+  t.after(() => close(oldServer));
+
+  let upgradeCalls = 0;
+  let runtimeStarts = 0;
+  const service = await startMosaService({
+    port,
+    libraryDir,
+    expectedIdentity: {
+      productVersion: "0.2.1-rc.1",
+      gitSha: "new-sha",
+      uiFingerprint: "new-ui",
+      runtimeFingerprint: "new-runtime",
+    },
+    allowStaleServiceUpgrade: true,
+    upgradeService: async (conflict) => {
+      upgradeCalls += 1;
+      assert.ok(conflict instanceof MosaServiceBuildMismatchError);
+      assert.equal(conflict.upgradeEligible, true);
+      await close(oldServer);
+      return true;
+    },
+    startRuntime: async ({ port: requestedPort }) => {
+      runtimeStarts += 1;
+      return {
+        url: `http://127.0.0.1:${requestedPort}`,
+        port: requestedPort,
+        libraryDir,
+        storage: "sqlite",
+        stop: async () => {},
+      };
+    },
+  });
+
+  assert.equal(upgradeCalls, 1);
+  assert.equal(runtimeStarts, 1);
+  assert.equal(service.mode, "owned");
+  assert.equal(service.port, port);
+  await service.stop();
+});
+
+test("controlled retirement requires matching service identity and lock owner, then sends SIGTERM only", async () => {
+  const libraryDir = resolve("/tmp/mosa-controlled-upgrade-library");
+  const service = {
+    state: "attached",
+    url: "http://127.0.0.1:43517",
+    port: 43517,
+    libraryDir,
+    storage: "sqlite",
+    productVersion: "0.2.0",
+    gitSha: "old-sha",
+    uiFingerprint: "old-ui",
+    runtimeFingerprint: "unknown",
+  };
+  const conflict = new MosaServiceBuildMismatchError({
+    details: service,
+    expectedIdentity: {
+      productVersion: "0.2.1-rc.1",
+      gitSha: "new-sha",
+      uiFingerprint: "new-ui",
+      runtimeFingerprint: "new-runtime",
+    },
+    mismatches: [{ field: "productVersion", expected: "0.2.1-rc.1", actual: "0.2.0" }],
+  });
+  const probes = [service, { state: "unavailable" }];
+  const alive = [true, false];
+  const signals = [];
+
+  const retired = await retireOlderMosaService(conflict, {
+    readFileImpl: async () => JSON.stringify({ token: "old-runtime-token", pid: 4242 }),
+    probeImpl: async () => probes.shift() || { state: "unavailable" },
+    isProcessAlive: () => alive.shift() ?? false,
+    terminateProcess: (pid) => signals.push({ pid, signal: "SIGTERM" }),
+    sleepImpl: async () => {},
+    timeoutMs: 100,
+    pollMs: 100,
+  });
+
+  assert.equal(retired, true);
+  assert.deepEqual(signals, [{ pid: 4242, signal: "SIGTERM" }]);
+});
+
+test("controlled retirement accepts a KeepAlive replacement only after it matches the requested build", async () => {
+  const libraryDir = resolve("/tmp/mosa-keepalive-upgrade-library");
+  const staleService = {
+    state: "attached",
+    url: "http://127.0.0.1:43517",
+    port: 43517,
+    libraryDir,
+    storage: "sqlite",
+    productVersion: "0.2.0",
+    gitSha: "old-sha",
+    uiFingerprint: "old-ui",
+    runtimeFingerprint: "old-runtime",
+  };
+  const expectedIdentity = {
+    productVersion: "0.2.1-rc.1",
+    gitSha: "new-sha",
+    uiFingerprint: "new-ui",
+    runtimeFingerprint: "new-runtime",
+  };
+  const restartedService = { ...staleService, ...expectedIdentity };
+  const conflict = new MosaServiceBuildMismatchError({
+    details: staleService,
+    expectedIdentity,
+    mismatches: [{ field: "productVersion", expected: "0.2.1-rc.1", actual: "0.2.0" }],
+  });
+  const probes = [staleService, restartedService];
+  const alive = [true, false];
+  const signals = [];
+
+  const retired = await retireOlderMosaService(conflict, {
+    readFileImpl: async () => JSON.stringify({ token: "old-runtime-token", pid: 4242 }),
+    probeImpl: async () => probes.shift() || restartedService,
+    isProcessAlive: () => alive.shift() ?? false,
+    terminateProcess: (pid) => signals.push({ pid, signal: "SIGTERM" }),
+    sleepImpl: async () => {},
+    timeoutMs: 100,
+    pollMs: 100,
+  });
+
+  assert.equal(retired, true);
+  assert.deepEqual(signals, [{ pid: 4242, signal: "SIGTERM" }]);
 });
 
 test("attaches to a matching pre-health-endpoint MOSA runtime", async (t) => {

--- a/test/service-manager.test.mjs
+++ b/test/service-manager.test.mjs
@@ -11,6 +11,7 @@ import {
   MosaServiceConflictError,
   compareMosaVersions,
   retireOlderMosaService,
+  shouldAllowStaleServiceUpgrade,
   startMosaService,
 } from "../desktop/service-manager.mjs";
 import { removeTestPath as rm } from "./test-cleanup.mjs";
@@ -159,7 +160,90 @@ test("compares MOSA release and prerelease versions for upgrade eligibility", ()
   assert.equal(compareMosaVersions("unknown", "0.2.0"), null);
 });
 
-test("packaged upgrade path retires a strictly older verified service and retries once", async (t) => {
+test("automatic stale-service retirement is enabled only for normal packaged launches", () => {
+  assert.equal(shouldAllowStaleServiceUpgrade({ isPackaged: true, qaRun: false, explicitPort: false }), true);
+  assert.equal(shouldAllowStaleServiceUpgrade({ isPackaged: false, qaRun: false, explicitPort: false }), false, "development launches stay fail-closed");
+  assert.equal(shouldAllowStaleServiceUpgrade({ isPackaged: true, qaRun: "1", explicitPort: false }), false, "QA launches stay fail-closed");
+  assert.equal(shouldAllowStaleServiceUpgrade({ isPackaged: true, qaRun: false, explicitPort: true }), false, "explicit port launches stay fail-closed");
+});
+
+test("automatic retirement does not target same-version, newer, unknown, or different-library services", async (t) => {
+  const root = await temporaryRoot(t, "mosa-service-upgrade-protections-");
+  const libraryDir = join(root, "library");
+  let health = null;
+  const server = createServer((_req, res) => {
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify(health));
+  });
+  await listen(server);
+  t.after(() => close(server));
+  const port = server.address().port;
+  let upgradeCalls = 0;
+  const expectedIdentity = {
+    productVersion: "0.2.1-rc.2",
+    gitSha: "target-sha",
+    uiFingerprint: "target-ui",
+    runtimeFingerprint: "target-runtime",
+  };
+  const cases = [
+    {
+      label: "same version",
+      identity: { productVersion: "0.2.1-rc.2", gitSha: "other-sha", uiFingerprint: "other-ui", runtimeFingerprint: "other-runtime" },
+    },
+    {
+      label: "newer version",
+      identity: { productVersion: "0.2.2", gitSha: "newer-sha", uiFingerprint: "newer-ui", runtimeFingerprint: "newer-runtime" },
+    },
+    {
+      label: "unknown version",
+      identity: { productVersion: "unknown", gitSha: "unknown", uiFingerprint: "unknown", runtimeFingerprint: "unknown" },
+    },
+  ];
+
+  for (const item of cases) {
+    health = { product: "mosa", libraryDir, storage: "sqlite", ...item.identity };
+    await assert.rejects(
+      startMosaService({
+        port,
+        libraryDir,
+        expectedIdentity,
+        allowStaleServiceUpgrade: true,
+        upgradeService: async () => {
+          upgradeCalls += 1;
+          return true;
+        },
+      }),
+      MosaServiceBuildMismatchError,
+      item.label,
+    );
+  }
+
+  health = {
+    product: "mosa",
+    libraryDir: join(root, "different-library"),
+    storage: "sqlite",
+    productVersion: "0.2.0",
+    gitSha: "old-sha",
+    uiFingerprint: "old-ui",
+    runtimeFingerprint: "old-runtime",
+  };
+  await assert.rejects(
+    startMosaService({
+      port,
+      libraryDir,
+      expectedIdentity,
+      allowStaleServiceUpgrade: true,
+      upgradeService: async () => {
+        upgradeCalls += 1;
+        return true;
+      },
+    }),
+    MosaServiceConflictError,
+  );
+  assert.equal(upgradeCalls, 0, "protected services are never passed to the retirement path");
+});
+
+test("packaged upgrade path waits through KeepAlive unavailability and attaches to the target build", async (t) => {
   const root = await temporaryRoot(t, "mosa-service-upgrade-retry-");
   const libraryDir = join(root, "library");
   const port = await availablePort();
@@ -180,15 +264,25 @@ test("packaged upgrade path retires a strictly older verified service and retrie
 
   let upgradeCalls = 0;
   let runtimeStarts = 0;
+  let replacementProbes = 0;
+  const expectedIdentity = {
+    productVersion: "0.2.1-rc.1",
+    gitSha: "new-sha",
+    uiFingerprint: "new-ui",
+    runtimeFingerprint: "new-runtime",
+  };
+  const replacement = {
+    state: "attached",
+    url: `http://127.0.0.1:${port}`,
+    port,
+    libraryDir,
+    storage: "sqlite",
+    ...expectedIdentity,
+  };
   const service = await startMosaService({
     port,
     libraryDir,
-    expectedIdentity: {
-      productVersion: "0.2.1-rc.1",
-      gitSha: "new-sha",
-      uiFingerprint: "new-ui",
-      runtimeFingerprint: "new-runtime",
-    },
+    expectedIdentity,
     allowStaleServiceUpgrade: true,
     upgradeService: async (conflict) => {
       upgradeCalls += 1;
@@ -197,23 +291,152 @@ test("packaged upgrade path retires a strictly older verified service and retrie
       await close(oldServer);
       return true;
     },
-    startRuntime: async ({ port: requestedPort }) => {
+    upgradeProbeImpl: async () => {
+      replacementProbes += 1;
+      if (replacementProbes === 1) return { state: "unavailable" };
+      if (replacementProbes === 2) {
+        return {
+          state: "conflict",
+          retryable: true,
+          error: new MosaServiceConflictError("replacement is still starting"),
+        };
+      }
+      return replacement;
+    },
+    upgradeReadySleepImpl: async () => {},
+    upgradeReadyTimeoutMs: 1000,
+    startRuntime: async () => {
       runtimeStarts += 1;
-      return {
-        url: `http://127.0.0.1:${requestedPort}`,
-        port: requestedPort,
-        libraryDir,
-        storage: "sqlite",
-        stop: async () => {},
-      };
+      throw new Error("startRuntime must not run during a KeepAlive upgrade handoff");
     },
   });
 
   assert.equal(upgradeCalls, 1);
-  assert.equal(runtimeStarts, 1);
-  assert.equal(service.mode, "owned");
+  assert.equal(replacementProbes, 3);
+  assert.equal(runtimeStarts, 0);
+  assert.equal(service.mode, "attached");
   assert.equal(service.port, port);
+  assert.equal(service.productVersion, expectedIdentity.productVersion);
+  assert.equal(service.gitSha, expectedIdentity.gitSha);
   await service.stop();
+});
+
+test("packaged upgrade handoff fails closed when a different build appears after retirement", async (t) => {
+  const root = await temporaryRoot(t, "mosa-service-upgrade-stranger-");
+  const libraryDir = join(root, "library");
+  const port = await availablePort();
+  const oldServer = createServer((_req, res) => {
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({
+      product: "mosa",
+      libraryDir,
+      storage: "sqlite",
+      productVersion: "0.2.0",
+      gitSha: "old-sha",
+      uiFingerprint: "old-ui",
+      runtimeFingerprint: "old-runtime",
+    }));
+  });
+  await listen(oldServer, port);
+  t.after(() => close(oldServer));
+
+  let upgradeCalls = 0;
+  let runtimeStarts = 0;
+  const expectedIdentity = {
+    productVersion: "0.2.1-rc.2",
+    gitSha: "target-sha",
+    uiFingerprint: "target-ui",
+    runtimeFingerprint: "target-runtime",
+  };
+  const stranger = {
+    state: "attached",
+    url: `http://127.0.0.1:${port}`,
+    port,
+    libraryDir,
+    storage: "sqlite",
+    productVersion: "0.2.1-rc.1",
+    gitSha: "stranger-sha",
+    uiFingerprint: "stranger-ui",
+    runtimeFingerprint: "stranger-runtime",
+  };
+
+  await assert.rejects(
+    startMosaService({
+      port,
+      libraryDir,
+      expectedIdentity,
+      allowStaleServiceUpgrade: true,
+      upgradeService: async () => {
+        upgradeCalls += 1;
+        await close(oldServer);
+        return true;
+      },
+      upgradeProbeImpl: async () => stranger,
+      startRuntime: async () => {
+        runtimeStarts += 1;
+        throw new Error("startRuntime must not run after a verified retirement");
+      },
+    }),
+    MosaServiceBuildMismatchError,
+  );
+
+  assert.equal(upgradeCalls, 1, "the verified old service is retired only once");
+  assert.equal(runtimeStarts, 0, "a stranger is never replaced by a second runtime");
+});
+
+test("packaged upgrade handoff times out without starting a second runtime", async (t) => {
+  const root = await temporaryRoot(t, "mosa-service-upgrade-timeout-");
+  const libraryDir = join(root, "library");
+  const port = await availablePort();
+  const oldServer = createServer((_req, res) => {
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({
+      product: "mosa",
+      libraryDir,
+      storage: "sqlite",
+      productVersion: "0.2.0",
+      gitSha: "old-sha",
+      uiFingerprint: "old-ui",
+      runtimeFingerprint: "old-runtime",
+    }));
+  });
+  await listen(oldServer, port);
+  t.after(() => close(oldServer));
+
+  let now = 0;
+  let runtimeStarts = 0;
+  await assert.rejects(
+    startMosaService({
+      port,
+      libraryDir,
+      expectedIdentity: {
+        productVersion: "0.2.1-rc.2",
+        gitSha: "target-sha",
+        uiFingerprint: "target-ui",
+        runtimeFingerprint: "target-runtime",
+      },
+      allowStaleServiceUpgrade: true,
+      upgradeService: async () => {
+        await close(oldServer);
+        return true;
+      },
+      upgradeProbeImpl: async () => ({ state: "unavailable" }),
+      upgradeReadyNowImpl: () => now,
+      upgradeReadySleepImpl: async (delayMs) => { now += delayMs; },
+      upgradeReadyTimeoutMs: 300,
+      upgradeReadyPollMs: 100,
+      startRuntime: async () => {
+        runtimeStarts += 1;
+        throw new Error("startRuntime must not run after retirement");
+      },
+    }),
+    (error) => {
+      assert.ok(error instanceof MosaServiceConflictError);
+      assert.doesNotMatch(error.message, /sha|fingerprint/i);
+      return true;
+    },
+  );
+  assert.equal(runtimeStarts, 0);
 });
 
 test("controlled retirement requires matching service identity and lock owner, then sends SIGTERM only", async () => {


### PR DESCRIPTION
Promotes 0.2.1-rc.1 through rc.3. Adds safe packaged stale-runtime handoff, waits for KeepAlive replacement readiness, preserves fail-closed boundaries, and packages macOS/Windows rc.3.\n\nValidated locally: npm test (965 passed, 2 skipped), npm run lint, npm run check, macOS/Windows packaging.