### PR TITLE
docs: keep download links version-neutral

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ MOSA is a local-first library for AI-generated images, videos, Prompts, provenan
 
 ## Downloads
 
-Download the current MOSA packages from the [official download page](https://mosa.azhuilab.com/#download). The page and its [release manifest](https://mosa.azhuilab.com/releases/latest.json) are the source of truth for newer versions, package sizes, and SHA-256 values.
+Download the current MOSA packages from the [official download page](https://mosa.azhuilab.com/#download). The page and its [release manifest](https://mosa.azhuilab.com/releases/latest.json) are the source of truth for newer versions, package sizes, and SHA-256 values. These links intentionally stay version-neutral so publishing a new package does not require another README edit.
 
-| Package | Platform | Download | Status |
+| Package | Platform | Download | Update source |
 | --- | --- | --- | --- |
-| MOSA Desktop `0.2.1-rc.4` | macOS arm64 | [Download ZIP](https://mosa.azhuilab.com/downloads/MOSA-darwin-arm64-0.2.1-rc.4.zip) | Preview package; unsigned |
-| MOSA Desktop `0.2.1-rc.4` | Windows x64 | [Download ZIP](https://mosa.azhuilab.com/downloads/MOSA-win32-x64-0.2.1-rc.4.zip) | Preview package; unsigned |
-| MOSA Web Capture `0.14.5` | Chrome / Chromium | [Download ZIP](https://mosa.azhuilab.com/downloads/MOSA-Web-Capture-0.14.5.zip) · [Install guide](https://mosa.azhuilab.com/guide/) | Developer-mode package; not a signed CRX |
+| MOSA Desktop | macOS arm64 | [Download latest package](https://mosa.azhuilab.com/#download) | Official page resolves the current package from the release manifest |
+| MOSA Desktop | Windows x64 | [Download latest package](https://mosa.azhuilab.com/#download) | Official page resolves the current package from the release manifest |
+| MOSA Web Capture | Chrome / Chromium | [Download latest package](https://mosa.azhuilab.com/#download) · [Install guide](https://mosa.azhuilab.com/guide/) | Official page maintains the current developer-mode ZIP; not a signed CRX |
 
-Desktop ZIPs are hosted outside Git history because of their size. Use the official download page for the newest published package; the direct links above identify the currently published files.
+Desktop ZIPs are hosted outside Git history because of their size. The official page is the canonical download entry for all packages; versioned filenames and package metadata may change there without requiring a source repository commit.
 
 ## Why MOSA
 


### PR DESCRIPTION
## Summary
- route README download entries through the official download page
- remove hard-coded package versions and filenames from the GitHub homepage
- keep the official site and release manifest as the source of truth

## Verification
- git diff --check
- existing package publishing remains outside Git history