### PR TITLE
Harden gallery selection and desktop runtime handoff

### DIFF
--- a/app/app.mjs
+++ b/app/app.mjs
@@ -63,7 +63,7 @@ function sourceTypeLabel(type) {
 
 const preference = safeStorageGet("mosa.ui-language") || "system";
 const state = {
-  project: "default", projects: [], cowartCanvases: [], assets: [], pageTotal: 0, nextCursor: null, loadedPageCount: 0, selectedId: null, selectedIds: new Set(), selectionProject: "default", detailAsset: null, versionHistory: null, recipeHistory: null, generationHistory: null, detailOpen: false, detailDirty: false, detailReturnFocus: null, imagePreviewId: null, previewReturnFocus: null, query: "",
+  project: "default", projects: [], cowartCanvases: [], assets: [], pageTotal: 0, nextCursor: null, loadedPageCount: 0, selectedId: null, selectedIds: new Set(), selectedStackNodes: new Map(), selectionProject: "default", selectionRequestKey: "", detailAsset: null, versionHistory: null, recipeHistory: null, generationHistory: null, detailOpen: false, detailDirty: false, detailReturnFocus: null, imagePreviewId: null, previewReturnFocus: null, query: "",
   scope: "all", facets: { source: "", group: "", category: "", style: "", conversation: "", generationBatch: "" }, sort: normalizeSort(safeStorageGet("mosa.asset-sort")),
   mediaKind: "all",
   groups: { total: 0, favorites: 0, recent: 0, unorganized: 0, trash: 0, codex: 0, cowart: 0, sourceTypes: [], groups: [], categories: [], styles: [], styleTotal: 0 },
@@ -209,7 +209,16 @@ Object.assign(els, {
   confirmDialogConfirm: document.querySelector("#confirmDialogConfirm"),
 });
 
-const gallerySelection = createGallerySelection({ els, state, t, announceGalleryStatus });
+const gallerySelection = createGallerySelection({
+  els,
+  state,
+  t,
+  announceGalleryStatus,
+  currentAssetRequest,
+  requestAssetPage,
+  apiFetch,
+  showToast,
+});
 const assetStacks = createAssetStackController({
   els,
   state,
@@ -577,9 +586,14 @@ function setupKeyboardShortcuts() {
     // and paste handlers that MOSA does not own.
     if ((event.metaKey || event.ctrlKey) && (event.key === "a" || event.key === "A" || event.key === "v" || event.key === "V")) {
       if (event.target.matches?.("input, textarea, select, [contenteditable]")) return;
+      if (confirmDialogState.pending
+        || els.importModal?.classList.contains("open")
+        || els.groupModal?.classList.contains("open")
+        || !els.imagePreviewModal?.hidden
+        || !els.settingsMenu?.hidden) return;
       if ((event.key === "a" || event.key === "A") && state.viewMode === "library" && state.assets.length) {
         event.preventDefault();
-        gallerySelection.selectAll({ announce: true });
+        void gallerySelection.selectAll({ announce: true });
         return;
       }
       // In Electron, the paste event handler in bindDesktopIntegration imports
@@ -692,7 +706,7 @@ function setupKeyboardShortcuts() {
       if (asset) {
         event.preventDefault();
         if (!state.activeStackId && asset.stack?.id) void assetStacks.enterStack(asset.stack.id, asset.stack);
-        else openImagePreview(asset.id, els.assetGrid?.querySelector(`.asset-card[data-id="${CSS.escape(asset.id)}"] .asset-card-select`));
+        else void openAssetView(asset.id, els.assetGrid?.querySelector(`.asset-card[data-id="${CSS.escape(asset.id)}"] .asset-card-select`));
         return;
       }
     }
@@ -1170,6 +1184,7 @@ const contextMenuActions = createContextMenuActions({
   copyOriginalImage: writeClipboardImage,
   isVideoAsset,
   pasteClipboardImage: window.electronAPI?.pasteImage ? pasteClipboardImage : null,
+  gallerySelection,
 });
 
 async function releaseAssetMediaForDeletion(assets = []) {
@@ -1489,7 +1504,7 @@ function bindEvents() {
   });
   els.activeFilters?.addEventListener("click", (event) => { const chip = event.target.closest("[data-chip]"); if (chip) void removeFilterChip(chip.dataset.chip); });
   els.detailPanel?.addEventListener("click", handleReferenceRightsOpen);
-  els.assetGrid?.addEventListener("click", (event) => {
+  els.assetGrid?.addEventListener("click", async (event) => {
     if (gallerySelection.handleGridClick(event)) return;
     const favoriteButton = event.target.closest(".card-favorite");
     if (favoriteButton) {
@@ -1510,6 +1525,10 @@ function bindEvents() {
     }
     const selectButton = event.target.closest(".asset-card-select");
     if (selectButton) {
+      // A browser emits the second click before dblclick. Let the dedicated
+      // dblclick handler own that second activation so one double-click never
+      // repeats Inspector selection work immediately before entering Viewer.
+      if (event.detail > 1) return;
       const id = selectButton.closest(".asset-card")?.dataset.id;
       if (id && gallerySelection.handleCardClick(event, id)) return;
       if (id) {
@@ -1519,11 +1538,11 @@ function bindEvents() {
           // A collapsed Stack is a logical gallery node. Single-click only
           // selects it; navigation is reserved for double-click (or Enter),
           // which prevents accidental entry while browsing or marqueeing.
-          if (!state.detailOpen && state.viewMode === "library") {
-            clearDetailSelection();
-            state.selectedId = id;
-            updateSelectedCard();
-          }
+          if (state.viewMode !== "library") return;
+          if (state.detailOpen && !await closeDetailSurface()) return;
+          clearDetailSelection();
+          state.selectedId = id;
+          updateSelectedCard();
           return;
         }
         void selectAsset(id);
@@ -1558,11 +1577,11 @@ function bindEvents() {
     const id = card?.dataset.id;
     if (!id) return;
     const asset = state.assets.find((item) => item.id === id);
-    if (card?.dataset.stackId || asset?.stack?.id) {
-      if (!state.activeStackId && asset?.stack?.id) void assetStacks.enterStack(asset.stack.id, asset.stack);
+    if (!state.activeStackId && (card?.dataset.stackId || asset?.stack?.id)) {
+      if (asset?.stack?.id) void assetStacks.enterStack(asset.stack.id, asset.stack);
       return;
     }
-    openImagePreview(id, selectButton);
+    void openAssetView(id, selectButton);
   });
   els.emptyTrashBtn?.addEventListener("click", async () => {
     if (state.scope !== "trash" || !Number(state.groups?.trash || 0)) return;
@@ -1811,10 +1830,8 @@ function bindEvents() {
     if (!els.imagePreviewModal?.hidden && els.imagePreviewImage?.getAttribute("src")) showToast(t("imageLoadFailed"), "error");
   });
   els.assetViewBack?.addEventListener("click", () => { void closeDetailSurface(); });
-  // Phase 3A 运行时修复（双击进入路径）：第一次 click 已打开查看模式并同步聚焦返回按钮，
-  // 紧随的第二次 mousedown 落在同坐标的舞台/主图上——浏览器默认动作会把焦点清到 BODY，
-  // 使打开焦点丢失。阻止舞台与主图 mousedown 的默认焦点转移（不改布局/不新增状态）；
-  // 视频元素排除在外，保留原生 controls 交互；缩放/平移接入（Phase 3B）时在同一监听器扩展。
+  // Phase 3A：Viewer 打开后返回按钮拥有进入焦点。舞台/主图上的普通 mousedown
+  // 不应把焦点无意义地清到 BODY；视频元素排除在外，保留原生 controls 交互。
   els.assetViewStage?.addEventListener("mousedown", (event) => {
     if (event.target === els.assetViewStage || event.target === els.assetViewImage) event.preventDefault();
   });
@@ -1848,6 +1865,7 @@ function bindEvents() {
     openAssetView,
     showToast,
     t,
+    gallerySelection,
   });
   // Phase 5B：ConfirmDialog 陷阱先于其余陷阱注册——Escape 优先级链最前（preventDefault +
   // stopPropagation，不穿透 Viewer/既有 Modal）；ConfirmDialog 未打开时后续陷阱照常工作。
@@ -2410,7 +2428,7 @@ function replaceVirtualGalleryCards(observerEntries) {
     const hydrate = item.isIntersecting;
     if (hydrate && !card.classList.contains("asset-card-virtual-placeholder")) continue;
     if (!hydrate && card.classList.contains("asset-card-virtual-placeholder")) continue;
-    if (!hydrate && (card.contains(document.activeElement) || card.classList.contains("selected") || card.classList.contains("multi-selected") || card.matches(".stack-drop-target, .stack-reorder-target"))) continue;
+    if (!hydrate && (card.contains(document.activeElement) || card.classList.contains("selected") || card.matches(".stack-drop-target, .stack-reorder-target"))) continue;
 
     if (!hydrate) {
       const span = Number.parseInt(String(card.style.gridRowEnd || "").replace(/\D+/g, ""), 10);

--- a/app/asset-stacks.mjs
+++ b/app/asset-stacks.mjs
@@ -147,6 +147,7 @@ export function createAssetStackController({
       scrollTop: els.assetGrid?.scrollTop || 0,
       selectedId: state.selectedId || "",
       selectedIds: [...(state.selectedIds instanceof Set ? state.selectedIds : new Set())],
+      selectedStackNodes: [...(state.selectedStackNodes instanceof Map ? state.selectedStackNodes : new Map())],
       stackId,
     };
     state.activeStackId = stackId;
@@ -199,6 +200,7 @@ export function createAssetStackController({
         if (returnCard?.dataset.id) state.selectedId = returnCard.dataset.id;
         const visibleIds = new Set((state.assets || []).map((asset) => asset.id));
         state.selectedIds = new Set((snapshot.selectedIds || []).filter((id) => visibleIds.has(id)));
+        state.selectedStackNodes = new Map((snapshot.selectedStackNodes || []).filter(([id]) => visibleIds.has(id)));
         els.assetGrid.querySelectorAll(":scope > .asset-card").forEach((card) => {
           card.classList.toggle("selected", Boolean(state.selectedId && card.dataset.id === state.selectedId));
         });
@@ -213,6 +215,7 @@ export function createAssetStackController({
 
   async function createStackFromSelection(coverAssetId = "") {
     if (state.activeStackId || state.scope === "trash" || state.storageKind !== "sqlite") return false;
+    if (gallerySelection.hasSelectedStacks?.()) return false;
     const selectedIds = [...(state.selectedIds instanceof Set ? state.selectedIds : new Set())];
     if (selectedIds.length < 2) return false;
     const coverId = coverAssetId && selectedIds.includes(coverAssetId)

--- a/app/context-menu-actions.mjs
+++ b/app/context-menu-actions.mjs
@@ -3,7 +3,7 @@
  * Defines all context menu items and their actions
  */
 
-export function createContextMenuActions({ state, els, t, apiClient, showToast, runAction, requestConfirmation, requestFollowupConfirmation, confirmDetailNavigation, discardDetailDraft, releaseAssetMedia, openGroupModal, getGroupColor, saveGroupColor, writeClipboardText, copyOriginalImage, isVideoAsset, pasteClipboardImage }) {
+export function createContextMenuActions({ state, els, t, apiClient, showToast, runAction, requestConfirmation, requestFollowupConfirmation, confirmDetailNavigation, discardDetailDraft, releaseAssetMedia, openGroupModal, getGroupColor, saveGroupColor, writeClipboardText, copyOriginalImage, isVideoAsset, pasteClipboardImage, gallerySelection }) {
   const { apiFetch } = apiClient;
   // getGroupColor falls back to the deterministic palette so call sites can rely
   // on a single source of truth for group colors (mirrors app.mjs colorForGroup).
@@ -59,6 +59,32 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
       else failed.push(asset);
     }
     return { succeeded, failed };
+  }
+
+  function logicalSelectionCount(selectedAssets = [], options = {}) {
+    const count = Number(options.selectionCount);
+    return Number.isFinite(count) && count > 0 ? count : Math.max(1, selectedAssets.length);
+  }
+
+  async function selectedMutationIds(asset, selectedAssets = [], options = {}) {
+    const count = logicalSelectionCount(selectedAssets, options);
+    if (count > 1 && typeof gallerySelection?.resolveSelectedAssetIds === "function") {
+      const ids = await gallerySelection.resolveSelectedAssetIds();
+      if (ids.length) return ids;
+    }
+    return [asset.id];
+  }
+
+  function mutationAssetsForIds(ids = []) {
+    const loaded = new Map((state.assets || []).map((entry) => [entry.id, entry]));
+    return ids.map((id) => loaded.get(id) || { id, project_id: state.project });
+  }
+
+  async function applyGroupMutation(ids, group) {
+    return apiFetch("/api/assets/batch", {
+      method: "POST",
+      body: { action: "group", projectId: state.project, assetIds: ids, group },
+    });
   }
 
   // Full manifest of one group via the existing paged asset query. Never cap a
@@ -203,13 +229,15 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
    */
   function getAssetMenu(asset, selectedAssets = [], options = {}) {
     if (state.scope === "trash") {
-      const assets = selectedAssets.length > 1 ? selectedAssets : [asset];
+      const selectionCount = logicalSelectionCount(selectedAssets, options);
       return [
         {
-          label: assets.length > 1 ? t("restoreAssets", { count: assets.length }) : t("restoreAsset"),
+          label: selectionCount > 1 ? t("restoreAssets", { count: selectionCount }) : t("restoreAsset"),
           icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 8v5h5"/><path d="M5.5 13a7 7 0 1 0 2-7"/></svg>',
           action: async () => {
             await runAction(async () => {
+              const ids = await selectedMutationIds(asset, selectedAssets, options);
+              const assets = mutationAssetsForIds(ids);
               for (const item of assets) {
                 await apiFetch(`/api/assets/${encodeURIComponent(item.project_id)}/${encodeURIComponent(item.id)}/restore`, { method: "POST" });
               }
@@ -225,6 +253,8 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
           icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 6h18M8 6V4h8v2m2 0-1 15H7L6 6"/><path d="M10 10v7M14 10v7"/></svg>',
           danger: true,
           action: async () => {
+            const ids = await selectedMutationIds(asset, selectedAssets, options);
+            const assets = mutationAssetsForIds(ids);
             const confirmed = await requestConfirmation({
               title: assets.length > 1 ? t("permanentDeleteAssetsTitle", { count: assets.length }) : t("permanentDeleteTitle"),
               description: t("permanentDeleteDescription"),
@@ -251,7 +281,7 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
         },
       ];
     }
-    if (options.stackNode && asset?.stack?.id) {
+    if (options.stackNode && asset?.stack?.id && logicalSelectionCount(selectedAssets, options) === 1) {
       return [
         {
           label: t("openStack"),
@@ -284,7 +314,8 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
         },
       ];
     }
-    const isMultiple = selectedAssets.length > 1;
+    const selectionCount = logicalSelectionCount(selectedAssets, options);
+    const isMultiple = selectionCount > 1;
     const items = [];
 
     if (!isMultiple) {
@@ -354,7 +385,8 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
         ? '<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="1.8"><path d="m12 3 2.8 5.7 6.2.9-4.5 4.4 1.1 6.2-5.6-3-5.6 3 1.1-6.2L3 9.6l6.2-.9L12 3Z"/></svg>'
         : '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="m12 3 2.8 5.7 6.2.9-4.5 4.4 1.1 6.2-5.6-3-5.6 3 1.1-6.2L3 9.6l6.2-.9L12 3Z"/></svg>',
       action: async () => {
-        const assets = isMultiple ? selectedAssets : [asset];
+        const ids = await selectedMutationIds(asset, selectedAssets, options);
+        const assets = mutationAssetsForIds(ids);
         await runAction(async () => {
           if (isMultiple) {
             const response = await apiFetch("/api/assets/batch", {
@@ -362,7 +394,7 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
               body: {
                 action: "favorite",
                 projectId: state.project,
-                assetIds: assets.map((entry) => entry.id),
+                assetIds: ids,
                 favorite: !asset.favorite,
               },
             });
@@ -398,17 +430,15 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
         {
           label: t("noGroup"),
           action: async () => {
-            const assets = isMultiple ? selectedAssets : [asset];
+            const ids = await selectedMutationIds(asset, selectedAssets, options);
+            const assets = mutationAssetsForIds(ids);
             if (!await confirmSelectedAssetMutation(assets)) return;
             await runAction(async () => {
-              for (const a of assets) {
-                await apiFetch(`/api/assets/${encodeURIComponent(a.project_id)}/${encodeURIComponent(a.id)}`, {
-                  method: "PATCH",
-                  body: { group: "" },
-                });
-              }
+              const response = await applyGroupMutation(ids, "");
+              const outcome = reconcileBatchMutation(assets, response);
               commitSelectedAssetMutation(assets);
-              showToast(t("movedToGroup"), "success");
+              if (outcome.failed.length) showToast(t("batchPartialResult", { succeeded: outcome.succeeded.length, failed: outcome.failed.length }), "error");
+              else showToast(t("movedToGroup"), "success");
               window.dispatchEvent(new CustomEvent("mosa:refresh-assets"));
             });
           },
@@ -422,17 +452,15 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
             label: groupName,
             icon: `<svg width="14" height="14" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" fill="${savedColor}"/></svg>`,
             action: async () => {
-              const assets = isMultiple ? selectedAssets : [asset];
+              const ids = await selectedMutationIds(asset, selectedAssets, options);
+              const assets = mutationAssetsForIds(ids);
               if (!await confirmSelectedAssetMutation(assets)) return;
               await runAction(async () => {
-                for (const a of assets) {
-                  await apiFetch(`/api/assets/${encodeURIComponent(a.project_id)}/${encodeURIComponent(a.id)}`, {
-                    method: "PATCH",
-                    body: { group: groupName },
-                  });
-                }
+                const response = await applyGroupMutation(ids, groupName);
+                const outcome = reconcileBatchMutation(assets, response);
                 commitSelectedAssetMutation(assets);
-                showToast(t("movedToGroup"), "success");
+                if (outcome.failed.length) showToast(t("batchPartialResult", { succeeded: outcome.succeeded.length, failed: outcome.failed.length }), "error");
+                else showToast(t("movedToGroup"), "success");
                 window.dispatchEvent(new CustomEvent("mosa:refresh-assets"));
               });
             },
@@ -475,6 +503,7 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
     items.push({
       label: t("exportAsset"),
       icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5-5 5 5"/><path d="M12 5v12"/></svg>',
+      disabled: isMultiple && (selectedAssets.length !== selectionCount || Boolean(gallerySelection?.hasSelectedStacks?.())),
       action: async () => {
         const assets = isMultiple ? selectedAssets : [asset];
         await runAction(async () => {
@@ -495,9 +524,10 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
         icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6h14Z"/></svg>',
         danger: true,
         action: async () => {
-          const assets = isMultiple ? selectedAssets : [asset];
+          const ids = await selectedMutationIds(asset, selectedAssets, options);
+          const assets = mutationAssetsForIds(ids);
           const confirmed = await requestConfirmation({
-            title: isMultiple ? t("moveAssetsToTrashTitle", { count: assets.length }) : t("moveToTrashTitle"),
+            title: ids.length > 1 ? t("moveAssetsToTrashTitle", { count: ids.length }) : t("moveToTrashTitle"),
             description: t("moveToTrashDescription"),
             confirmLabel: t("moveToTrash"),
             tone: "danger",
@@ -511,7 +541,7 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
               body: {
                 action: "trash",
                 projectId: state.project,
-                assetIds: assets.map((entry) => entry.id),
+                assetIds: ids,
               },
             });
             const outcome = reconcileBatchMutation(assets, response);

--- a/app/context-menu-bindings.mjs
+++ b/app/context-menu-bindings.mjs
@@ -19,6 +19,7 @@ export function bindContextMenuEvents(options = {}) {
     openAssetView,
     showToast,
     t,
+    gallerySelection,
   } = options;
 
   const bindGroupContextMenu = (list) => list?.addEventListener("contextmenu", (event) => {
@@ -64,17 +65,16 @@ export function bindContextMenuEvents(options = {}) {
 
     const asset = state.assets.find((entry) => entry.id === card.dataset.id);
     if (!asset) return;
-    const selectedIds = state.selectedIds instanceof Set ? state.selectedIds : new Set();
-    const selectedAssets = selectedIds.has(asset.id)
-      ? state.assets.filter((entry) => selectedIds.has(entry.id))
-      : [asset];
-    const selectionContainsStack = !state.activeStackId && selectedAssets.some((entry) => entry.stack?.id);
-    // A mixed root selection may contain logical Stack nodes. A normal asset
-    // menu must never turn those cover IDs into batch mutations.
-    const actionAssets = selectionContainsStack && !asset.stack?.id ? [asset] : selectedAssets;
+    let selectedIds = state.selectedIds instanceof Set ? state.selectedIds : new Set();
+    if (!selectedIds.has(asset.id)) {
+      gallerySelection?.replaceWith?.(asset.id);
+      selectedIds = state.selectedIds instanceof Set ? state.selectedIds : new Set([asset.id]);
+    }
+    const selectedAssets = state.assets.filter((entry) => selectedIds.has(entry.id));
     contextMenu.show({
-      items: contextMenuActions.getAssetMenu(asset, actionAssets, {
+      items: contextMenuActions.getAssetMenu(asset, selectedAssets, {
         stackNode: !state.activeStackId && Boolean(asset.stack?.id),
+        selectionCount: selectedIds.size,
       }),
       x: event.clientX,
       y: event.clientY,
@@ -91,6 +91,9 @@ export function bindContextMenuEvents(options = {}) {
     if (!removedVisibleCount) return 0;
     if (state.selectedIds instanceof Set) {
       for (const id of removedIds) state.selectedIds.delete(id);
+    }
+    if (state.selectedStackNodes instanceof Map) {
+      for (const id of removedIds) state.selectedStackNodes.delete(id);
     }
     if (Number.isFinite(Number(state.pageTotal))) {
       state.pageTotal = Math.max(state.assets.length, Number(state.pageTotal) - removedVisibleCount);

--- a/app/gallery-selection.mjs
+++ b/app/gallery-selection.mjs
@@ -2,6 +2,7 @@ export const MARQUEE_DRAG_THRESHOLD_PX = 3;
 export const MARQUEE_CARD_DRAG_THRESHOLD_PX = 6;
 const AUTO_SCROLL_EDGE_PX = 36;
 const AUTO_SCROLL_MAX_PX = 18;
+const MARQUEE_GEOMETRY_BAND_PX = 512;
 
 export function rectFromPoints(x1, y1, x2, y2) {
   const left = Math.min(x1, x2);
@@ -15,6 +16,17 @@ export function rectsIntersect(a, b) {
   return a.left <= b.right && a.right >= b.left && a.top <= b.bottom && a.bottom >= b.top;
 }
 
+export function selectionRangeIds(assets = [], anchorId = "", targetId = "") {
+  const ids = (assets || []).map((asset) => String(asset?.id || "")).filter(Boolean);
+  const targetIndex = ids.indexOf(String(targetId || ""));
+  if (targetIndex < 0) return targetId ? [String(targetId)] : [];
+  const anchorIndex = ids.indexOf(String(anchorId || ""));
+  if (anchorIndex < 0) return [ids[targetIndex]];
+  const start = Math.min(anchorIndex, targetIndex);
+  const end = Math.max(anchorIndex, targetIndex);
+  return ids.slice(start, end + 1);
+}
+
 function sameIds(a, b) {
   if (a.size !== b.size) return false;
   for (const id of a) if (!b.has(id)) return false;
@@ -25,35 +37,82 @@ function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
 }
 
-export function createGallerySelection({ els, state, t, announceGalleryStatus }) {
+export function createGallerySelection({
+  els,
+  state,
+  t,
+  announceGalleryStatus,
+  currentAssetRequest,
+  requestAssetPage,
+  apiFetch,
+  showToast,
+}) {
   let pointer = null;
   let selectionBox = null;
   let suppressNextGridClick = false;
   let autoScrollFrame = 0;
   let selectionUpdateFrame = 0;
   let pendingSelectionPoint = null;
-  let stackedAssetSetSource = null;
-  let stackedAssetIds = new Set();
+  let selectionAnchorId = "";
+  let selectAllInFlight = false;
+  let selectionRevision = 0;
+
+  function currentSelectionRequestKey() {
+    if (typeof currentAssetRequest !== "function") return "";
+    try {
+      const request = currentAssetRequest();
+      return JSON.stringify([
+        request.project,
+        request.stackId || "",
+        request.query || "",
+        request.scope || "all",
+        request.mediaKind || "all",
+        ...Object.keys(request.facets || {}).sort().map((key) => `${key}:${request.facets[key] || ""}`),
+      ]);
+    } catch {
+      return "";
+    }
+  }
+
+  function ensureStackSelectionMap() {
+    if (!(state.selectedStackNodes instanceof Map)) state.selectedStackNodes = new Map();
+    return state.selectedStackNodes;
+  }
+
+  function resetSelectionState({ requestKey = currentSelectionRequestKey(), resetAnchor = true } = {}) {
+    state.selectedIds = new Set();
+    state.selectedStackNodes = new Map();
+    state.selectionProject = state.project;
+    state.selectionRequestKey = requestKey;
+    if (resetAnchor) selectionAnchorId = "";
+    selectionRevision += 1;
+  }
 
   function ensureSelectionSet() {
     if (!(state.selectedIds instanceof Set)) state.selectedIds = new Set(state.selectedIds || []);
-    if (state.selectionProject !== state.project) {
-      state.selectedIds.clear();
-      state.selectionProject = state.project;
-    }
+    ensureStackSelectionMap();
+    const requestKey = currentSelectionRequestKey();
+    if (state.selectionProject !== state.project
+      || (state.selectionRequestKey && requestKey && state.selectionRequestKey !== requestKey)) {
+      resetSelectionState({ requestKey });
+    } else if (!state.selectionRequestKey && requestKey) state.selectionRequestKey = requestKey;
     return state.selectedIds;
   }
 
-  function loadedIds() {
-    return new Set((state.assets || []).map((asset) => asset.id));
+  function isStackNode(asset) {
+    return !state.activeStackId && Boolean(asset?.stack?.id);
   }
 
-  function currentStackedAssetIds() {
-    if (stackedAssetSetSource !== state.assets) {
-      stackedAssetSetSource = state.assets;
-      stackedAssetIds = new Set((state.assets || []).filter((asset) => asset.stack?.id).map((asset) => asset.id));
+  function reconcileStackSelection(nextSelection, explicitStackNodes = null) {
+    const nextStacks = explicitStackNodes instanceof Map
+      ? new Map([...explicitStackNodes].filter(([id]) => nextSelection.has(id)))
+      : new Map([...ensureStackSelectionMap()].filter(([id]) => nextSelection.has(id)));
+    for (const asset of state.assets || []) {
+      if (!nextSelection.has(asset.id)) continue;
+      if (isStackNode(asset)) nextStacks.set(asset.id, asset.stack.id);
+      else nextStacks.delete(asset.id);
     }
-    return stackedAssetIds;
+    return nextStacks;
   }
 
   function applyCardSelectionState(card, selectedIds) {
@@ -74,9 +133,15 @@ export function createGallerySelection({ els, state, t, announceGalleryStatus })
 
   function syncRenderedSelection({ prune = true, changedIds = null } = {}) {
     const selectedIds = ensureSelectionSet();
-    if (prune) {
-      const validIds = loadedIds();
-      for (const id of selectedIds) if (!validIds.has(id)) selectedIds.delete(id);
+    // Selection may span unloaded cursor pages. Query/project changes clear it
+    // via ensureSelectionSet(), so never prune valid off-DOM IDs merely because
+    // the gallery currently renders only a window of the result set.
+    void prune;
+    const stackNodes = ensureStackSelectionMap();
+    for (const asset of state.assets || []) {
+      if (!selectedIds.has(asset.id)) continue;
+      if (isStackNode(asset)) stackNodes.set(asset.id, asset.stack.id);
+      else stackNodes.delete(asset.id);
     }
 
     if (changedIds instanceof Set) {
@@ -91,11 +156,10 @@ export function createGallerySelection({ els, state, t, announceGalleryStatus })
     if (els.selectionBar) els.selectionBar.hidden = count === 0;
     els.assetGrid?.classList.toggle("selection-active", count > 0);
     if (els.selectionCount) els.selectionCount.textContent = t("batchSelected", { count });
-    if (els.selectionSelectAll) els.selectionSelectAll.disabled = !state.assets.length || count >= state.assets.length;
+    if (els.selectionSelectAll) els.selectionSelectAll.disabled = selectAllInFlight || !state.pageTotal || count >= state.pageTotal;
     if (els.selectionClear) els.selectionClear.disabled = count === 0;
     if (els.selectionStack) {
-      const stackedIds = currentStackedAssetIds();
-      const includesExistingStack = [...selectedIds].some((id) => stackedIds.has(id));
+      const includesExistingStack = ensureStackSelectionMap().size > 0;
       els.selectionStack.disabled = state.scope === "trash" || state.storageKind !== "sqlite" || count < 2 || includesExistingStack;
     }
     if (els.selectionRemoveFromStack) els.selectionRemoveFromStack.disabled = count === 0;
@@ -107,19 +171,22 @@ export function createGallerySelection({ els, state, t, announceGalleryStatus })
     announceGalleryStatus?.(count ? t("batchSelected", { count }) : t("batchCancel"));
   }
 
-  function commitSelection(nextSelection, { announce = false } = {}) {
+  function commitSelection(nextSelection, { announce = false, stackNodes = null, anchorId = null } = {}) {
     const current = ensureSelectionSet();
     const changedIds = new Set();
     for (const id of current) if (!nextSelection.has(id)) changedIds.add(id);
     for (const id of nextSelection) if (!current.has(id)) changedIds.add(id);
     if (!sameIds(current, nextSelection)) state.selectedIds = new Set(nextSelection);
+    state.selectedStackNodes = reconcileStackSelection(nextSelection, stackNodes);
+    if (anchorId !== null) selectionAnchorId = anchorId;
+    selectionRevision += 1;
     syncRenderedSelection({ prune: false, changedIds });
     if (announce) announceSelection();
   }
 
   function clear({ announce = false } = {}) {
     if (!ensureSelectionSet().size) return false;
-    state.selectedIds = new Set();
+    resetSelectionState();
     syncRenderedSelection({ prune: false });
     if (announce) announceSelection();
     return true;
@@ -130,14 +197,88 @@ export function createGallerySelection({ els, state, t, announceGalleryStatus })
     const next = new Set(ensureSelectionSet());
     if (next.has(id)) next.delete(id);
     else next.add(id);
-    commitSelection(next, { announce });
+    commitSelection(next, { announce, anchorId: id });
     return true;
   }
 
-  function selectAll({ announce = true } = {}) {
-    const next = new Set((state.assets || []).map((asset) => asset.id));
-    if (!next.size) return false;
-    commitSelection(next, { announce });
+  function selectRange(id, { additive = false, announce = true } = {}) {
+    if (!id) return false;
+    const range = selectionRangeIds(state.assets, selectionAnchorId || state.selectedId || id, id);
+    const next = additive ? new Set(ensureSelectionSet()) : new Set();
+    range.forEach((assetId) => next.add(assetId));
+    commitSelection(next, { announce, anchorId: id });
+    return true;
+  }
+
+  async function selectAll({ announce = true } = {}) {
+    if (selectAllInFlight || typeof currentAssetRequest !== "function" || typeof requestAssetPage !== "function") return false;
+    ensureSelectionSet();
+    const request = currentAssetRequest();
+    const requestKey = currentSelectionRequestKey();
+    const startRevision = selectionRevision;
+    const next = new Set();
+    const stackNodes = new Map();
+    const seenCursors = new Set();
+    let cursor = "";
+    selectAllInFlight = true;
+    syncRenderedSelection({ prune: false });
+    try {
+      while (true) {
+        if (cursor) {
+          if (seenCursors.has(cursor)) throw new Error("Selection pagination stalled.");
+          seenCursors.add(cursor);
+        }
+        const page = await requestAssetPage(request, { cursor, limit: 250, includeTotal: cursor ? false : true });
+        for (const asset of page.assets || []) {
+          if (!asset?.id) continue;
+          next.add(asset.id);
+          if (!request.stackId && asset.stack?.id) stackNodes.set(asset.id, asset.stack.id);
+        }
+        cursor = page.page?.nextCursor || "";
+        if (!cursor) break;
+      }
+      if (selectionRevision !== startRevision || (requestKey && currentSelectionRequestKey() !== requestKey)) return false;
+      if (!next.size) return false;
+      state.selectionRequestKey = requestKey;
+      commitSelection(next, { announce, stackNodes, anchorId: "" });
+      return true;
+    } catch (error) {
+      showToast?.(error?.message || String(error), "error");
+      return false;
+    } finally {
+      selectAllInFlight = false;
+      syncRenderedSelection({ prune: false });
+    }
+  }
+
+  async function resolveSelectedAssetIds() {
+    const selected = new Set(ensureSelectionSet());
+    const stackNodes = new Map(ensureStackSelectionMap());
+    if (!stackNodes.size) return [...selected];
+    if (typeof apiFetch !== "function") return [...selected].filter((id) => !stackNodes.has(id));
+    for (const [coverId, stackId] of stackNodes) {
+      selected.delete(coverId);
+      const seenCursors = new Set();
+      let cursor = "";
+      while (true) {
+        if (cursor) {
+          if (seenCursors.has(cursor)) throw new Error("Stack selection pagination stalled.");
+          seenCursors.add(cursor);
+        }
+        const params = new URLSearchParams({ project: state.project, limit: "250", includeTotal: "0" });
+        if (cursor) params.set("cursor", cursor);
+        const page = await apiFetch(`/api/asset-stacks/${encodeURIComponent(stackId)}/assets?${params}`);
+        for (const asset of page.assets || []) if (asset?.id) selected.add(asset.id);
+        cursor = page.page?.nextCursor || "";
+        if (!cursor) break;
+      }
+    }
+    return [...selected];
+  }
+
+  function replaceWith(id, { announce = false } = {}) {
+    if (!id) return false;
+    commitSelection(new Set([id]), { announce, anchorId: id });
     return true;
   }
 
@@ -203,6 +344,15 @@ export function createGallerySelection({ els, state, t, announceGalleryStatus })
         },
       };
     }).filter((entry) => entry.id);
+    pointer.cardRectBands = new Map();
+    for (const entry of pointer.cardRects) {
+      const firstBand = Math.floor(entry.rect.top / MARQUEE_GEOMETRY_BAND_PX);
+      const lastBand = Math.floor(entry.rect.bottom / MARQUEE_GEOMETRY_BAND_PX);
+      for (let band = firstBand; band <= lastBand; band += 1) {
+        if (!pointer.cardRectBands.has(band)) pointer.cardRectBands.set(band, []);
+        pointer.cardRectBands.get(band).push(entry);
+      }
+    }
   }
 
   function updateDragSelection(clientX, clientY) {
@@ -233,7 +383,13 @@ export function createGallerySelection({ els, state, t, announceGalleryStatus })
     // Keeping it explicitly also avoids a one-pixel boundary miss at the exact
     // pointer origin and keeps the first card selected during auto-scroll.
     if (pointer.startCardId) next.add(pointer.startCardId);
-    for (const entry of pointer.cardRects || []) if (rectsIntersect(rect, entry.rect)) next.add(entry.id);
+    const candidateById = new Map();
+    const firstBand = Math.floor(rect.top / MARQUEE_GEOMETRY_BAND_PX);
+    const lastBand = Math.floor(rect.bottom / MARQUEE_GEOMETRY_BAND_PX);
+    for (let band = firstBand; band <= lastBand; band += 1) {
+      for (const entry of pointer.cardRectBands?.get(band) || []) candidateById.set(entry.id, entry);
+    }
+    for (const entry of candidateById.values()) if (rectsIntersect(rect, entry.rect)) next.add(entry.id);
     commitSelection(next);
   }
 
@@ -283,6 +439,7 @@ export function createGallerySelection({ els, state, t, announceGalleryStatus })
       lastY: event.clientY,
       additive: event.shiftKey,
       baseSelection: new Set(ensureSelectionSet()),
+      baseStackNodes: new Map(ensureStackSelectionMap()),
       startCardId: startCard?.dataset.id || "",
       dragging: false,
     };
@@ -314,6 +471,7 @@ export function createGallerySelection({ els, state, t, announceGalleryStatus })
     if (!pointer || pointer.id !== event.pointerId) return;
     const completedDrag = pointer.dragging;
     const baseSelection = pointer.baseSelection;
+    const baseStackNodes = pointer.baseStackNodes;
     if (completedDrag && !canceled && pendingSelectionPoint) {
       updateDragSelection(pendingSelectionPoint.x, pendingSelectionPoint.y);
     }
@@ -321,11 +479,19 @@ export function createGallerySelection({ els, state, t, announceGalleryStatus })
     stopAutoScroll();
     removeSelectionBox();
     try { els.assetGrid?.releasePointerCapture(event.pointerId); } catch { /* already released */ }
-    if (canceled && completedDrag) commitSelection(baseSelection);
+    if (canceled && completedDrag) {
+      suppressNextGridClick = false;
+      commitSelection(baseSelection, { stackNodes: baseStackNodes });
+    }
     else if (completedDrag) {
       announceSelection();
       window.setTimeout(() => { suppressNextGridClick = false; }, 0);
     }
+  }
+
+  function cancelPointerGesture() {
+    if (!pointer) return;
+    endPointer({ pointerId: pointer.id }, { canceled: true });
   }
 
   function handleGridClick(event) {
@@ -339,10 +505,15 @@ export function createGallerySelection({ els, state, t, announceGalleryStatus })
   }
 
   function handleCardClick(event, id) {
-    if (!(event.metaKey || event.ctrlKey)) return false;
-    event.preventDefault();
-    toggle(id, { announce: true });
-    return true;
+    if (event.shiftKey) {
+      event.preventDefault();
+      return selectRange(id, { additive: Boolean(event.metaKey || event.ctrlKey), announce: true });
+    }
+    if (event.metaKey || event.ctrlKey) {
+      event.preventDefault();
+      return toggle(id, { announce: true });
+    }
+    return false;
   }
 
   function bind() {
@@ -354,13 +525,17 @@ export function createGallerySelection({ els, state, t, announceGalleryStatus })
     window.addEventListener("pointermove", movePointer, { capture: true });
     window.addEventListener("pointerup", (event) => endPointer(event), { capture: true });
     window.addEventListener("pointercancel", (event) => endPointer(event, { canceled: true }), { capture: true });
+    els.assetGrid.addEventListener("lostpointercapture", () => {
+      if (pointer?.dragging) cancelPointerGesture();
+    });
     // Browser-native image dragging competes with marquee pointer events when
     // the gesture begins directly on a thumbnail. MOSA has no internal card
     // drag operation, so suppress only drags originating from an asset card.
     els.assetGrid.addEventListener("dragstart", (event) => {
       if (event.target.closest?.(".asset-card")) event.preventDefault();
     });
-    els.selectionSelectAll?.addEventListener("click", () => selectAll({ announce: true }));
+    window.addEventListener("blur", cancelPointerGesture);
+    els.selectionSelectAll?.addEventListener("click", () => { void selectAll({ announce: true }); });
     els.selectionClear?.addEventListener("click", () => clear({ announce: true }));
   }
 
@@ -368,7 +543,11 @@ export function createGallerySelection({ els, state, t, announceGalleryStatus })
     bind,
     clear,
     toggle,
+    replaceWith,
     selectAll,
+    selectRange,
+    resolveSelectedAssetIds,
+    hasSelectedStacks: () => ensureStackSelectionMap().size > 0,
     syncRenderedSelection,
     handleGridClick,
     handleCardClick,

--- a/app/styles.css
+++ b/app/styles.css
@@ -377,12 +377,8 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
 
 /* ===== 瀑布流图库（CSS grid 1px 行高 + JS span 计算，行优先、分页友好） ===== */
 .grid { display: grid; flex: 1; min-width: 0; grid-auto-flow: row; grid-auto-rows: 1px; grid-template-columns: repeat(4, minmax(0, 1fr)); align-content: start; column-gap: var(--gallery-gap); row-gap: 0; overflow: auto; padding: var(--space-2) 20px var(--space-3); background: var(--app-bg); }
-/* Phase 2C / Batch bar 底部补偿（任务十二）：批量条（--statusbar-height + 1px 边框）
-   出现时末行卡片让位，关闭后仅保留 --space-3 常规呼吸位，不残留多余底部空白；
-   补偿全部消费 Token，无魔法值。batch-active 挂在 .grid 上（app.js 既有行为，不改 JS），
-   详情面板经 :has 关联同步让位，其底部操作不被批量条遮挡。 */
-.grid.batch-active { padding-bottom: calc(var(--statusbar-height) + var(--space-2)); }
-.shell:has(.grid.batch-active) .detail { padding-bottom: var(--statusbar-height); }
+/* Batch bar compensation follows the single live selection state. */
+.shell:has(.grid.selection-active) .detail { padding-bottom: var(--statusbar-height); }
 @media (max-width: 1400px) { .grid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
 @media (max-width: 900px) { .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 
@@ -426,7 +422,6 @@ body.asset-stack-dragging { cursor: grabbing; user-select: none; }
 .card-check svg { width: 10px; height: 10px; }
 .asset-card.selected .card-check { display: grid; }
 .asset-card.multi-selected .card-check { display: grid; }
-.batch-active .card-check { display: none; }
 .thumb { display: block; width: 100%; height: auto; background: var(--app-hover); }
 .thumb.gallery-media-unloaded { visibility: hidden; }
 .thumb.image-thumb-pending { min-height: 96px; background: linear-gradient(110deg, var(--app-hover) 8%, var(--app-sidebar) 18%, var(--app-hover) 33%); background-size: 200% 100%; animation: asset-thumb-pending 1.4s linear infinite; }
@@ -455,14 +450,6 @@ body.asset-stack-dragging { cursor: grabbing; user-select: none; }
 .card-action-btn:hover { background: rgb(12 10 9 / 0.92); }
 .card-action-btn svg { width: 15px; height: 15px; }
 .card-favorite.is-fav svg { fill: currentColor; }
-
-/* 批量模式复选框 */
-.asset-card .card-checkbox { position: absolute; z-index: 3; top: 8px; left: 8px; display: flex; width: 20px; height: 20px; align-items: center; justify-content: center; margin: 0; padding: 0; border: 2px solid color-mix(in srgb, var(--color-media-text) 80%, transparent); border-radius: var(--radius-control); background: color-mix(in srgb, var(--color-media-backdrop) 25%, transparent); cursor: pointer; opacity: 0; appearance: none; transition: opacity .15s ease; }
-.asset-card:hover .card-checkbox, .asset-card .card-checkbox:checked { opacity: 1; }
-.asset-card .card-checkbox:checked { border-color: var(--color-accent); background: var(--color-accent); }
-.asset-card .card-checkbox:checked::after { content: "✓"; color: var(--color-accent-contrast); font-size: 11px; font-weight: 700; }
-.batch-active .asset-card .card-checkbox { opacity: 1; }
-.card-checkbox:focus-visible { outline: 2px solid var(--color-focus-ring); outline-offset: 1px; opacity: 1; }
 
 /* 信息密度：隐藏而非移除，切换密度不会改变卡片顺序。V2：去卡片边框后信息区
    不再需要 border-top 分隔线；标题字号提升、元数据改 mono 字体并降级为三级文字，
@@ -1118,7 +1105,7 @@ input::placeholder, textarea::placeholder { color: var(--color-text-tertiary); }
    子按钮级抑制覆盖 hover / focus-within / selected / 收藏常显与触摸常显回退，
    操作区保持隐藏；批量复选框与批量工具栏为唯一操作路径。特异性：(0,4,0) 显式变体
    赢过所有显现规则（最高 (0,3,0)），基础 (0,3,0) 规则同源后写赢过触摸回退 (0,1,0)。 */
-.batch-active .asset-card .card-action-btn, .batch-active .asset-card:hover .card-action-btn, .batch-active .asset-card:focus-within .card-action-btn, .batch-active .asset-card.selected .card-action-btn { opacity: 0; pointer-events: none; }
+.selection-active .asset-card .card-action-btn, .selection-active .asset-card:hover .card-action-btn, .selection-active .asset-card:focus-within .card-action-btn, .selection-active .asset-card.selected .card-action-btn { opacity: 0; pointer-events: none; }
 
 /* ===== 响应式 ===== */
 /* Phase 2B / F-18：≤1399px 档（验证视口 1179×740 与 960×640 同属此收敛路径）——
@@ -1215,7 +1202,7 @@ input::placeholder, textarea::placeholder { color: var(--color-text-tertiary); }
   .toast { transition: none; transform: none; }
   .asset-view-control, .asset-view-fit, .asset-view-nav-btn { transition: none; }
   .segmented-btn, .segmented-thumb, .toolbar-icon, .toolbar-filter, .create-button, .icon-button,
-  .card-checkbox, .action-btn, .mini-btn, .prompt-text, input, textarea, select,
+  .action-btn, .mini-btn, .prompt-text, input, textarea, select,
   .btn-primary, .btn-secondary, .btn-danger { transition: none; }
 }
 
@@ -1310,7 +1297,7 @@ html.electron-shell body.mosa-v2 .brand-info h1 { margin-left: 76px; }
   .mosa-v2 .card-favorite:not(.is-fav):hover { color: rgb(255 255 255 / .88); background: transparent; opacity: 1; }
   .mosa-v2 .card-favorite.is-fav:hover { color: var(--color-danger); background: transparent; opacity: .82; }
 }
-.mosa-v2 .card-quick-copy { display: none; }.mosa-v2 .card-checkbox { border-radius: 50%; }
+.mosa-v2 .card-quick-copy { display: none; }
 .mosa-v2 .gallery-skeleton { grid-template-columns: repeat(5, minmax(0, 1fr)); gap: var(--gallery-gap); padding: 0; }.mosa-v2 .asset-skeleton { border-radius: 8px; background: linear-gradient(100deg, var(--app-search) 30%, var(--app-search-focus) 45%, var(--app-search) 60%); }.mosa-v2 .gallery-empty-state, .mosa-v2 .error-state { color: var(--color-text-tertiary); }.mosa-v2 .empty-state-actions .btn-primary { background: #2424ff; }
 
 .mosa-v2 .filter-panel, .mosa-v2 .settings-menu { border: 1px solid rgb(255 255 255 / .68); border-radius: 16px; background: rgb(from var(--app-menu) r g b / .92); box-shadow: 0 18px 42px -10px rgb(0 0 0 / .16); backdrop-filter: blur(20px) saturate(160%); -webkit-backdrop-filter: blur(20px) saturate(160%); }
@@ -2477,7 +2464,6 @@ html.electron-shell body.mosa-v2 .brand-info h1 { margin-left: 76px; }
   .segmented-btn,
   .toolbar-icon,
   .create-button,
-  .card-checkbox,
   .action-btn,
   .mini-btn,
   .prompt-text,

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -8,7 +8,7 @@ import { DEFAULT_MOSA_DESKTOP_PORT, MOSA_RESERVED_PRODUCTION_PORTS } from "../li
 import { validateRuntimeIsolation } from "../lib/runtime-isolation-guard.mjs";
 import { parseDisabledBridges } from "../lib/runtime-bridges.mjs";
 import { cleanupOrphanStagedFiles, importStagingDir, writeStagedPng } from "../lib/import-staging.mjs";
-import { shouldAllowStaleServiceUpgrade, startMosaService } from "./service-manager.mjs";
+import { shouldAllowSameVersionServiceReplacement, shouldAllowStaleServiceUpgrade, startMosaService } from "./service-manager.mjs";
 import { getDesktopText, getNotificationTextForAssetsImported, getUpdateNotificationText } from "./notification-i18n.mjs";
 import { loadOrCreateWebCaptureToken, MOSA_WEB_CAPTURE_DEFAULT_ORIGINS } from "./web-capture-pairing.mjs";
 import { desktopPlatformAdapter } from "./platform/index.mjs";
@@ -17,6 +17,7 @@ import { prepareAnonymousUsage } from "./anonymous-usage.mjs";
 import { resolveAllowedFolderPath } from "../lib/server-security.js";
 import { isPathInsideOrEqual, isUrlLikePath, pathsEqual } from "../lib/path-safety.mjs";
 import { getBuildIdentity } from "../lib/build-identity.mjs";
+import { MOSA_SERVICE_PROTOCOL_VERSION } from "../lib/version-identities.mjs";
 
 const preloadPath = fileURLToPath(new URL("./preload.cjs", import.meta.url));
 const desktopPlatform = desktopPlatformAdapter();
@@ -25,7 +26,10 @@ const desktopPlatform = desktopPlatformAdapter();
 // when packaged. Deriving it from the module location keeps both modes on a
 // single source of truth instead of the app path API.
 const appRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
-const expectedServiceIdentity = getBuildIdentity(join(appRoot, "app"));
+const expectedServiceIdentity = Object.freeze({
+  ...getBuildIdentity(join(appRoot, "app")),
+  serviceProtocolVersion: MOSA_SERVICE_PROTOCOL_VERSION,
+});
 // `desktopDataDir` is the *actual* userData after Chromium applied the QA
 // --user-data-dir override (if any). It is deliberately NOT the production
 // default: Electron rewrites userData before any JS runs, so the un-overridden
@@ -574,6 +578,14 @@ async function createMainWindow() {
       // port launches stay fail-closed so test tooling never terminates an
       // unrelated local process.
       allowStaleServiceUpgrade: shouldAllowStaleServiceUpgrade({
+        isPackaged: app.isPackaged,
+        qaRun: isolationContext.qaRun,
+        explicitPort: Boolean(process.env.MOSA_DESKTOP_PORT),
+      }),
+      // Source development may safely replace a verified same-version MOSA
+      // owner for the same library. Packaged builds keep the stricter semver
+      // upgrade rule; QA and explicit-port launches remain fail-closed.
+      allowSameVersionServiceReplacement: shouldAllowSameVersionServiceReplacement({
         isPackaged: app.isPackaged,
         qaRun: isolationContext.qaRun,
         explicitPort: Boolean(process.env.MOSA_DESKTOP_PORT),

--- a/desktop/service-manager.mjs
+++ b/desktop/service-manager.mjs
@@ -37,12 +37,22 @@ export class MosaServiceBuildMismatchError extends MosaServiceConflictError {
     this.service = Object.freeze({ ...details });
     this.expectedIdentity = Object.freeze({ ...expectedIdentity });
     this.mismatches = Object.freeze(mismatches.map((item) => Object.freeze({ ...item })));
-    this.upgradeEligible = compareMosaVersions(expectedVersion, runningVersion) === 1;
+    const versionComparison = compareMosaVersions(expectedVersion, runningVersion);
+    this.upgradeEligible = versionComparison === 1;
+    // Source development commonly keeps one package version across several
+    // commits. A verified same-version runtime with a different build identity
+    // is stale for an explicit source desktop launch even though semver cannot
+    // order those two builds.
+    this.sameVersionReplacementEligible = versionComparison === 0;
   }
 }
 
 export function shouldAllowStaleServiceUpgrade({ isPackaged, qaRun, explicitPort } = {}) {
   return isPackaged === true && !qaRun && !explicitPort;
+}
+
+export function shouldAllowSameVersionServiceReplacement({ isPackaged, qaRun, explicitPort } = {}) {
+  return isPackaged !== true && !qaRun && !explicitPort;
 }
 
 /**
@@ -120,16 +130,18 @@ export async function startMosaService(options = {}) {
   // fail-closed unless they explicitly opt in, and same/newer builds are never
   // terminated automatically.
   if (identityMismatch) {
-    if (
-      options.allowStaleServiceUpgrade === true
-      && identityMismatch.upgradeEligible === true
-      && hasCompleteServiceIdentity(identityMismatch.expectedIdentity)
-    ) {
+    const olderUpgradeAllowed = options.allowStaleServiceUpgrade === true
+      && identityMismatch.upgradeEligible === true;
+    const sameVersionReplacementAllowed = options.allowSameVersionServiceReplacement === true
+      && identityMismatch.sameVersionReplacementEligible === true;
+    if ((olderUpgradeAllowed || sameVersionReplacementAllowed)
+      && hasCompleteServiceIdentity(identityMismatch.expectedIdentity)) {
       const upgradeService = options.upgradeService || retireOlderMosaService;
       const retired = await upgradeService(identityMismatch, {
         host,
         fetchImpl: options.fetchImpl,
         probeTimeoutMs: options.probeTimeoutMs,
+        allowSameVersionReplacement: sameVersionReplacementAllowed,
       });
       if (retired) {
         const replacement = await waitForUpgradedMosaService(identityMismatch, {
@@ -221,6 +233,7 @@ export async function probeMosaService(options = {}) {
       port,
       libraryDir,
       storage: typeof health.storage === "string" ? health.storage : "unknown",
+      serviceProtocolVersion: typeof health.serviceProtocolVersion === "string" ? health.serviceProtocolVersion : "unknown",
       productVersion: typeof health.productVersion === "string" ? health.productVersion : "unknown",
       gitSha: typeof health.gitSha === "string" ? health.gitSha : "unknown",
       uiFingerprint: typeof health.uiFingerprint === "string" ? health.uiFingerprint : "unknown",
@@ -244,7 +257,7 @@ export async function probeMosaService(options = {}) {
  * before SIGTERM is sent, and we never escalate to SIGKILL.
  */
 export async function retireOlderMosaService(conflict, options = {}) {
-  if (!(conflict instanceof MosaServiceBuildMismatchError) || conflict.upgradeEligible !== true) return false;
+  if (!isRetirableServiceMismatch(conflict, options)) return false;
   const service = conflict.service;
   if (!service || !Number.isInteger(service.port) || typeof service.libraryDir !== "string") return false;
 
@@ -264,7 +277,7 @@ export async function retireOlderMosaService(conflict, options = {}) {
   const current = await probeImpl(probeOptions);
   if (current.state !== "attached" || !sameReportedServiceIdentity(current, service)) return false;
   const currentConflict = serviceIdentityConflict(current, conflict.expectedIdentity);
-  if (!(currentConflict instanceof MosaServiceBuildMismatchError) || currentConflict.upgradeEligible !== true) return false;
+  if (!isRetirableServiceMismatch(currentConflict, options)) return false;
 
   const isProcessAlive = options.isProcessAlive || defaultIsProcessAlive;
   if (!isProcessAlive(owner.pid)) return false;
@@ -404,7 +417,7 @@ function conflict(message, cause, { retryable = false } = {}) {
 
 function serviceIdentityConflict(details, expectedIdentity) {
   if (!expectedIdentity || typeof expectedIdentity !== "object") return null;
-  const fields = ["productVersion", "gitSha", "uiFingerprint", "runtimeFingerprint"];
+  const fields = ["serviceProtocolVersion", "productVersion", "gitSha", "uiFingerprint", "runtimeFingerprint"];
   const mismatches = [];
   for (const field of fields) {
     const expected = normalizedIdentityValue(expectedIdentity[field]);
@@ -471,8 +484,15 @@ function hasCompleteServiceIdentity(identity) {
 }
 
 function sameReportedServiceIdentity(left, right) {
-  return ["productVersion", "gitSha", "uiFingerprint", "runtimeFingerprint"]
+  return ["serviceProtocolVersion", "productVersion", "gitSha", "uiFingerprint", "runtimeFingerprint"]
     .every((field) => normalizedIdentityValue(left?.[field]) === normalizedIdentityValue(right?.[field]));
+}
+
+function isRetirableServiceMismatch(conflict, options = {}) {
+  if (!(conflict instanceof MosaServiceBuildMismatchError)) return false;
+  if (conflict.upgradeEligible === true) return true;
+  return options.allowSameVersionReplacement === true
+    && conflict.sameVersionReplacementEligible === true;
 }
 
 async function readRuntimeLockOwner(lockPath, readFileImpl) {

--- a/lib/api/asset-routes.mjs
+++ b/lib/api/asset-routes.mjs
@@ -384,7 +384,7 @@ export async function handleAssetRoute({ req, res, url, context }) {
 
   const body = await readJson(req);
   const { action, assetIds } = body;
-  if (!["favorite", "archive", "trash"].includes(action)) {
+  if (!["favorite", "archive", "trash", "group"].includes(action)) {
     sendJson(res, 400, { error: `Unknown batch action: ${action}` });
     return true;
   }
@@ -392,11 +392,21 @@ export async function handleAssetRoute({ req, res, url, context }) {
     sendJson(res, 400, { error: "assetIds must be a non-empty array" });
     return true;
   }
+  if (action === "group" && body.group != null && typeof body.group !== "string") {
+    sendJson(res, 400, { error: "group must be a string" });
+    return true;
+  }
   const projectId = body.projectId || "default";
   const uniqueAssetIds = [...new Set(assetIds)];
+  const groupValue = action === "group" ? String(body.group || "") : "";
   // Resolve every asset before mutating one, so a malformed selection cannot
   // report a complete-looking batch after only its first few rows changed.
-  const currentAssets = await Promise.all(uniqueAssetIds.map((assetId) => store.getAsset(projectId, assetId)));
+  // Only Favorite and Trash need the current rows. Group/archive can mutate by
+  // ID directly, which keeps large Select All operations from doing thousands
+  // of redundant point reads before the first write.
+  const currentAssets = action === "favorite" || action === "trash"
+    ? await Promise.all(uniqueAssetIds.map((assetId) => store.getAsset(projectId, assetId)))
+    : [];
   const favoriteValue = action === "favorite" && typeof body.favorite === "boolean" ? body.favorite : true;
 
   if (action === "trash") {
@@ -466,9 +476,12 @@ export async function handleAssetRoute({ req, res, url, context }) {
           ? current
           : await store.toggleFavorite(projectId, assetId);
         results.push({ id: assetId, favorite: Boolean(updated.favorite) });
-      } else {
+      } else if (action === "archive") {
         await store.archiveAsset(projectId, assetId);
         results.push({ id: assetId, archived: true });
+      } else {
+        await store.updateMetadata(projectId, assetId, { group: groupValue });
+        results.push({ id: assetId, group: groupValue });
       }
     } catch (error) {
       failures += 1;

--- a/lib/api/bridge-routes.mjs
+++ b/lib/api/bridge-routes.mjs
@@ -10,7 +10,7 @@ import {
   WEB_CAPTURE_MAX_VIDEO_BYTES,
 } from "../web-capture-ingest.js";
 import { getBuildIdentity } from "../build-identity.mjs";
-import { MCP_SERVER_VERSION } from "../version-identities.mjs";
+import { MCP_SERVER_VERSION, MOSA_SERVICE_PROTOCOL_VERSION } from "../version-identities.mjs";
 
 // Shared trust bar with the registry and the bridge manager: the canvas must
 // be a real, non-symlink direct child of the project holding a Cowart marker.
@@ -55,11 +55,12 @@ export async function handleBridgeRoute({ req, res, url, context }) {
   } = context;
 
   if (req.method === "GET" && url.pathname === "/api/health") {
-    const identity = getBuildIdentity(context.appDir);
+    const identity = context.buildIdentity || getBuildIdentity(context.appDir);
     sendJson(res, 200, {
       product: "mosa",
       libraryDir,
       storage: store?.storageKind || "json",
+      serviceProtocolVersion: MOSA_SERVICE_PROTOCOL_VERSION,
       productVersion: identity.productVersion,
       mcpServerVersion: MCP_SERVER_VERSION,
       gitSha: identity.gitSha,

--- a/lib/mosa-runtime.mjs
+++ b/lib/mosa-runtime.mjs
@@ -11,6 +11,7 @@ import { createCowartProjectRegistry } from "./cowart-project-registry.js";
 import { createGrokMediaBridge } from "./grok-media-bridge.js";
 import { isAllowedIngestOrigin, isAllowedLocalOrigin, isApprovedExtensionOrigin, parseAllowedIngestOrigins } from "./server-security.js";
 import { createDerivativeWorker } from "./derivative-worker.js";
+import { getBuildIdentity } from "./build-identity.mjs";
 import { acquireMosaRuntimeLock } from "./runtime-lock.js";
 import { cleanupWebCaptureTemp, createWebCaptureIngest } from "./web-capture-ingest.js";
 import { handleApiRequest } from "./api-routes.mjs";
@@ -55,6 +56,7 @@ let derivativeWorker;
 let libraryChangeStream;
 let trashPurgeTimer = null;
 let appDir;
+let runtimeBuildIdentity = null;
 // BUG-01 fix: exact import staging root trusted for the desktop shell's
 // staged imports; null outside Electron so the default boundary is unchanged.
 let importStagingRoot = null;
@@ -98,6 +100,11 @@ export async function startMosaRuntime(options = {}) {
   }));
   webCaptureOrigins = parseAllowedIngestOrigins(options.webCaptureOrigins || env.MOSA_WEB_CAPTURE_ORIGINS);
   appDir = resolve(options.appDir || join(managerDir, "app"));
+  // Freeze the identity of the code/UI pair this process started with. Static
+  // assets are deliberately read from disk on every request, so without this
+  // snapshot a long-lived old runtime could read a newly-written
+  // build-identity.json later and falsely report itself as the new build.
+  runtimeBuildIdentity = Object.freeze({ ...getBuildIdentity(appDir) });
   importStagingRoot = options.importStagingRoot ? resolve(options.importStagingRoot) : null;
   // `disabledBridges` is validated through the shared helper so the server CLI
   // and the desktop shell can never silently accept an unknown bridge name. An
@@ -366,6 +373,7 @@ async function cleanupRuntime() {
   store = null;
   runtimeLock = null;
   importStagingRoot = null;
+  runtimeBuildIdentity = null;
   actualUserData = null;
   if (!server?.listening) server = null;
 
@@ -428,6 +436,7 @@ function apiContext() {
   const effectiveLibraryDir = store?.libraryDir || (store?.assetsRoot ? dirname(store.assetsRoot) : libraryDir);
   return {
     appDir,
+    buildIdentity: runtimeBuildIdentity,
     libraryDir: effectiveLibraryDir,
     actualUserData,
     grokSessionsDir,

--- a/lib/version-identities.mjs
+++ b/lib/version-identities.mjs
@@ -1,1 +1,5 @@
 export const MCP_SERVER_VERSION = "0.2.0";
+// Versioned contract for the local desktop/web runtime health + API surface.
+// A long-lived pre-contract service must never masquerade as the current
+// runtime merely because it is serving freshly-written static files from disk.
+export const MOSA_SERVICE_PROTOCOL_VERSION = "1";

--- a/scripts/desktop-start.mjs
+++ b/scripts/desktop-start.mjs
@@ -25,6 +25,8 @@ import { tmpdir, homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn, execFileSync } from "node:child_process";
+import { getBuildIdentity } from "../lib/build-identity.mjs";
+import { MOSA_SERVICE_PROTOCOL_VERSION } from "../lib/version-identities.mjs";
 
 const __dirname = resolve(fileURLToPath(new URL(".", import.meta.url)));
 const REPO_ROOT = resolve(__dirname, "..");
@@ -47,6 +49,16 @@ const ELECTRON_BIN = process.platform === "darwin"
 const DESKTOP_SCRIPT = "desktop/main.mjs";
 const HEALTH_URL = "http://127.0.0.1:43517/api/health";
 const HEALTH_TIMEOUT_MS = 30_000;
+const EXPECTED_SERVICE_IDENTITY = Object.freeze({
+  ...getBuildIdentity(join(REPO_ROOT, "app")),
+  serviceProtocolVersion: MOSA_SERVICE_PROTOCOL_VERSION,
+});
+
+function healthMatchesCurrentBuild(health) {
+  if (health?.product !== "mosa") return false;
+  return ["serviceProtocolVersion", "productVersion", "gitSha", "uiFingerprint", "runtimeFingerprint"]
+    .every((field) => typeof health?.[field] === "string" && health[field] === EXPECTED_SERVICE_IDENTITY[field]);
+}
 
 function shellQuote(value) {
   return `'${String(value).replaceAll("'", `'"'"'`)}'`;
@@ -163,9 +175,12 @@ async function main() {
     const res = await fetch(HEALTH_URL);
     if (res.ok) {
       const health = await res.json();
-      console.log(`MOSA is already running (pid unknown, libraryDir=${health.libraryDir}).`);
-      console.log(`Health: ${JSON.stringify(health)}`);
-      return;
+      if (healthMatchesCurrentBuild(health)) {
+        console.log(`MOSA is already running (pid unknown, libraryDir=${health.libraryDir}).`);
+        console.log(`Health: ${JSON.stringify(health)}`);
+        return;
+      }
+      console.log("A stale MOSA local service is running; launching the current desktop build so it can perform a verified handoff.");
     }
   } catch {
     // not running, proceed to launch

--- a/test/asset-stack-ui.test.mjs
+++ b/test/asset-stack-ui.test.mjs
@@ -42,8 +42,12 @@ test("visual stack behavior is wired into the shared web and desktop renderer", 
     "collapsed Stack single-click must not navigate");
   assert.match(singleClick, /state\.selectedId = id;[\s\S]*?updateSelectedCard\(\)/,
     "collapsed Stack single-click keeps a lightweight logical selection");
+  assert.match(doubleClick, /if \(!state\.activeStackId && \(card\?\.dataset\.stackId \|\| asset\?\.stack\?\.id\)\)/,
+    "only the collapsed Stack node intercepts double-click; active Stack members remain openable");
   assert.match(doubleClick, /assetStacks\.enterStack\(asset\.stack\.id, asset\.stack\)/,
     "collapsed Stack double-click opens the Stack");
+  assert.match(doubleClick, /void openAssetView\(id, selectButton\)/,
+    "a member double-click inside the active Stack opens the dedicated Viewer");
   assert.match(app, /asset-stack-count/);
   assert.match(app, /stackMatchAccessibleName/);
   assert.match(css, /\.asset-card\.is-stack \.card-actions \{ opacity: 0; pointer-events: none; \}/);
@@ -81,13 +85,16 @@ test("visual stack behavior is wired into the shared web and desktop renderer", 
   assert.match(selection, /includesExistingStack/);
   assert.match(selection, /state\.storageKind !== "sqlite"/);
 
-  assert.match(contextActions, /if \(options\.stackNode && asset\?\.stack\?\.id\)/);
+  assert.match(contextActions, /if \(options\.stackNode && asset\?\.stack\?\.id && logicalSelectionCount\(selectedAssets, options\) === 1\)/);
   assert.match(contextActions, /mosa:open-stack/);
   assert.match(contextActions, /dissolveStack/);
   assert.match(contextActions, /method: "DELETE"/);
+  assert.match(contextActions, /gallerySelection\?\.resolveSelectedAssetIds/,
+    "mixed Stack selections resolve to real member asset IDs at mutation time");
   assert.match(contextBindings, /stackNode: !state\.activeStackId && Boolean\(asset\.stack\?\.id\)/);
-  assert.match(contextBindings, /selectionContainsStack/);
-  assert.match(contextBindings, /const actionAssets = selectionContainsStack && !asset\.stack\?\.id \? \[asset\] : selectedAssets/);
+  assert.match(contextBindings, /if \(!selectedIds\.has\(asset\.id\)\) \{[\s\S]*?gallerySelection\?\.replaceWith\?\.\(asset\.id\)/,
+    "right-clicking outside the current selection first makes that card the selection");
+  assert.match(contextBindings, /selectionCount: selectedIds\.size/);
 
   assert.match(html, /id="stackBack"/);
   assert.match(html, /id="selectionStack"/);

--- a/test/build-identity.test.mjs
+++ b/test/build-identity.test.mjs
@@ -6,7 +6,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { getBuildIdentity, resetBuildIdentityCache, computeRuntimeFingerprint, computeUiFingerprint } from "../lib/build-identity.mjs";
 import { startMosaRuntime } from "../lib/mosa-runtime.mjs";
-import { MCP_SERVER_VERSION } from "../lib/version-identities.mjs";
+import { MCP_SERVER_VERSION, MOSA_SERVICE_PROTOCOL_VERSION } from "../lib/version-identities.mjs";
 import { removeTestPath as rm } from "./test-cleanup.mjs";
 
 const repositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
@@ -155,7 +155,7 @@ test("runtimeFingerprint in build-identity.json matches the actual local runtime
   resetBuildIdentityCache();
 });
 
-test("/api/health returns product, MCP, Git, UI, and runtime build identities", async (t) => {
+test("/api/health returns product, protocol, MCP, Git, UI, and runtime build identities", async (t) => {
   const root = await mkdtemp(join(tmpdir(), "mosa-health-build-id-"));
   t.after(() => rm(root, { recursive: true, force: true }));
   const service = await startMosaRuntime(runtimeOptions(root));
@@ -165,6 +165,7 @@ test("/api/health returns product, MCP, Git, UI, and runtime build identities", 
   assert.equal(response.status, 200);
   const health = await response.json();
   assert.equal(health.product, "mosa");
+  assert.equal(health.serviceProtocolVersion, MOSA_SERVICE_PROTOCOL_VERSION);
   assert.equal(typeof health.productVersion, "string");
   assert.equal(health.mcpServerVersion, MCP_SERVER_VERSION);
   assert.equal(typeof health.gitSha, "string");
@@ -179,6 +180,41 @@ test("/api/health returns product, MCP, Git, UI, and runtime build identities", 
   assert.equal(health.uiFingerprint, identity.uiFingerprint);
   assert.equal(health.runtimeFingerprint, identity.runtimeFingerprint);
   resetBuildIdentityCache();
+});
+
+test("runtime health keeps the identity snapshot captured at process start", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "mosa-health-snapshot-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const tempAppDir = join(root, "app");
+  await mkdir(tempAppDir, { recursive: true });
+  const initialIdentity = {
+    productVersion: "1.0.0",
+    gitSha: "started-sha",
+    uiFingerprint: "started-ui",
+    runtimeFingerprint: "started-runtime",
+  };
+  await writeFile(join(tempAppDir, "build-identity.json"), JSON.stringify(initialIdentity));
+  resetBuildIdentityCache();
+  const service = await startMosaRuntime(runtimeOptions(root, { appDir: tempAppDir }));
+  t.after(async () => {
+    await service.stop();
+    resetBuildIdentityCache();
+  });
+
+  await writeFile(join(tempAppDir, "build-identity.json"), JSON.stringify({
+    productVersion: "1.0.0",
+    gitSha: "newer-disk-sha",
+    uiFingerprint: "newer-disk-ui",
+    runtimeFingerprint: "newer-disk-runtime",
+  }));
+  resetBuildIdentityCache();
+
+  const response = await fetch(`${service.url}/api/health`);
+  assert.equal(response.status, 200);
+  const health = await response.json();
+  assert.equal(health.gitSha, initialIdentity.gitSha);
+  assert.equal(health.uiFingerprint, initialIdentity.uiFingerprint);
+  assert.equal(health.runtimeFingerprint, initialIdentity.runtimeFingerprint);
 });
 
 test("static resources served by the runtime match the source files in app/", async (t) => {

--- a/test/card-action-contract.test.mjs
+++ b/test/card-action-contract.test.mjs
@@ -204,7 +204,7 @@ test("15. reduced-motion contract covers the quick actions", async () => {
 // 16. Event isolation: delegated favorite/copy handlers keep stopPropagation.
 test("16. favorite and copy listeners keep event isolation", async () => {
   const app = await readApp();
-  const delegatedGridHandler = /els\.assetGrid\?\.addEventListener\("click", \(event\) => \{[\s\S]*?const favoriteButton = event\.target\.closest\("\.card-favorite"\);[\s\S]*?event\.stopPropagation\(\);[\s\S]*?const copyButton = event\.target\.closest\("\.card-quick-copy"\);[\s\S]*?event\.stopPropagation\(\);/;
+  const delegatedGridHandler = /els\.assetGrid\?\.addEventListener\("click", (?:async )?\(event\) => \{[\s\S]*?const favoriteButton = event\.target\.closest\("\.card-favorite"\);[\s\S]*?event\.stopPropagation\(\);[\s\S]*?const copyButton = event\.target\.closest\("\.card-quick-copy"\);[\s\S]*?event\.stopPropagation\(\);/;
   assert.match(app, delegatedGridHandler, "delegated quick actions must keep stopPropagation (no detail opening)");
   assert.doesNotMatch(app, /querySelectorAll\("\.card-(?:quick-copy|favorite)"\)\.forEach\([^\n]*addEventListener/,
     "renderGrid must not recreate per-card quick-action listeners");
@@ -331,19 +331,17 @@ test("23-25. hover, focus-within and selected each reveal both quick actions", a
 // this test used to guard was removed alongside the batch mode entry
 // points. Card quick-actions now stay reactive at all times.
 
-// 28. In batch mode :focus-within must NOT restore the single-card actions.
-test("28. batch mode: focus-within does not restore quick actions", async () => {
+// 28. The live selection state owns batch affordances. Hover/focus on a
+// selected gallery must never leak the single-card quick actions back in.
+test("28. selection mode: focus-within does not restore quick actions", async () => {
   const css = await readCss();
   const section = disclosureSection(css);
-  for (const variant of [".batch-active .asset-card .card-action-btn", ".batch-active .asset-card:hover .card-action-btn", ".batch-active .asset-card:focus-within .card-action-btn", ".batch-active .asset-card.selected .card-action-btn"]) {
+  for (const variant of [".selection-active .asset-card .card-action-btn", ".selection-active .asset-card:hover .card-action-btn", ".selection-active .asset-card:focus-within .card-action-btn", ".selection-active .asset-card.selected .card-action-btn"]) {
     assert.match(section, new RegExp(variant.replace(/[.:]/g, "\\$&") + "[^{]*\\{ opacity: 0; pointer-events: none; \\}"),
-      `batch suppression must cover ${variant} (hidden even on hover/focus-within/selected)`);
+      `selection suppression must cover ${variant} (hidden even on hover/focus-within/selected)`);
   }
-  assert.ok(!section.includes(".batch-active .asset-card .card-actions {"), "the old container-level batch rule must be gone");
-  assert.ok(!section.includes(".batch-active .asset-card:focus-within .card-actions {"), "the old batch focus-within restore must be gone");
-  // The batch affordance itself stays visible and clear.
-  assert.match(css, /\.batch-active \.asset-card \.card-checkbox \{ opacity: 1; \}/,
-    "batch checkboxes must stay visible in batch mode");
+  assert.ok(!section.includes(".batch-active"), "the retired batch-active state must stay gone");
+  assert.ok(!css.includes(".card-checkbox"), "the retired checkbox affordance must stay gone");
 });
 
 // 29. (Retired) Leaving batch mode restores the quick actions.

--- a/test/confirm-dialog-contract.test.mjs
+++ b/test/confirm-dialog-contract.test.mjs
@@ -345,7 +345,8 @@ test("context-menu bulk Trash action passes the selected count into its title", 
 
   assert.match(translations.zh.moveAssetsToTrashTitle, /\{count\}/);
   assert.match(translations.en.moveAssetsToTrashTitle, /\{count\}/);
-  assert.match(source, /t\("moveAssetsToTrashTitle", \{ count: assets\.length \}\)/);
+  assert.match(source, /t\("moveAssetsToTrashTitle", \{ count: ids\.length \}\)/,
+    "Trash confirmation reports the real expanded mutation count, including Stack members and unloaded selections");
   assert.doesNotMatch(source, /t\("moveAssetsToTrashTitle"\)/);
   assert.doesNotMatch(source, /t\("archiveAsset"\)/, "archive is no longer exposed from the asset context menu");
 });

--- a/test/gallery-marquee-selection.test.mjs
+++ b/test/gallery-marquee-selection.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-import { MARQUEE_CARD_DRAG_THRESHOLD_PX, MARQUEE_DRAG_THRESHOLD_PX, rectFromPoints, rectsIntersect } from "../app/gallery-selection.mjs";
+import { MARQUEE_CARD_DRAG_THRESHOLD_PX, MARQUEE_DRAG_THRESHOLD_PX, rectFromPoints, rectsIntersect, selectionRangeIds } from "../app/gallery-selection.mjs";
 
 test("marquee geometry normalizes drag direction and detects overlap", () => {
   assert.deepEqual(rectFromPoints(40, 50, 10, 20), {
@@ -17,6 +17,9 @@ test("marquee geometry normalizes drag direction and detects overlap", () => {
   assert.equal(rectsIntersect({ left: 0, top: 0, right: 19, bottom: 19 }, { left: 20, top: 20, right: 30, bottom: 30 }), false);
   assert.equal(MARQUEE_DRAG_THRESHOLD_PX, 3);
   assert.equal(MARQUEE_CARD_DRAG_THRESHOLD_PX, 6);
+  const assets = ["a", "b", "c", "d"].map((id) => ({ id }));
+  assert.deepEqual(selectionRangeIds(assets, "b", "d"), ["b", "c", "d"]);
+  assert.deepEqual(selectionRangeIds(assets, "d", "b"), ["b", "c", "d"]);
 });
 
 test("gallery marquee selection is wired into shared web/app renderer", async () => {
@@ -27,7 +30,7 @@ test("gallery marquee selection is wired into shared web/app renderer", async ()
   const selection = await readFile(new URL("../app/gallery-selection.mjs", import.meta.url), "utf8");
 
   assert.match(app, /selectedIds: new Set\(\)/);
-  assert.match(app, /createGallerySelection\(\{ els, state, t, announceGalleryStatus \}\)/);
+  assert.match(app, /createGallerySelection\(\{[\s\S]*?currentAssetRequest,[\s\S]*?requestAssetPage,[\s\S]*?apiFetch,[\s\S]*?showToast/);
   assert.match(app, /gallerySelection\.bind\(\)/);
   assert.match(app, /gallerySelection\.handleCardClick\(event, id\)/);
   assert.match(app, /gallerySelection\.handleGridClick\(event\)/);
@@ -57,9 +60,27 @@ test("gallery marquee selection is wired into shared web/app renderer", async ()
   const beginPointerSection = selection.slice(selection.indexOf("function beginPointer"), selection.indexOf("function movePointer"));
   assert.doesNotMatch(beginPointerSection, /event\.target\.closest\?\.\("\.asset-card, button/);
   assert.match(selection, /window\.addEventListener\("pointermove", movePointer, \{ capture: true \}\)/);
+  assert.match(selection, /window\.addEventListener\("blur", cancelPointerGesture\)/,
+    "window blur must cancel an in-flight marquee instead of leaving capture/crosshair state behind");
+  assert.match(selection, /addEventListener\("lostpointercapture"[\s\S]*?cancelPointerGesture\(\)/,
+    "lost pointer capture cancels the marquee state machine just like Stack dragging");
+  assert.match(selection, /if \(canceled && completedDrag\) \{\s+suppressNextGridClick = false;/,
+    "pointercancel must not eat the next real gallery click");
+  assert.match(selection, /if \(event\.shiftKey\)[\s\S]*?selectRange\(id/,
+    "Shift-click uses desktop-style contiguous range selection");
+  assert.match(selection, /while \(true\) \{[\s\S]*?requestAssetPage\(request, \{ cursor, limit: 250/,
+    "Select all walks the complete cursor result instead of only selecting loaded DOM cards");
+  assert.match(selection, /resolveSelectedAssetIds/);
+  assert.match(selection, /MARQUEE_GEOMETRY_BAND_PX = 512/);
+  assert.match(selection, /pointer\.cardRectBands = new Map\(\)/);
+  assert.match(selection, /candidateById/,
+    "pointermove intersects only vertical-band candidates instead of every loaded card");
+  assert.match(selection, /\/api\/asset-stacks\/\$\{encodeURIComponent\(stackId\)\}\/assets/,
+    "logical Stack selections expand to their member asset IDs only when an action executes");
   assert.match(selection, /addEventListener\("dragstart"/);
   assert.match(css, /\.asset-card-select, \.asset-card-select \.thumb \{ user-select: none; -webkit-user-drag: none; \}/);
 
   assert.match(bindings, /state\.selectedIds instanceof Set/);
-  assert.match(bindings, /getAssetMenu\(asset, actionAssets, \{/);
+  assert.match(bindings, /getAssetMenu\(asset, selectedAssets, \{/);
+  assert.match(bindings, /gallerySelection\?\.replaceWith\?\.\(asset\.id\)/);
 });

--- a/test/import-flow.test.mjs
+++ b/test/import-flow.test.mjs
@@ -136,6 +136,15 @@ test("import rejections reach the client as 400 with a code, and the format list
   assert.equal(unfavorite.status, 200);
   assert.deepEqual((await unfavorite.json()).results, [{ id: asset.id, favorite: false }]);
 
+  const grouped = await batch({ action: "group", projectId: "default", assetIds: [asset.id], group: "Selected" });
+  assert.equal(grouped.status, 200);
+  assert.deepEqual((await grouped.json()).results, [{ id: asset.id, group: "Selected" }]);
+  const groupedAsset = await (await fetch(`${runtime.url}/api/assets/default/${encodeURIComponent(asset.id)}`)).json();
+  assert.equal(groupedAsset.asset.group, "Selected");
+  const invalidGroup = await batch({ action: "group", projectId: "default", assetIds: [asset.id], group: { invalid: true } });
+  assert.equal(invalidGroup.status, 400);
+  assert.match((await invalidGroup.json()).error, /group must be a string/);
+
   const invalidBatch = await batch({ action: "delete", projectId: "default", assetIds: [asset.id] });
   assert.equal(invalidBatch.status, 400);
   const archive = await batch({ action: "archive", projectId: "default", assetIds: [asset.id] });

--- a/test/keyboard-accessibility-contract.test.mjs
+++ b/test/keyboard-accessibility-contract.test.mjs
@@ -79,7 +79,10 @@ const checks = [
     assert.match(app, /event\.stopPropagation\(\);.*buttons\[next\]\.click\(\)/s);
   }],
   ["17 gallery card has native button entry", async () => assert.match(await read("app/app.mjs"), /<button class="asset-card-select" type="button"/)],
-  ["18 keyboard card activation opens the V2 detail inspector", async () => assert.match(await read("app/app.mjs"), /void selectAsset\(id\)/)],
+  ["18 Enter on a gallery asset opens the dedicated Viewer", async () => {
+    const app = await read("app/app.mjs");
+    assert.match(app, /if \(event\.key === "Enter"[\s\S]*?else void openAssetView\(asset\.id, els\.assetGrid\?\.querySelector/);
+  }],
   ["19 viewer entry focuses Return", async () => assert.match(await read("app/asset-view.mjs"), /els\.assetViewBack\?\.focus\(\);/)],
   ["20 hidden library is inert in viewer", async () => assert.match(await read("app/asset-view.mjs"), /els\.libraryView\.toggleAttribute\("inert", assetMode\)/)],
   ["21 viewer navigation buttons stay native", async () => {

--- a/test/large-view-mode-contract.test.mjs
+++ b/test/large-view-mode-contract.test.mjs
@@ -141,26 +141,34 @@ test("9. compact 960–1120 keeps three columns (no detail drop)", async () => {
   assert.doesNotMatch(rail, /\.detail \{[^}]*position: static/, "detail must not re-enter the document flow in the rail band");
 });
 
-// 10. Ordinary assets keep the V2 inspector as their single-click destination.
-// A collapsed Stack is a logical node: single-click selects it without
-// navigating or leaking its cover into the Inspector, while double-click opens
-// the Stack member view.
-test("10. single click selects a logical Stack and double click enters it", async () => {
+// 10. Ordinary assets keep the V2 inspector as their single-click destination,
+// while double-click uses the dedicated Asset Viewer. A collapsed Stack is a
+// logical node: single-click selects it without navigating or leaking its cover
+// into the Inspector, while double-click opens the Stack member view.
+test("10. single click inspects, double click views, and Stack double click enters it", async () => {
   const app = await readApp();
   const cards = sliceBetween(app, 'const selectButton = event.target.closest(".asset-card-select")', 'const loadMoreButton = event.target.closest');
   assert.match(cards, /const id = selectButton\.closest\("\.asset-card"\)\?\.dataset\.id;/,
     "card click resolves the asset id");
+  assert.match(cards, /if \(event\.detail > 1\) return;/,
+    "the second click in a double-click does not repeat Inspector selection work");
   assert.match(cards, /if \(id\) \{\s+gallerySelection\.clear\(\);[\s\S]*?void selectAsset\(id\);\s+\}/,
     "ordinary asset click clears batch selection before opening the V2 detail inspector");
   assert.match(cards, /if \(!state\.activeStackId && asset\?\.stack\?\.id\) \{[\s\S]*?state\.selectedId = id;[\s\S]*?updateSelectedCard\(\);[\s\S]*?return;/,
     "collapsed Stack click only selects the logical Stack card");
   assert.doesNotMatch(cards, /assetStacks\.enterStack/,
     "single-click must not enter a collapsed Stack");
-  assert.doesNotMatch(cards, /openAssetView/, "card click does not enter the retired canvas viewer");
+  assert.doesNotMatch(cards, /openAssetView/, "single-click must not enter the dedicated Viewer");
 
   const doubleClick = sliceBetween(app, 'els.assetGrid?.addEventListener("dblclick"', 'els.newAssetTopBtn?.addEventListener');
+  assert.match(doubleClick, /if \(!state\.activeStackId && \(card\?\.dataset\.stackId \|\| asset\?\.stack\?\.id\)\)/,
+    "only a collapsed Stack intercepts double-click; members inside an active Stack fall through to Viewer");
   assert.match(doubleClick, /assetStacks\.enterStack\(asset\.stack\.id, asset\.stack\)/,
     "double-click enters a collapsed Stack");
+  assert.match(doubleClick, /void openAssetView\(id, selectButton\)/,
+    "ordinary asset double-click enters the dedicated Asset Viewer");
+  assert.doesNotMatch(doubleClick, /openImagePreview/,
+    "gallery double-click no longer routes through the legacy quick preview");
 });
 
 // 11. The card favourite quick action does not bubble.
@@ -497,14 +505,10 @@ test("41. detail-drawer Escape listener bails on defaultPrevented", async () => 
     "detail-drawer Escape listener must bail before its overlay guards when a trap consumed the event");
 });
 
-// 42. Runtime-verified fix: entering via double-click means the first click opens
-//     the view and synchronously focuses the back button, then the second
-//     mousedown lands on the stage/main image now occupying those coordinates —
-//     the browser default action moves focus to <body> and the open-focus is lost
-//     (found in the double-click entry re-verification, flow 31/36). The stage
-//     mousedown guard prevents the default focus theft on stage/image only;
-//     the video element is excluded so native controls keep working.
-test("42. asset-view stage mousedown guard prevents double-click focus theft", async () => {
+// 42. Viewer entry synchronously focuses the back button. Ordinary pointer
+//     interaction on the quiet stage/main image must not clear that focus to
+//     <body>; video is excluded so native controls keep their normal behavior.
+test("42. asset-view stage mousedown guard preserves viewer focus", async () => {
   const app = await readApp();
   const bind = functionBody(app, "bindEvents");
   const guard = sliceBetween(bind, 'els.assetViewStage?.addEventListener("mousedown"', "});");

--- a/test/phase7-polish-contract.test.mjs
+++ b/test/phase7-polish-contract.test.mjs
@@ -188,7 +188,7 @@ test("10. Main app reduced-motion coverage complete", async () => {
   const blockStart = css.lastIndexOf("@media (prefers-reduced-motion: reduce)");
   assert.notEqual(blockStart, -1, "reduced-motion block exists");
   const block = css.slice(blockStart);
-  for (const selector of [".asset-card", ".card-action-btn", ".toast", ".asset-view-control", ".nav-item", ".icon-button", ".segmented-btn", ".toolbar-icon", ".create-button", ".card-checkbox", ".action-btn", ".mini-btn", ".prompt-text", ".btn-primary", ".btn-danger"]) {
+  for (const selector of [".asset-card", ".card-action-btn", ".toast", ".asset-view-control", ".nav-item", ".icon-button", ".segmented-btn", ".toolbar-icon", ".create-button", ".action-btn", ".mini-btn", ".prompt-text", ".btn-primary", ".btn-danger"]) {
     assert.ok(block.includes(selector), `reduced-motion covers ${selector}`);
   }
 });

--- a/test/service-manager.test.mjs
+++ b/test/service-manager.test.mjs
@@ -11,6 +11,7 @@ import {
   MosaServiceConflictError,
   compareMosaVersions,
   retireOlderMosaService,
+  shouldAllowSameVersionServiceReplacement,
   shouldAllowStaleServiceUpgrade,
   startMosaService,
 } from "../desktop/service-manager.mjs";
@@ -165,6 +166,63 @@ test("automatic stale-service retirement is enabled only for normal packaged lau
   assert.equal(shouldAllowStaleServiceUpgrade({ isPackaged: false, qaRun: false, explicitPort: false }), false, "development launches stay fail-closed");
   assert.equal(shouldAllowStaleServiceUpgrade({ isPackaged: true, qaRun: "1", explicitPort: false }), false, "QA launches stay fail-closed");
   assert.equal(shouldAllowStaleServiceUpgrade({ isPackaged: true, qaRun: false, explicitPort: true }), false, "explicit port launches stay fail-closed");
+});
+
+test("same-version service replacement is enabled only for normal source desktop launches", () => {
+  assert.equal(shouldAllowSameVersionServiceReplacement({ isPackaged: false, qaRun: false, explicitPort: false }), true);
+  assert.equal(shouldAllowSameVersionServiceReplacement({ isPackaged: true, qaRun: false, explicitPort: false }), false, "packaged launches do not replace an unordered same-version build");
+  assert.equal(shouldAllowSameVersionServiceReplacement({ isPackaged: false, qaRun: "1", explicitPort: false }), false, "QA launches stay fail-closed");
+  assert.equal(shouldAllowSameVersionServiceReplacement({ isPackaged: false, qaRun: false, explicitPort: true }), false, "explicit port launches stay fail-closed");
+});
+
+test("source desktop hands off a verified same-version stale runtime to the current build", async (t) => {
+  const root = await temporaryRoot(t, "mosa-service-same-version-handoff-");
+  const libraryDir = join(root, "library");
+  const staleHealth = {
+    product: "mosa",
+    libraryDir,
+    storage: "sqlite",
+    serviceProtocolVersion: "unknown",
+    productVersion: "0.2.1-rc.4",
+    gitSha: "old-sha",
+    uiFingerprint: "old-ui",
+    runtimeFingerprint: "old-runtime",
+  };
+  const expectedIdentity = {
+    serviceProtocolVersion: "1",
+    productVersion: "0.2.1-rc.4",
+    gitSha: "new-sha",
+    uiFingerprint: "new-ui",
+    runtimeFingerprint: "new-runtime",
+  };
+  const replacement = {
+    state: "attached",
+    url: "http://127.0.0.1:43517",
+    port: 43517,
+    libraryDir,
+    storage: "sqlite",
+    ...expectedIdentity,
+  };
+  let handoffCalls = 0;
+
+  const attached = await startMosaService({
+    port: 43517,
+    libraryDir,
+    expectedIdentity,
+    allowSameVersionServiceReplacement: true,
+    fetchImpl: async () => ({ ok: true, json: async () => staleHealth }),
+    upgradeService: async (conflict, options) => {
+      handoffCalls += 1;
+      assert.equal(conflict.sameVersionReplacementEligible, true);
+      assert.equal(options.allowSameVersionReplacement, true);
+      return true;
+    },
+    upgradeProbeImpl: async () => replacement,
+  });
+
+  assert.equal(handoffCalls, 1);
+  assert.equal(attached.url, replacement.url);
+  assert.equal(attached.productVersion, expectedIdentity.productVersion);
 });
 
 test("automatic retirement does not target same-version, newer, unknown, or different-library services", async (t) => {

--- a/test/shell-layout-contract.test.mjs
+++ b/test/shell-layout-contract.test.mjs
@@ -160,18 +160,12 @@ test("15-18. overlay levels and batch-bar compensation", async () => {
   assert.match(inspectorScroll, /overflow-y: auto/);
 
   assert.match(css, /--statusbar-height: 48px;/);
-  assert.match(blockAfter(css, ".grid.batch-active {"), /padding-bottom: calc\(var\(--statusbar-height\) \+ var\(--space-2\)\)/);
-  assert.match(blockAfter(css, ".shell:has(.grid.batch-active) .detail {"), /padding-bottom: var\(--statusbar-height\)/);
+  assert.match(blockAfter(css, ".grid.selection-active {"), /padding-bottom: calc\(var\(--statusbar-height\) \+ var\(--space-2\)\)/);
+  assert.match(blockAfter(css, ".shell:has(.grid.selection-active) .detail {"), /padding-bottom: var\(--statusbar-height\)/);
   // Off-state keeps only the regular breathing room — no residual batch padding.
   assert.match(blockAfter(css, ".grid {"), /padding: var\(--space-2\) 20px var\(--space-3\)/);
-  // 2026-08-18: V2-only token consolidation. The V2 design removed the
-  // bottom statusbar / batch-bar chrome and the JS hook that toggled
-  // `.batch-active` on the grid. The CSS compensation rule below stays
-  // in place (token-driven, harmless when no element sets the class),
-  // and the contract now documents that V2 choice rather than asserting
-  // a JS hook that has been retired.
-  assert.match(css, /\.grid\.batch-active \{ padding-bottom: calc\(var\(--statusbar-height\) \+ var\(--space-2\)\); \}/,
-    "CSS compensation rule for the retired batch-bar stays in place");
+  assert.doesNotMatch(css, /\.grid\.batch-active\b/,
+    "the retired batch-active state must not survive beside selection-active");
 });
 
 // 22. The public CSS keeps the O2 compact-desktop decision executable after

--- a/test/trash-gallery-regression.test.mjs
+++ b/test/trash-gallery-regression.test.mjs
@@ -32,8 +32,10 @@ test("Move to Trash uses one batch mutation and reconciles removed cards before 
     readFile(resolve(root, "app/context-menu-bindings.mjs"), "utf8"),
   ]);
 
-  assert.match(actions, /apiFetch\("\/api\/assets\/batch"[\s\S]*?action: "trash"[\s\S]*?assetIds: assets\.map/,
+  assert.match(actions, /apiFetch\("\/api\/assets\/batch"[\s\S]*?action: "trash"[\s\S]*?assetIds: ids/,
     "Trash selection must not issue one HTTP DELETE per card");
+  assert.match(actions, /selectedMutationIds\(asset, selectedAssets, options\)/,
+    "Trash must operate on the complete logical selection, including unloaded pages and Stack members");
   assert.match(actions, /removedAssetIds: outcome\.succeeded\.map/,
     "partial batches must remove only server-confirmed successes from the visible gallery");
   assert.match(bindings, /function applyImmediateAssetRemoval\(assetIds = \[\]\)/);

--- a/test/ui-component-contract.test.mjs
+++ b/test/ui-component-contract.test.mjs
@@ -329,7 +329,7 @@ test("out-of-scope files stay locked and the Phase 1C card contract is stable", 
   for (const rule of [
     ".card-actions { position: absolute; z-index: var(--z-card-overlay); top: var(--space-1); right: var(--space-1); display: flex; gap: var(--space-1); pointer-events: none; }",
     ".mosa-v2 .card-actions { top: 8px; right: 8px; gap: 0; opacity: 1; }",
-    ".batch-active .asset-card .card-action-btn, .batch-active .asset-card:hover .card-action-btn, .batch-active .asset-card:focus-within .card-action-btn, .batch-active .asset-card.selected .card-action-btn { opacity: 0; pointer-events: none; }",
+    ".selection-active .asset-card .card-action-btn, .selection-active .asset-card:hover .card-action-btn, .selection-active .asset-card:focus-within .card-action-btn, .selection-active .asset-card.selected .card-action-btn { opacity: 0; pointer-events: none; }",
   ]) {
     assert.ok(css.includes(rule), `card quick-action contract rule must stay verbatim: ${rule.slice(0, 48)}…`);
   }


### PR DESCRIPTION
## Summary\n- complete gallery selection, range selection, marquee cancellation, and logical Stack expansion\n- route double-click into the dedicated Viewer and keep selection state coherent across bulk actions\n- harden same-version source desktop runtime handoff and batch group mutations\n- update regression and contract coverage\n\n## Validation\n- npm test (985 passed, 2 skipped, 0 failed)\n- npm run lint\n- npm run check\n- npm run check:web-capture-store\n- npm run check:desktop-node\n- git diff --check\n- npm run qa:gallery:performance (2,000 assets; hydrated 50; 5,270 DOM nodes; no long tasks; no visible bottom placeholders)