### PR TITLE
Optimize capture lookups and harden desktop library isolation

### DIFF
--- a/app/app.mjs
+++ b/app/app.mjs
@@ -2355,21 +2355,23 @@ const galleryCardVirtualBackgroundPendingChanges = new Map();
 let galleryCardVirtualBatchFrame = null;
 let galleryCardVirtualWindowFrame = null;
 const galleryCardVirtualEntries = new Map();
+const galleryCardVirtualNodes = new Map();
 const galleryCardVirtualHydratedIds = new Set();
 const galleryCardVirtualSpanCache = new Map();
+let galleryCardVirtualColumnWidth = 180;
 let galleryCardVirtualGeometryColumns = [];
 const galleryCardVirtualGeometryById = new Map();
 const GALLERY_CARD_VIRTUAL_THRESHOLD = 40;
 const GALLERY_CARD_INITIAL_HYDRATE = 40;
 
-function galleryVirtualSpanKey(assetId) {
-  return `${state.galleryDensity}\u001f${Math.round(galleryCardColumnWidth())}\u001f${assetId}`;
+function galleryVirtualSpanKey(assetId, columnWidth = galleryCardVirtualColumnWidth) {
+  return `${state.galleryDensity}\u001f${Math.round(columnWidth)}\u001f${assetId}`;
 }
 
-function galleryCardColumnWidth() {
+function galleryCardColumnWidth(styles = null) {
   const grid = els.assetGrid;
   if (!grid) return 180;
-  const tracks = getComputedStyle(grid).gridTemplateColumns.split(/\s+/).map(Number.parseFloat).filter((value) => Number.isFinite(value) && value > 0);
+  const tracks = (styles || getComputedStyle(grid)).gridTemplateColumns.split(/\s+/).map(Number.parseFloat).filter((value) => Number.isFinite(value) && value > 0);
   if (tracks.length) return tracks[0];
   return Math.max(120, grid.clientWidth / 5);
 }
@@ -2459,6 +2461,7 @@ function replaceVirtualGalleryCards(observerEntries) {
       releaseObservedGalleryMedia(card);
     }
     card.replaceWith(replacement);
+    galleryCardVirtualNodes.set(entry.id, replacement);
     galleryCardVirtualObserver?.observe(replacement);
     changedIds.add(entry.id);
     changed = true;
@@ -2542,7 +2545,12 @@ function galleryCardVirtualLowerBound(column, minRow) {
 }
 
 function galleryCardVirtualNode(grid, id) {
-  return grid.querySelector(`:scope > .asset-card[data-id="${CSS.escape(id)}"]`);
+  const cached = galleryCardVirtualNodes.get(id);
+  if (cached?.isConnected && cached.parentElement === grid && cached.dataset.id === id) return cached;
+  if (cached) galleryCardVirtualNodes.delete(id);
+  const card = grid.querySelector(`:scope > .asset-card[data-id="${CSS.escape(id)}"]`);
+  if (card) galleryCardVirtualNodes.set(id, card);
+  return card;
 }
 
 function syncGalleryCardVirtualWindow() {
@@ -2768,6 +2776,8 @@ function setupGalleryMediaVirtualization(roots = null) {
           if (media.dataset.galleryUnloaded === "true" && source) {
             media.dataset.galleryUnloaded = "false";
             media.classList.remove("gallery-media-unloaded");
+            if (media.dataset.gallerySrcset) media.setAttribute("srcset", media.dataset.gallerySrcset);
+            if (media.dataset.gallerySizes) media.setAttribute("sizes", media.dataset.gallerySizes);
             media.src = source;
           }
           return;
@@ -2775,6 +2785,10 @@ function setupGalleryMediaVirtualization(roots = null) {
         if (!source || media.dataset.galleryUnloaded === "true" || !media.complete || media.naturalWidth <= 0) return;
         media.dataset.galleryUnloaded = "true";
         media.classList.add("gallery-media-unloaded");
+        if (media.hasAttribute("srcset")) media.dataset.gallerySrcset = media.getAttribute("srcset") || "";
+        if (media.hasAttribute("sizes")) media.dataset.gallerySizes = media.getAttribute("sizes") || "";
+        media.removeAttribute("srcset");
+        media.removeAttribute("sizes");
         media.removeAttribute("src");
       });
     }, { root: grid, rootMargin: "1200px 0px" });
@@ -2800,6 +2814,8 @@ function layoutMasonry(cards = null) {
   if (!grid) return;
   const gridStyles = getComputedStyle(grid);
   const galleryGap = Number.parseFloat(gridStyles.getPropertyValue("--gallery-gap")) || Number.parseFloat(gridStyles.columnGap) || 0;
+  const virtualColumnWidth = galleryCardColumnWidth(gridStyles);
+  galleryCardVirtualColumnWidth = virtualColumnWidth;
   const targets = cards ? [...cards] : [...grid.querySelectorAll(".asset-card")];
   const measureTargets = [];
   const measurements = [];
@@ -2830,7 +2846,7 @@ function layoutMasonry(cards = null) {
   measurements.forEach(([card, span, previousSpan]) => {
     if (!Number.isFinite(previousSpan) || previousSpan !== span) needsPlacement = true;
     card.style.gridRowEnd = `span ${span}`;
-    if (card.dataset.id) galleryCardVirtualSpanCache.set(galleryVirtualSpanKey(card.dataset.id), span);
+    if (card.dataset.id) galleryCardVirtualSpanCache.set(galleryVirtualSpanKey(card.dataset.id, virtualColumnWidth), span);
     card.classList.add("masonry-content-virtualized");
   });
   if (!needsPlacement) {
@@ -3120,8 +3136,10 @@ function reconcileAssetCards(entries) {
         card.replaceWith(replacement);
       }
       card = replacement;
+      galleryCardVirtualNodes.set(entry.id, card);
       changedCards.push(card);
     }
+    if (card) galleryCardVirtualNodes.set(entry.id, card);
     keptCards.add(card);
     desiredCards.push(card);
   }
@@ -3130,6 +3148,7 @@ function reconcileAssetCards(entries) {
     if (!keptCards.has(card)) {
       if (card.contains(document.activeElement)) replacedFocusedCard = true;
       releaseObservedGalleryMedia(card);
+      if (card.dataset.id) galleryCardVirtualNodes.delete(card.dataset.id);
       card.remove();
     }
   });
@@ -3150,7 +3169,12 @@ function appendAssetCards(entries) {
   grid.querySelectorAll(":scope > .asset-load-more, :scope > .infinite-scroll-sentinel").forEach((element) => element.remove());
   const createdCards = createAssetCardElements(entries);
   const changedCards = entries.map((entry) => createdCards.get(entry.id)).filter(Boolean);
-  if (changedCards.length) grid.append(...changedCards);
+  if (changedCards.length) {
+    grid.append(...changedCards);
+    changedCards.forEach((card) => {
+      if (card.dataset.id) galleryCardVirtualNodes.set(card.dataset.id, card);
+    });
+  }
   if (state.nextCursor) grid.insertAdjacentHTML("beforeend", galleryPaginationMarkup());
   if (changedCards.length) invalidateCardGeometryCache();
   return changedCards;
@@ -3184,6 +3208,7 @@ function renderGrid() {
   };
   // Loading, failed, empty and populated are four distinct renders; the empty
   // state is only reachable once a request has actually answered with nothing.
+  if (state.galleryStatus === "loading" || state.galleryStatus === "error" || !state.assets.length) galleryCardVirtualNodes.clear();
   if (state.galleryStatus === "loading") { els.assetGrid.innerHTML = gallerySkeletonMarkup(); restoreGridFallbackFocus(); return; }
   if (state.galleryStatus === "error") {
     const message = state.galleryError?.message || "";
@@ -3207,6 +3232,7 @@ function renderGrid() {
     && existingCardCount === animateFrom
     && els.assetGrid.dataset.renderedDensity === state.galleryDensity;
   const renderAssets = canAppendFast ? state.assets.slice(animateFrom) : state.assets;
+  galleryCardVirtualColumnWidth = galleryCardColumnWidth();
   if (!canAppendFast) {
     galleryCardVirtualEntries.clear();
     const currentIds = new Set(state.assets.map((asset) => asset.id));

--- a/app/asset-stacks.mjs
+++ b/app/asset-stacks.mjs
@@ -394,6 +394,14 @@ export function createAssetStackController({
 
   function endPointer(event, { canceled = false } = {}) {
     if (!pointer || pointer.id !== event.pointerId) return;
+    // A synthetic/test gesture (and a very fast real gesture) can deliver
+    // pointerup before the coalesced animation frame runs. Resolve the latest
+    // pointer position synchronously so the drop target is never lost.
+    if (pointerMoveFrame !== null) {
+      cancelAnimationFrame(pointerMoveFrame);
+      pointerMoveFrame = null;
+      flushPointerMove();
+    }
     const drag = pointer;
     const completed = drag.dragging;
     const targetId = dropTarget?.dataset.id || "";

--- a/app/asset-stacks.mjs
+++ b/app/asset-stacks.mjs
@@ -53,6 +53,7 @@ export function createAssetStackController({
   let dropPlacement = "";
   let mutationInFlight = false;
   let suppressClickAfterDrag = false;
+  let pointerMoveFrame = null;
 
   function clearDropTarget() {
     dropTarget?.classList.remove("stack-drop-target", "stack-reorder-target", "stack-reorder-before", "stack-reorder-after");
@@ -80,6 +81,8 @@ export function createAssetStackController({
     const hadPointer = Boolean(pointer);
     const pointerId = pointer?.id;
     pointer = null;
+    if (pointerMoveFrame !== null) cancelAnimationFrame(pointerMoveFrame);
+    pointerMoveFrame = null;
     state.assetStackDragCandidate = false;
     state.assetStackDragging = false;
     if (releaseCapture && pointerId != null) releasePointerCapture(pointerId);
@@ -302,6 +305,33 @@ export function createAssetStackController({
     return element?.closest?.(".asset-card") || null;
   }
 
+  function flushPointerMove() {
+    pointerMoveFrame = null;
+    if (!pointer?.dragging) return;
+    const clientX = pointer.lastX;
+    const clientY = pointer.lastY;
+    const marker = createGhost(pointer.assetIds.length);
+    marker.style.transform = `translate3d(${clientX + 12}px, ${clientY + 12}px, 0)`;
+    const target = targetCardAt(clientX, clientY);
+    if (target !== dropTarget) clearDropTarget();
+    if (!target) return;
+    const targetId = target.dataset.id;
+    if (!targetId) return;
+    if (state.activeStackId) {
+      if (pointer.assetIds.includes(targetId)) return;
+      dropTarget = target;
+      target.classList.add("stack-reorder-target");
+      const rect = target.getBoundingClientRect();
+      dropPlacement = clientX < rect.left + rect.width / 2 ? "before" : "after";
+      target.classList.add(dropPlacement === "after" ? "stack-reorder-after" : "stack-reorder-before");
+      return;
+    }
+    const targetAsset = state.assets.find((asset) => asset.id === targetId);
+    if (!targetAsset) return;
+    dropTarget = target;
+    target.classList.add("stack-drop-target");
+  }
+
   function movePointer(event) {
     if (!pointer || pointer.id !== event.pointerId) return;
     pointer.lastX = event.clientX;
@@ -314,26 +344,7 @@ export function createAssetStackController({
       document.body.classList.add("asset-stack-dragging");
     }
     event.preventDefault();
-    const marker = createGhost(pointer.assetIds.length);
-    marker.style.transform = `translate3d(${event.clientX + 12}px, ${event.clientY + 12}px, 0)`;
-    const target = targetCardAt(event.clientX, event.clientY);
-    if (target !== dropTarget) clearDropTarget();
-    if (!target) return;
-    const targetId = target.dataset.id;
-    if (!targetId) return;
-    if (state.activeStackId) {
-      if (pointer.assetIds.includes(targetId)) return;
-      dropTarget = target;
-      target.classList.add("stack-reorder-target");
-      const rect = target.getBoundingClientRect();
-      dropPlacement = event.clientX < rect.left + rect.width / 2 ? "before" : "after";
-      target.classList.add(dropPlacement === "after" ? "stack-reorder-after" : "stack-reorder-before");
-      return;
-    }
-    const targetAsset = state.assets.find((asset) => asset.id === targetId);
-    if (!targetAsset) return;
-    dropTarget = target;
-    target.classList.add("stack-drop-target");
+    if (pointerMoveFrame === null) pointerMoveFrame = requestAnimationFrame(flushPointerMove);
   }
 
   async function finishRootDrop(targetId, drag) {

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, Menu, dialog, ipcMain, clipboard, nativeImage, session, shell, Notification } from "electron";
 import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync } from "node:fs";
 import { cp, mkdir, readdir, rm } from "node:fs/promises";
-import { homedir } from "node:os";
+import { userInfo } from "node:os";
 import { dirname, join, resolve, isAbsolute } from "node:path";
 import { fileURLToPath } from "node:url";
 import { DEFAULT_MOSA_DESKTOP_PORT, MOSA_RESERVED_PRODUCTION_PORTS } from "../lib/runtime-defaults.mjs";
@@ -41,7 +41,11 @@ const productionDefaultUserData = join(app.getPath("appData"), app.name);
 const importStagingRoot = importStagingDir(desktopDataDir);
 const desktopPort = process.env.MOSA_DESKTOP_PORT || DEFAULT_MOSA_DESKTOP_PORT;
 const LIBRARY_LOCATION_PATH = join(desktopDataDir, "library-location.json");
-const defaultLibraryDir = join(homedir(), "MOSA Library");
+// `homedir()` follows HOME on macOS, and tool sandboxes may intentionally
+// rewrite HOME to a temporary directory. userInfo().homedir comes from the OS
+// account record instead, so source desktop launches still resolve the signed-
+// in user's real MOSA Library instead of forking a sandbox-only empty library.
+const defaultLibraryDir = join(userInfo().homedir, "MOSA Library");
 
 function loadSavedLibraryDir() {
   try {
@@ -88,7 +92,7 @@ const guard = validateRuntimeIsolation({
   defaultUserData: isolationContext.productionDefaultUserData,
   argv: isolationContext.argv,
   runtimeKind: isolationContext.runtimeKind,
-  productionLibraryDir: join(homedir(), "MOSA Library"),
+  productionLibraryDir: defaultLibraryDir,
   productionPorts: MOSA_RESERVED_PRODUCTION_PORTS,
 });
 if (!guard.ok) {
@@ -573,6 +577,11 @@ async function createMainWindow() {
       port: desktopPort,
       libraryDir,
       allowPortFallback: !process.env.MOSA_DESKTOP_PORT,
+      // If the primary MOSA port is already owned by a verified MOSA runtime
+      // for another library, fail closed instead of silently spawning a second
+      // desktop library on 43518+. This turns future path-resolution regressions
+      // into an explicit startup error rather than an apparently empty library.
+      failOnPrimaryLibraryMismatch: true,
       // Normal packaged launches may replace a strictly older MOSA runtime
       // that owns this exact library. QA, source development, and explicit
       // port launches stay fail-closed so test tooling never terminates an

--- a/desktop/service-manager.mjs
+++ b/desktop/service-manager.mjs
@@ -47,6 +47,17 @@ export class MosaServiceBuildMismatchError extends MosaServiceConflictError {
   }
 }
 
+export class MosaServiceLibraryMismatchError extends MosaServiceConflictError {
+  constructor({ port, expectedLibraryDir, actualLibraryDir }) {
+    super(`Port ${port} is already serving a different MOSA library. Quit the other MOSA instance before opening this library.`);
+    this.name = "MosaServiceLibraryMismatchError";
+    this.code = "MOSA_SERVICE_LIBRARY_MISMATCH";
+    this.port = port;
+    this.expectedLibraryDir = resolve(expectedLibraryDir);
+    this.actualLibraryDir = resolve(actualLibraryDir);
+  }
+}
+
 export function shouldAllowStaleServiceUpgrade({ isPackaged, qaRun, explicitPort } = {}) {
   return isPackaged === true && !qaRun && !explicitPort;
 }
@@ -119,6 +130,11 @@ export async function startMosaService(options = {}) {
     }
     if (initial.state === "conflict") {
       lastConflict = initial.error;
+      if (candidatePort === port
+        && options.failOnPrimaryLibraryMismatch === true
+        && initial.error instanceof MosaServiceLibraryMismatchError) {
+        throw initial.error;
+      }
       continue;
     }
     availablePorts.push(candidatePort);
@@ -144,6 +160,33 @@ export async function startMosaService(options = {}) {
         allowSameVersionReplacement: sameVersionReplacementAllowed,
       });
       if (retired) {
+        if (sameVersionReplacementAllowed) {
+          try {
+            const runtime = await (options.startRuntime || startMosaRuntime)({
+              ...(options.runtimeOptions || {}),
+              port: identityMismatch.service.port,
+              libraryDir,
+              isolationContext: options.isolationContext,
+              importStagingRoot: options.importStagingRoot ?? null,
+            });
+            return ownedService(runtime);
+          } catch (error) {
+            const retry = await probeMosaService({
+              host,
+              port: identityMismatch.service.port,
+              libraryDir,
+              fetchImpl: options.fetchImpl,
+              timeoutMs: options.probeTimeoutMs,
+            });
+            if (retry.state === "attached") {
+              const retryConflict = serviceIdentityConflict(retry, options.expectedIdentity);
+              if (!retryConflict) return attachedService(retry);
+              throw retryConflict;
+            }
+            if (retry.state === "conflict") throw retry.error;
+            throw error;
+          }
+        }
         const replacement = await waitForUpgradedMosaService(identityMismatch, {
           host,
           fetchImpl: options.fetchImpl,
@@ -225,7 +268,15 @@ export async function probeMosaService(options = {}) {
       return conflict(`Port ${port} is occupied by a service that is not MOSA.`);
     }
     if (resolve(health.libraryDir) !== libraryDir) {
-      return conflict(`Port ${port} is serving a different MOSA library.`);
+      return {
+        state: "conflict",
+        error: new MosaServiceLibraryMismatchError({
+          port,
+          expectedLibraryDir: libraryDir,
+          actualLibraryDir: health.libraryDir,
+        }),
+        retryable: false,
+      };
     }
     return {
       state: "attached",

--- a/lib/api/asset-routes.mjs
+++ b/lib/api/asset-routes.mjs
@@ -9,6 +9,36 @@ import {
   stageReadableForImport,
 } from "../import-staging.mjs";
 
+const referencePruneStates = new WeakMap();
+
+function scheduleReferencePrune(store, webCaptureIngest, projectId) {
+  if (!store || typeof webCaptureIngest?.pruneReferences !== "function") return;
+  let state = referencePruneStates.get(store);
+  if (!state) {
+    state = { projects: new Set(), timer: null };
+    referencePruneStates.set(store, state);
+  }
+  state.projects.add(projectId);
+  if (state.timer) return;
+  state.timer = setTimeout(() => {
+    state.timer = null;
+    const projects = [...state.projects];
+    state.projects.clear();
+    void Promise.all(projects.map(async (queuedProjectId) => {
+      try {
+        const referencedIds = typeof store.listReferencedAttachmentIds === "function"
+          ? await store.listReferencedAttachmentIds(queuedProjectId)
+          : await referencedAttachmentIds(store, queuedProjectId);
+        await webCaptureIngest.pruneReferences(queuedProjectId, referencedIds);
+      } catch (error) {
+        if (/database connection is not open/i.test(String(error?.message || error))) return;
+        console.warn(`[MOSA] reference attachment cleanup failed: ${error?.message || error}`);
+      }
+    }));
+  }, 75);
+  state.timer.unref?.();
+}
+
 function decodedUploadFileName(value) {
   if (Array.isArray(value)) value = value[0];
   if (typeof value !== "string" || !value) return "";
@@ -337,16 +367,7 @@ export async function handleAssetRoute({ req, res, url, context }) {
     const projectId = decodeURIComponent(permanentMatch[1]);
     const assetId = decodeURIComponent(permanentMatch[2]);
     const result = await store.permanentlyDeleteAsset(projectId, assetId);
-    if (typeof webCaptureIngest?.pruneReferences === "function") {
-      try {
-        const referencedIds = typeof store.listReferencedAttachmentIds === "function"
-          ? await store.listReferencedAttachmentIds(projectId)
-          : await referencedAttachmentIds(store, projectId);
-        await webCaptureIngest.pruneReferences(projectId, referencedIds);
-      } catch (error) {
-        console.warn(`[MOSA] reference attachment cleanup failed: ${error?.message || error}`);
-      }
-    }
+    scheduleReferencePrune(store, webCaptureIngest, projectId);
     sendJson(res, 200, { result });
     return true;
   }

--- a/lib/generation-history.mjs
+++ b/lib/generation-history.mjs
@@ -139,8 +139,9 @@ export function normalizeGenerationRelationCandidate(input = {}) {
  * therefore emits candidates only. It never creates a GenerationRelation.
  * Candidates become durable relations only after explicit user confirmation.
  */
-export function resolveGenerationRelationCandidates({ projectId = "default", events = [], relations = [], candidates = [], now = new Date().toISOString() }) {
+export function resolveGenerationRelationCandidates({ projectId = "default", events = [], relations = [], candidates = [], childEventIds = null, now = new Date().toISOString() }) {
   const normalizedProjectId = clean(projectId) || "default";
+  const targetChildIds = childEventIds == null ? null : new Set([...childEventIds].map(clean).filter(Boolean));
   const ordered = [...events]
     .filter((event) => event?.id)
     .sort(compareGenerationEvents);
@@ -152,18 +153,21 @@ export function resolveGenerationRelationCandidates({ projectId = "default", eve
 
   for (let childIndex = 0; childIndex < ordered.length; childIndex += 1) {
     const child = ordered[childIndex];
+    if (targetChildIds && !targetChildIds.has(clean(child.id))) continue;
     if (clean(child.provider).toLowerCase() !== "chatgpt") continue;
     if (!clean(child.conversation_id)) continue;
-    const prior = ordered
-      .slice(0, childIndex)
-      .filter((parent) => isEligibleGptParent(parent, child))
-      .reverse();
     const suggestions = [];
-    for (let rank = 0; rank < prior.length; rank += 1) {
-      const parent = prior[rank];
+    let rank = 0;
+    for (let parentIndex = childIndex - 1; parentIndex >= 0; parentIndex -= 1) {
+      const parent = ordered[parentIndex];
+      if (!isEligibleGptParent(parent, child)) continue;
       const pairKey = generationCandidatePairKey({ child_generation_id: child.id, parent_generation_id: parent.id });
-      if (relationPairs.has(pairKey)) continue;
+      if (relationPairs.has(pairKey)) {
+        rank += 1;
+        continue;
+      }
       const scored = scoreGptRelationCandidate(parent, child, rank);
+      rank += 1;
       if (scored.confidence < GPT_RELATION_CANDIDATE_THRESHOLD) continue;
       suggestions.push(normalizeGenerationRelationCandidate({
         project_id: normalizedProjectId,

--- a/lib/mosa-runtime.mjs
+++ b/lib/mosa-runtime.mjs
@@ -207,7 +207,7 @@ export async function startMosaRuntime(options = {}) {
       }
       return result;
     };
-    await purgeTrash().catch((error) => {
+    void purgeTrash().catch((error) => {
       console.warn(`[MOSA] trash purge failed: ${error?.message || error}`);
     });
     trashPurgeTimer = setInterval(() => {

--- a/lib/sqlite-asset-store.mjs
+++ b/lib/sqlite-asset-store.mjs
@@ -1000,6 +1000,38 @@ export function createSqliteAssetStore(options = {}) {
       `).get(sanitizeProjectId(projectId || DEFAULT_PROJECT_ID), path);
       return row ? rowToAsset(database, row, { includeRelations: false }) : null;
     },
+    async findAssetByProviderIdentity(projectId, provider, providerAssetId = "", logicalOutputId = "") {
+      const cleanProjectId = sanitizeProjectId(projectId || DEFAULT_PROJECT_ID);
+      const cleanProvider = String(provider || "").trim().toLowerCase();
+      const cleanProviderAssetId = String(providerAssetId || "").trim();
+      const cleanLogicalOutputId = String(logicalOutputId || "").trim();
+      if (!cleanProvider || (!cleanProviderAssetId && !cleanLogicalOutputId)) return null;
+      const providerSourceTypes = {
+        chatgpt: "web-chatgpt",
+        gemini: "web-gemini",
+        flow: "web-flow",
+        "google-ai-studio": "web-google-ai-studio",
+      };
+      const sourceType = providerSourceTypes[cleanProvider] || "";
+      if (!sourceType) return null;
+      const clauses = [];
+      const params = [cleanProjectId, sourceType];
+      if (cleanProviderAssetId) {
+        clauses.push("provider_asset_id = ?");
+        params.push(cleanProviderAssetId);
+      }
+      if (cleanLogicalOutputId) {
+        clauses.push("logical_output_id = ?");
+        params.push(cleanLogicalOutputId);
+      }
+      const row = database.prepare(`
+        SELECT * FROM assets
+        WHERE project_id = ? AND source_type = ? AND deleted_at IS NULL
+          AND (${clauses.join(" OR ")})
+        ORDER BY archived ASC, created_at DESC, id DESC LIMIT 1
+      `).get(...params);
+      return row ? rowToAsset(database, row, { includeRelations: false }) : null;
+    },
     async findAssetByPixelHash(projectId, pixelHash) {
       const hash = String(pixelHash || "");
       if (!hash) return null;
@@ -1011,6 +1043,30 @@ export function createSqliteAssetStore(options = {}) {
         ORDER BY archived ASC, mosa_normalize_created_at(created_at) DESC, id DESC LIMIT 1
       `).get(sanitizeProjectId(projectId || DEFAULT_PROJECT_ID), hash, PIXEL_HASH_VERSION);
       return row ? rowToAsset(database, row) : null;
+    },
+    async findAssetsByPixelHash(projectId, pixelHash) {
+      const hash = String(pixelHash || "");
+      if (!hash) return [];
+      return database.prepare(`
+        SELECT * FROM assets INDEXED BY assets_project_pixel_hash_idx
+        WHERE project_id = ? AND pixel_sha256 = ? AND deleted_at IS NULL
+        ORDER BY archived ASC, mosa_normalize_created_at(created_at) DESC, id DESC
+      `).all(sanitizeProjectId(projectId || DEFAULT_PROJECT_ID), hash)
+        .map((row) => rowToAsset(database, row, { includeRelations: false }));
+    },
+    async listAssetsByConversation(projectId, conversationId) {
+      const cleanProjectId = sanitizeProjectId(projectId || DEFAULT_PROJECT_ID);
+      const cleanConversationId = String(conversationId || "").trim();
+      if (!cleanConversationId) return [];
+      const select = database.prepare(`
+        SELECT * FROM assets INDEXED BY assets_project_conversation_idx
+        WHERE project_id = ? AND archived = ? AND conversation_id = ? AND deleted_at IS NULL
+        ORDER BY created_at DESC, id DESC
+      `);
+      return [
+        ...select.all(cleanProjectId, 0, cleanConversationId),
+        ...select.all(cleanProjectId, 1, cleanConversationId),
+      ].map((row) => rowToAsset(database, row, { includeRelations: false }));
     },
     async findAutomaticIngestSuppression(projectId = DEFAULT_PROJECT_ID, hashes = {}) {
       const cleanProjectId = sanitizeProjectId(projectId || DEFAULT_PROJECT_ID);
@@ -1746,7 +1802,7 @@ export function createSqliteAssetStore(options = {}) {
         references_json: JSON.stringify(storedEvent.references || []),
         evidence_json: JSON.stringify(storedEvent.evidence || {}),
       });
-      syncSqliteGenerationRelationCandidates(database, event.project_id);
+      syncSqliteGenerationRelationCandidatesForEvent(database, event.project_id, existing ? generationEventFromRow(existing) : null, storedEvent);
       return storedEvent;
     },
     async listGenerationEvents(projectId, filters = {}) {
@@ -2248,6 +2304,23 @@ function ensureSourcePathColumn(database) {
   `).run();
 }
 
+function ensureWebCaptureLookupColumns(database) {
+  const columns = new Set(database.prepare("SELECT name FROM pragma_table_info('assets')").all().map((row) => row.name));
+  const needsBackfill = !columns.has("provider_asset_id") || !columns.has("logical_output_id");
+  if (!columns.has("provider_asset_id")) database.exec("ALTER TABLE assets ADD COLUMN provider_asset_id TEXT NOT NULL DEFAULT ''");
+  if (!columns.has("logical_output_id")) database.exec("ALTER TABLE assets ADD COLUMN logical_output_id TEXT NOT NULL DEFAULT ''");
+  database.exec("CREATE INDEX IF NOT EXISTS assets_project_provider_asset_idx ON assets(project_id, provider_asset_id)");
+  database.exec("CREATE INDEX IF NOT EXISTS assets_project_logical_output_idx ON assets(project_id, logical_output_id)");
+  if (!needsBackfill) return;
+  database.prepare(`
+    UPDATE assets
+    SET provider_asset_id = COALESCE(CAST(json_extract(source_json, '$.provider_asset_id') AS TEXT), ''),
+        logical_output_id = COALESCE(CAST(json_extract(source_json, '$.logical_output_id') AS TEXT), '')
+    WHERE provider_asset_id != COALESCE(CAST(json_extract(source_json, '$.provider_asset_id') AS TEXT), '')
+       OR logical_output_id != COALESCE(CAST(json_extract(source_json, '$.logical_output_id') AS TEXT), '')
+  `).run();
+}
+
 function ensureSuppressionPixelHashVersion(database) {
   const hasColumn = database.prepare("SELECT COUNT(*) AS count FROM pragma_table_info('automatic_ingest_suppressions') WHERE name = 'pixel_hash_version'").get().count > 0;
   if (!hasColumn) database.exec("ALTER TABLE automatic_ingest_suppressions ADD COLUMN pixel_hash_version TEXT NOT NULL DEFAULT ''");
@@ -2387,6 +2460,7 @@ function ensureGenerationEventColumns(database) {
     database.exec("ALTER TABLE generation_events ADD COLUMN generation_status TEXT NOT NULL DEFAULT 'unknown'");
   }
   database.exec("CREATE INDEX IF NOT EXISTS generation_events_tool_call_idx ON generation_events(project_id, provider, provider_tool_call_id, created_at, id)");
+  database.exec("CREATE INDEX IF NOT EXISTS generation_events_conversation_idx ON generation_events(project_id, provider, conversation_id, created_at, id)");
 }
 
 function openDatabase(databasePath) {
@@ -2482,6 +2556,8 @@ function initializeSchema(database) {
       source_type TEXT NOT NULL,
       source_json TEXT NOT NULL,
       source_path TEXT NOT NULL DEFAULT '',
+      provider_asset_id TEXT NOT NULL DEFAULT '',
+      logical_output_id TEXT NOT NULL DEFAULT '',
       metadata_json TEXT NOT NULL,
       search_text TEXT NOT NULL,
       tags_text TEXT NOT NULL DEFAULT '',
@@ -2638,6 +2714,7 @@ function initializeSchema(database) {
   ensureCreatedAtEpoch(database);
   ensurePixelHashColumn(database);
   ensureSourcePathColumn(database);
+  ensureWebCaptureLookupColumns(database);
   ensureSuppressionPixelHashVersion(database);
   ensureSortName(database);
   ensureAssetStackSortColumns(database);
@@ -2743,7 +2820,9 @@ function saveAsset(database, metadata, options = {}) {
         business_fields_json = excluded.business_fields_json, theme = excluded.theme, favorite = excluded.favorite,
         archived = excluded.archived, group_name = excluded.group_name, category = excluded.category, rating = excluded.rating,
         parent_asset_id = excluded.parent_asset_id, version_change = excluded.version_change, source_type = excluded.source_type,
-        pixel_sha256 = excluded.pixel_sha256, source_json = excluded.source_json, source_path = excluded.source_path, metadata_json = excluded.metadata_json, search_text = excluded.search_text,
+        pixel_sha256 = excluded.pixel_sha256, source_json = excluded.source_json, source_path = excluded.source_path,
+        provider_asset_id = excluded.provider_asset_id, logical_output_id = excluded.logical_output_id,
+        metadata_json = excluded.metadata_json, search_text = excluded.search_text,
         tags_text = excluded.tags_text, business_search_text = excluded.business_search_text, source_search_text = excluded.source_search_text,
         media_kind = excluded.media_kind, source_group = excluded.source_group,
         conversation_id = excluded.conversation_id, generation_batch = excluded.generation_batch,
@@ -2754,13 +2833,13 @@ function saveAsset(database, metadata, options = {}) {
       INSERT INTO assets (
         project_id, id, asset, original_path, preview_path, thumbnail_path, content_sha256, pixel_sha256, prompt, skill, style, ratio,
         business_fields_json, theme, favorite, archived, group_name, category, rating, parent_asset_id, version_change,
-        source_type, source_json, source_path, metadata_json, search_text, tags_text, business_search_text, source_search_text, media_kind, source_group,
+        source_type, source_json, source_path, provider_asset_id, logical_output_id, metadata_json, search_text, tags_text, business_search_text, source_search_text, media_kind, source_group,
         conversation_id, generation_batch,
         created_at, created_at_epoch, updated_at, sort_name
       ) VALUES (
         @project_id, @id, @asset, @image_path, NULL, NULL, @content_sha256, @pixel_sha256, @prompt, @skill, @style, @ratio,
         @business_fields_json, @theme, @favorite, @archived, @group_name, @category, @rating, @parent_asset_id, @version_change,
-        @source_type, @source_json, @source_path, @metadata_json, @search_text, @tags_text, @business_search_text, @source_search_text, @media_kind, @source_group,
+        @source_type, @source_json, @source_path, @provider_asset_id, @logical_output_id, @metadata_json, @search_text, @tags_text, @business_search_text, @source_search_text, @media_kind, @source_group,
         @conversation_id, @generation_batch,
         @created_at, @created_at_epoch, @updated_at, @sort_name
       )
@@ -2788,6 +2867,8 @@ function saveAsset(database, metadata, options = {}) {
       source_type: String(source.type || "local-file"),
       source_json: JSON.stringify(source),
       source_path: sourcePath,
+      provider_asset_id: String(source.provider_asset_id || ""),
+      logical_output_id: String(source.logical_output_id || ""),
       metadata_json: JSON.stringify(unknownMetadata),
       search_text: searchText,
       tags_text: tagsText,
@@ -3681,6 +3762,71 @@ function generationRelationCandidateFromRow(row) {
   };
 }
 
+function syncSqliteGenerationRelationCandidatesForEvent(database, projectId, previousEvent, nextEvent) {
+  const changedEvents = [previousEvent, nextEvent].filter(Boolean);
+  const conversations = [...new Set(changedEvents
+    .filter((event) => String(event?.provider || "").toLowerCase() === "chatgpt" && event?.conversation_id)
+    .map((event) => String(event.conversation_id)))];
+  const eventIds = [...new Set(changedEvents.map((event) => event.id).filter(Boolean))];
+  const conversationClause = conversations.length
+    ? ` OR (provider = 'chatgpt' AND conversation_id IN (${conversations.map(() => "?").join(",")}))`
+    : "";
+  const idClause = eventIds.length ? `id IN (${eventIds.map(() => "?").join(",")})` : "0";
+  const events = database.prepare(`
+    SELECT * FROM generation_events
+    WHERE project_id = ? AND (${idClause}${conversationClause})
+    ORDER BY created_at, id
+  `).all(projectId, ...eventIds, ...conversations).map(generationEventFromRow);
+  const compareEvents = (left, right) => (
+    String(left?.created_at || "").localeCompare(String(right?.created_at || ""))
+    || String(left?.id || "").localeCompare(String(right?.id || ""))
+  );
+  const thresholdsByConversation = new Map();
+  for (const event of changedEvents) {
+    if (String(event?.provider || "").toLowerCase() !== "chatgpt" || !event?.conversation_id) continue;
+    const key = String(event.conversation_id);
+    const current = thresholdsByConversation.get(key);
+    if (!current || compareEvents(event, current) < 0) thresholdsByConversation.set(key, event);
+  }
+  const changedIds = new Set(eventIds);
+  const childIds = [...new Set(events
+    .filter((event) => {
+      if (changedIds.has(event.id)) return true;
+      const threshold = thresholdsByConversation.get(String(event.conversation_id || ""));
+      return threshold && compareEvents(event, threshold) >= 0;
+    })
+    .map((event) => event.id))];
+  if (!childIds.length) return [];
+  const placeholders = childIds.map(() => "?").join(",");
+  const relations = database.prepare(`
+    SELECT * FROM generation_relations
+    WHERE project_id = ? AND child_generation_id IN (${placeholders})
+    ORDER BY created_at, child_generation_id, parent_generation_id
+  `).all(projectId, ...childIds).map(generationRelationFromRow);
+  const candidates = database.prepare(`
+    SELECT * FROM generation_relation_candidates
+    WHERE project_id = ? AND child_generation_id IN (${placeholders})
+  `).all(projectId, ...childIds).map(generationRelationCandidateFromRow);
+  const resolved = resolveGenerationRelationCandidates({ projectId, events, relations, candidates, childEventIds: childIds, now: now() });
+  const write = database.transaction(() => {
+    database.prepare(`DELETE FROM generation_relation_candidates WHERE project_id = ? AND child_generation_id IN (${placeholders})`).run(projectId, ...childIds);
+    const insert = database.prepare(`
+      INSERT INTO generation_relation_candidates (
+        project_id, child_generation_id, parent_generation_id, suggested_relation_type,
+        confidence, verification_level, evidence_json, status, created_at, updated_at
+      ) VALUES (
+        @project_id, @child_generation_id, @parent_generation_id, @suggested_relation_type,
+        @confidence, @verification_level, @evidence_json, @status, @created_at, @updated_at
+      )
+    `);
+    for (const candidate of resolved) {
+      insert.run({ ...candidate, evidence_json: JSON.stringify(candidate.evidence || {}) });
+    }
+  });
+  write();
+  return resolved;
+}
+
 function syncSqliteGenerationRelationCandidates(database, projectId) {
   const events = database.prepare("SELECT * FROM generation_events WHERE project_id = ? ORDER BY created_at, id").all(projectId).map(generationEventFromRow);
   const relations = database.prepare("SELECT * FROM generation_relations WHERE project_id = ? ORDER BY created_at, child_generation_id, parent_generation_id").all(projectId).map(generationRelationFromRow);
@@ -3697,9 +3843,7 @@ function syncSqliteGenerationRelationCandidates(database, projectId) {
         @confidence, @verification_level, @evidence_json, @status, @created_at, @updated_at
       )
     `);
-    for (const candidate of resolved) {
-      insert.run({ ...candidate, evidence_json: JSON.stringify(candidate.evidence || {}) });
-    }
+    for (const candidate of resolved) insert.run({ ...candidate, evidence_json: JSON.stringify(candidate.evidence || {}) });
   });
   write();
   return resolved;

--- a/lib/web-capture-ingest.ts
+++ b/lib/web-capture-ingest.ts
@@ -76,6 +76,9 @@ interface Store {
   recordGenerationEvent?(input: Metadata): Promise<Metadata>;
   findAssetByContentHash?(projectId: string, contentHash: string): Promise<StoredAsset | null>;
   findAssetByPixelHash?(projectId: string, pixelHash: string): Promise<StoredAsset | null>;
+  findAssetsByPixelHash?(projectId: string, pixelHash: string): Promise<StoredAsset[]>;
+  findAssetByProviderIdentity?(projectId: string, provider: string, providerAssetId?: string, logicalOutputId?: string): Promise<StoredAsset | null>;
+  listAssetsByConversation?(projectId: string, conversationId: string): Promise<StoredAsset[]>;
   libraryDir?: string;
   assetsRoot?: string;
   [key: string]: unknown;
@@ -192,13 +195,28 @@ async function upgradeWebCaptureMetadata({ store, projectId, input }: { store: S
   const providerAssetId = String(input.providerAssetId || input.provider_asset_id || "").trim();
   const logicalOutputId = logicalCaptureKey(projectId, provider, input);
   const sourceMediaUrl = sanitizeStoredMediaUrl(input.sourceMediaUrl || input.source_media_url);
-  const assets = await Promise.all([
-    store.listAssets({ projectId }),
-    store.listAssets({ projectId, archived: true }).catch(() => []),
-  ]).then(([active, archived]) => [...active, ...archived]);
-  let asset = findLogicalProviderAsset(assets, provider, providerAssetId, logicalOutputId);
+  let assets: StoredAsset[] | null = null;
+  let asset = typeof store.findAssetByProviderIdentity === "function"
+    ? await store.findAssetByProviderIdentity(projectId, provider, providerAssetId, logicalOutputId)
+    : null;
+  if (!asset && typeof store.findAssetByProviderIdentity !== "function") {
+    const listedAssets = await Promise.all([
+      store.listAssets({ projectId }),
+      store.listAssets({ projectId, archived: true }).catch(() => []),
+    ]).then(([active, archived]) => [...active, ...archived]);
+    assets = listedAssets;
+    asset = findLogicalProviderAsset(listedAssets, provider, providerAssetId, logicalOutputId);
+  }
   if (!asset && sourceMediaUrl) {
-    asset = assets.find((candidate) => {
+    let listedAssets = assets;
+    if (!listedAssets) {
+      listedAssets = await Promise.all([
+        store.listAssets({ projectId }),
+        store.listAssets({ projectId, archived: true }).catch(() => []),
+      ]).then(([active, archived]) => [...active, ...archived]);
+      assets = listedAssets;
+    }
+    asset = (listedAssets || []).find((candidate) => {
       if (String(candidate.source?.provider || "").trim().toLowerCase() !== provider) return false;
       const occurrences = Array.isArray(candidate.source?.capture_occurrences) ? candidate.source.capture_occurrences : [];
       return occurrences.some((entry) => sanitizeStoredMediaUrl((entry as Metadata)?.source_media_url) === sourceMediaUrl);
@@ -419,7 +437,9 @@ async function ingestWebCaptureUnlocked(options: { store: Store; referenceStore?
   };
   let logicalExistingForReplacement: StoredAsset | null = null;
   if (providerAssetId || logicalOutputId) {
-    const logicalExisting = findLogicalProviderAsset(await projectAssets(), provider, providerAssetId, logicalOutputId);
+    const logicalExisting = typeof store.findAssetByProviderIdentity === "function"
+      ? await store.findAssetByProviderIdentity(projectId, provider, providerAssetId, logicalOutputId)
+      : findLogicalProviderAsset(await projectAssets(), provider, providerAssetId, logicalOutputId);
     if (logicalExisting) {
       const existingHash = String(logicalExisting.source?.content_sha256 || "").trim();
       if (existingHash === contentHash) return finalizeDuplicate(logicalExisting);
@@ -441,7 +461,7 @@ async function ingestWebCaptureUnlocked(options: { store: Store; referenceStore?
   try {
     const explicitAssetId = String(input.assetId || "").trim();
     let assetId = sanitizeAssetId(explicitAssetId || `${providerConfig.assetIdPrefix}-${contentHash.slice(0, 12)}`, providerConfig.assetIdPrefix);
-    const references = await turnReferences(projectAssets, referenceStore, projectId, { conversationId, generationContextId, capturedAt, selfAssetId: assetId });
+    const references = await turnReferences(store, projectAssets, referenceStore, projectId, { conversationId, generationContextId, capturedAt, selfAssetId: assetId });
     const assetInput = {
       projectId,
       imagePath: tempPath,
@@ -751,7 +771,7 @@ async function ingestWebVideoCapture(options: {
   try {
     const explicitAssetId = String(input.assetId || "").trim();
     let assetId = sanitizeAssetId(explicitAssetId || `${providerConfig.assetIdPrefix}-video-${contentHash.slice(0, 12)}`, providerConfig.assetIdPrefix);
-    const references = await turnReferences(projectAssets, referenceStore, projectId, { conversationId, generationContextId, capturedAt, selfAssetId: assetId });
+    const references = await turnReferences(store, projectAssets, referenceStore, projectId, { conversationId, generationContextId, capturedAt, selfAssetId: assetId });
     const assetInput = {
       projectId,
       imagePath: tempPath,
@@ -1120,7 +1140,10 @@ async function findArchivedDuplicate(store: Store, projectId: string, contentHas
     ? await store.findAssetByPixelHash(projectId, pixelHash)
     : (await projectAssets()).find((a) => a.source?.pixel_sha256 === pixelHash) || null;
   if (indexedMatch && await isTrustedPixelMatch(store, indexedMatch, pixelHash)) return indexedMatch;
-  const candidates = (await projectAssets()).filter((asset) => asset.source?.pixel_sha256 === pixelHash && asset.id !== indexedMatch?.id);
+  const candidates = (typeof store.findAssetsByPixelHash === "function"
+    ? await store.findAssetsByPixelHash(projectId, pixelHash)
+    : (await projectAssets()).filter((asset) => asset.source?.pixel_sha256 === pixelHash))
+    .filter((asset) => asset.id !== indexedMatch?.id);
   for (const candidate of candidates) if (await isTrustedPixelMatch(store, candidate, pixelHash)) return candidate;
   return null;
 }
@@ -1140,7 +1163,7 @@ async function isTrustedPixelMatch(store: Store, asset: StoredAsset, pixelHash: 
 
 const MAX_TURN_REFERENCES = 8;
 
-async function turnReferences(projectAssets: () => Promise<StoredAsset[]>, referenceStore: ReturnType<typeof createReferenceAttachmentStore>, projectId: string, { conversationId, generationContextId, capturedAt, selfAssetId }: { conversationId: string; generationContextId: string; capturedAt: string; selfAssetId: string }): Promise<Metadata[]> {
+async function turnReferences(store: Store, projectAssets: () => Promise<StoredAsset[]>, referenceStore: ReturnType<typeof createReferenceAttachmentStore>, projectId: string, { conversationId, generationContextId, capturedAt, selfAssetId }: { conversationId: string; generationContextId: string; capturedAt: string; selfAssetId: string }): Promise<Metadata[]> {
   if (!conversationId && !generationContextId) return [];
   const now = createdAtTimestamp(capturedAt);
   if (now === null) return [];
@@ -1157,7 +1180,9 @@ async function turnReferences(projectAssets: () => Promise<StoredAsset[]>, refer
       .map(({ attachment, usage }) => referenceMetadata(attachment, usage));
   }
 
-  const members = (await projectAssets()).filter((asset) =>
+  const members = (typeof store.listAssetsByConversation === "function"
+    ? await store.listAssetsByConversation(projectId, conversationId)
+    : await projectAssets()).filter((asset) =>
     asset.id !== selfAssetId && asset.source?.conversation_id === conversationId);
   const timeOf = (asset: StoredAsset) => createdAtTimestamp(asset.source?.captured_at || asset.created_at);
 
@@ -1232,7 +1257,7 @@ async function mergeDuplicateGenerationRecipe(
   },
 ): Promise<{ asset: StoredAsset; merged: boolean }> {
   if (typeof store.updateMetadata !== "function") return { asset: existing, merged: false };
-  const references = await turnReferences(input.projectAssets, input.referenceStore, input.projectId, {
+  const references = await turnReferences(store, input.projectAssets, input.referenceStore, input.projectId, {
     conversationId: input.conversationId,
     generationContextId: input.generationContextId,
     capturedAt: input.capturedAt,

--- a/test/asset-stack-ui.test.mjs
+++ b/test/asset-stack-ui.test.mjs
@@ -72,6 +72,8 @@ test("visual stack behavior is wired into the shared web and desktop renderer", 
   assert.match(stackController, /if \(movingIds\.includes\(targetId\)\) return false/);
   assert.match(stackController, /STACK_DRAG_THRESHOLD_PX = 8/);
   assert.match(stackController, /setPointerCapture\(event\.pointerId\)/);
+  assert.match(stackController, /if \(pointerMoveFrame !== null\) \{\s+cancelAnimationFrame\(pointerMoveFrame\);\s+pointerMoveFrame = null;\s+flushPointerMove\(\);/,
+    "pointerup flushes a coalesced move before resolving the drop target");
   assert.match(stackController, /lostpointercapture/);
   assert.match(stackController, /window\.addEventListener\("blur"/);
   assert.match(stackController, /moveBlockRelative\(currentIds, drag\.assetIds, targetId, placement\)/);

--- a/test/desktop-packaging.test.mjs
+++ b/test/desktop-packaging.test.mjs
@@ -348,6 +348,9 @@ test("keeps the desktop window single-instance and sandboxed", async () => {
   assert.match(source, /startMosaService/);
   assert.match(source, /DEFAULT_MOSA_DESKTOP_PORT/);
   assert.match(source, /const desktopDataDir = app\.getPath\("userData"\)/);
+  assert.match(source, /const defaultLibraryDir = join\(userInfo\(\)\.homedir, "MOSA Library"\)/);
+  assert.doesNotMatch(source, /homedir\(\).*MOSA Library/);
+  assert.match(source, /failOnPrimaryLibraryMismatch: true/);
   assert.match(source, /cowartProjectDir: desktopDataDir/);
   assert.match(source, /loadURL\(service\.url\)/);
   assert.doesNotMatch(source, /loadFile\(/);

--- a/test/service-manager.test.mjs
+++ b/test/service-manager.test.mjs
@@ -9,6 +9,7 @@ import { startMosaRuntime } from "../lib/mosa-runtime.mjs";
 import {
   MosaServiceBuildMismatchError,
   MosaServiceConflictError,
+  MosaServiceLibraryMismatchError,
   compareMosaVersions,
   retireOlderMosaService,
   shouldAllowSameVersionServiceReplacement,
@@ -196,14 +197,13 @@ test("source desktop hands off a verified same-version stale runtime to the curr
     runtimeFingerprint: "new-runtime",
   };
   const replacement = {
-    state: "attached",
     url: "http://127.0.0.1:43517",
     port: 43517,
     libraryDir,
     storage: "sqlite",
-    ...expectedIdentity,
   };
   let handoffCalls = 0;
+  let startCalls = 0;
 
   const attached = await startMosaService({
     port: 43517,
@@ -217,12 +217,18 @@ test("source desktop hands off a verified same-version stale runtime to the curr
       assert.equal(options.allowSameVersionReplacement, true);
       return true;
     },
-    upgradeProbeImpl: async () => replacement,
+    startRuntime: async (options) => {
+      startCalls += 1;
+      assert.equal(options.port, 43517);
+      assert.equal(options.libraryDir, libraryDir);
+      return { ...replacement, stop: async () => {} };
+    },
   });
 
   assert.equal(handoffCalls, 1);
+  assert.equal(startCalls, 1);
   assert.equal(attached.url, replacement.url);
-  assert.equal(attached.productVersion, expectedIdentity.productVersion);
+  assert.equal(attached.mode, "owned");
 });
 
 test("automatic retirement does not target same-version, newer, unknown, or different-library services", async (t) => {
@@ -708,6 +714,45 @@ test("falls back to another discovery port when the preferred port is occupied",
   assert.equal(service.port, fallbackPort);
   assert.equal(foreign.listening, true);
   assert.equal((await fetch(`${service.url}/api/health`)).status, 200);
+});
+
+test("desktop fail-closed mode does not fork to a fallback port when primary MOSA serves another library", async (t) => {
+  const root = await temporaryRoot(t, "mosa-service-library-mismatch-");
+  const libraryDir = join(root, "library");
+  const otherLibraryDir = join(root, "other-library");
+  const preferredPort = await availablePort();
+  const fallbackPort = await availablePort();
+  const primaryMosa = createServer((_req, res) => {
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ product: "mosa", libraryDir: otherLibraryDir, storage: "sqlite" }));
+  });
+  await listen(primaryMosa, preferredPort);
+  t.after(() => close(primaryMosa));
+  let startCalls = 0;
+
+  await assert.rejects(
+    startMosaService({
+      port: preferredPort,
+      libraryDir,
+      allowPortFallback: true,
+      failOnPrimaryLibraryMismatch: true,
+      discoveryPorts: [preferredPort, fallbackPort],
+      startRuntime: async () => {
+        startCalls += 1;
+        throw new Error("must not start fallback runtime");
+      },
+    }),
+    (error) => {
+      assert.ok(error instanceof MosaServiceLibraryMismatchError);
+      assert.equal(error.code, "MOSA_SERVICE_LIBRARY_MISMATCH");
+      assert.equal(error.port, preferredPort);
+      assert.equal(error.expectedLibraryDir, resolve(libraryDir));
+      assert.equal(error.actualLibraryDir, resolve(otherLibraryDir));
+      return true;
+    },
+  );
+  assert.equal(startCalls, 0, "a second library runtime must not be spawned on a fallback port");
+  assert.equal(primaryMosa.listening, true);
 });
 
 test("discovers an already-running matching MOSA on a fallback port before acquiring the library lock", async (t) => {


### PR DESCRIPTION
## Summary\n- add indexed SQLite lookups for provider identity, pixel duplicates, and conversation-scoped references\n- incrementally refresh generation relation candidates and defer reference pruning\n- avoid blocking runtime startup on trash cleanup\n- make source desktop library resolution use the OS account home and fail closed on primary-port library mismatches\n- keep gallery virtualization and Stack dragging within the animation frame budget\n\n## Validation\n- npm test (986 passed, 2 skipped, 0 failed)\n- npm run lint\n- npm run check\n- npm run check:web-capture-store\n- npm run check:desktop-node\n- git diff --check\n- npm run qa:gallery:performance (2,000 assets; 50 hydrated; 5,270 DOM nodes; 0ms long tasks; 0 visible bottom placeholders)