### PR TITLE
chore: bump desktop package version to 0.2.1-rc.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mosa",
-  "version": "0.2.1-rc.4",
+  "version": "0.2.1-rc.5",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",
   "type": "module",


### PR DESCRIPTION
Bump the desktop package version from 0.2.1-rc.4 to 0.2.1-rc.5 so the newly built macOS and Windows artifacts are uniquely identifiable and rollback-safe. Product code is unchanged; this PR only updates package.json version metadata.