### PR TITLE
fix: harden gallery interactions and navigation races

### DIFF
--- a/app/api-client.mjs
+++ b/app/api-client.mjs
@@ -73,15 +73,7 @@ export function createApiClient(deps) {
       state.supportedMediaExtensions = Array.isArray(library.supportedMediaExtensions) ? library.supportedMediaExtensions : [];
       updateCodexHint();
     }
-    const rawGroups = result.navigation || {};
-    const nextGroups = {
-      total: Number(rawGroups.total || 0),
-      favorites: Number(rawGroups.favorites || 0),
-      unorganized: Number(rawGroups.unorganized || 0),
-      trash: Number(rawGroups.trash || 0),
-      sourceTypes: Array.isArray(rawGroups.sourceTypes) ? rawGroups.sourceTypes : [],
-      groups: Array.isArray(rawGroups.groups) ? rawGroups.groups : [],
-    };
+    const nextGroups = navigationStateFromPayload(result);
     const changed = JSON.stringify(nextGroups) !== JSON.stringify(state.groups);
     state.groups = nextGroups;
     if (!options.background || changed) {
@@ -90,6 +82,85 @@ export function createApiClient(deps) {
         || state.assets.every((asset) => (asset.project_id || project) === project);
       if (state.galleryStatus !== "loading" && assetsBelongToProject) updateViewTitle();
     }
+    return true;
+  }
+
+  function navigationStateFromPayload(result = {}) {
+    const rawGroups = result.navigation || {};
+    return {
+      total: Number(rawGroups.total || 0),
+      favorites: Number(rawGroups.favorites || 0),
+      unorganized: Number(rawGroups.unorganized || 0),
+      trash: Number(rawGroups.trash || 0),
+      sourceTypes: Array.isArray(rawGroups.sourceTypes) ? rawGroups.sourceTypes : [],
+      groups: Array.isArray(rawGroups.groups) ? rawGroups.groups : [],
+    };
+  }
+
+  // Project switching is a transaction, not a sequence of state mutations.
+  // Fetch the complete destination workspace against an explicit request first;
+  // only after every required request succeeds do we replace project-scoped
+  // state. A failed switch therefore leaves the old project and its gallery
+  // paired, instead of exposing old cards under a new project id.
+  async function switchProjectWorkspace(project, options = {}) {
+    const projectId = String(project || "").trim();
+    if (!projectId || projectId === state.project) return true;
+    const request = {
+      project: projectId,
+      query: "",
+      scope: "all",
+      mediaKind: "all",
+      facets: Object.fromEntries(FACET_KEYS.map((key) => [key, ""])),
+      sort: state.sort,
+      stackId: "",
+    };
+    const [library, navigation, assetsResult] = await Promise.all([
+      apiFetch(`/api/library-path?project=${encodeURIComponent(projectId)}`).catch(() => null),
+      apiFetch(`/api/navigation?project=${encodeURIComponent(projectId)}`),
+      requestAssetPage(request, { limit: GALLERY_INITIAL_PAGE_SIZE }),
+    ]);
+    if (typeof options.shouldCommit === "function" && !options.shouldCommit()) return false;
+
+    resetAssetPrefetch();
+    state.project = projectId;
+    state.query = "";
+    state.scope = "all";
+    state.mediaKind = "all";
+    state.facets = { ...request.facets };
+    state.activeStackId = "";
+    state.activeStackSummary = null;
+    state.stackReturnSnapshot = null;
+    state.selectedId = null;
+    state.selectedIds = new Set();
+    state.selectedStackNodes = new Map();
+    state.selectionProject = projectId;
+    state.selectionRequestKey = "";
+    state.detailAsset = null;
+    state.detailStack = null;
+    state.versionHistory = null;
+    state.recipeHistory = null;
+    state.generationHistory = null;
+    state.assets = assetsResult.assets || [];
+    state.loadedAssetCount = state.assets.length;
+    state.loadedPageCount = 1;
+    state.pageTotal = Number.isFinite(Number(assetsResult.page?.total)) ? Number(assetsResult.page.total) : state.assets.length;
+    state.nextCursor = assetsResult.page?.nextCursor || null;
+    state.galleryStatus = "ready";
+    state.galleryError = null;
+    state.paginationStatus = "idle";
+    state.groups = navigationStateFromPayload(navigation);
+    state.libraryPath = library?.path || "";
+    state.libraryRoot = library?.libraryDir || "";
+    state.codexImagesDir = library?.codexGeneratedImagesDir || "";
+    state.supportedMediaExtensions = Array.isArray(library?.supportedMediaExtensions) ? library.supportedMediaExtensions : [];
+    updateCodexHint();
+    renderQuickFilters();
+    renderSettingsMenu();
+    renderGrid({ preserveScroll: false });
+    updateViewTitle();
+    lastCommittedAssetRequestKey = assetRequestKey(request);
+    noteLibraryRevision(assetsResult.revision);
+    if (state.nextCursor) void prefetchNextAssetPage();
     return true;
   }
 
@@ -606,7 +677,7 @@ export function createApiClient(deps) {
   }
 
   return {
-    apiFetch, loadProjects, loadStats, loadAssets, refreshLibraryInBackground, refreshLibraryIfChanged,
+    apiFetch, loadProjects, loadStats, switchProjectWorkspace, loadAssets, refreshLibraryInBackground, refreshLibraryIfChanged,
     refreshAssetPageTotalInBackground, refreshLoadedAssetsInBackground, performFullGalleryReconciliation,
     buildAssetPageParams, requestAssetPage, requestAssetTotal, currentAssetRequest, assetRequestKey, assetListVersion, assetVersion,
     noteLibraryRevision, getLibraryRevisionBaseline, setLibraryDeltaApplier, fetchLibraryChanges,

--- a/app/app.mjs
+++ b/app/app.mjs
@@ -179,7 +179,7 @@ const apiClient = createApiClient({
   prewarmAssetMedia,
   refreshSelectedStackInspector,
 });
-const { apiFetch, loadProjects, loadStats, loadAssets, refreshLibraryInBackground, refreshLibraryIfChanged, refreshAssetPageTotalInBackground, performFullGalleryReconciliation, reconcileLibraryRevision, noteLibraryRevision, getLibraryRevisionBaseline, setLibraryDeltaApplier, fetchLibraryChanges, resetAssetPrefetch, buildAssetPageParams, requestAssetPage, currentAssetRequest, assetRequestKey, assetListVersion, assetVersion } = apiClient;
+const { apiFetch, loadProjects, loadStats, switchProjectWorkspace, loadAssets, refreshLibraryInBackground, refreshLibraryIfChanged, refreshAssetPageTotalInBackground, performFullGalleryReconciliation, reconcileLibraryRevision, noteLibraryRevision, getLibraryRevisionBaseline, setLibraryDeltaApplier, fetchLibraryChanges, resetAssetPrefetch, buildAssetPageParams, requestAssetPage, currentAssetRequest, assetRequestKey, assetListVersion, assetVersion } = apiClient;
 
 // ===== New element references =====
 Object.assign(els, {
@@ -219,6 +219,33 @@ Object.assign(els, {
   confirmDialogConfirm: document.querySelector("#confirmDialogConfirm"),
 });
 
+function gallerySelectionRects() {
+  const grid = els.assetGrid;
+  if (!grid || !galleryCardVirtualGeometryById.size || !galleryCardVirtualGeometryColumns.length) return null;
+  const styles = getComputedStyle(grid);
+  const paddingLeft = Number.parseFloat(styles.paddingLeft) || 0;
+  const paddingTop = Number.parseFloat(styles.paddingTop) || 0;
+  const gap = Number.parseFloat(styles.columnGap) || 0;
+  const columnWidth = galleryCardVirtualColumnWidth || galleryCardColumnWidth(styles);
+  const result = [];
+  for (const geometry of galleryCardVirtualGeometryById.values()) {
+    const left = paddingLeft + geometry.columnIndex * (columnWidth + gap);
+    const top = paddingTop + Math.max(0, geometry.rowStart - 1);
+    const slotHeight = Math.max(1, geometry.rowEnd - geometry.rowStart);
+    const cardHeight = Math.max(1, slotHeight - gap);
+    result.push({
+      id: geometry.id,
+      rect: {
+        left,
+        right: left + columnWidth,
+        top,
+        bottom: top + cardHeight,
+      },
+    });
+  }
+  return result;
+}
+
 const gallerySelection = createGallerySelection({
   els,
   state,
@@ -228,6 +255,7 @@ const gallerySelection = createGallerySelection({
   requestAssetPage,
   apiFetch,
   showToast,
+  getCardSelectionRects: gallerySelectionRects,
 });
 
 // ===== Library Change 增量 reconciliation =====
@@ -854,7 +882,8 @@ function announceEmptyState(kind) {
  * container is the fallback.
  */
 async function resetLibraryRefinements() {
-  if (!await confirmDetailNavigation(null)) return false;
+  const intent = beginNavigationIntent();
+  if (!await authorizeNavigationIntent(intent)) return false;
   discardDetailDraft();
   state.query = "";
   if (els.searchInput) els.searchInput.value = "";
@@ -1473,12 +1502,33 @@ function updateViewTitle() {
 
 async function clearSearchQuery() {
   if (!state.query && !els.searchInput?.value) return false;
-  if (!await confirmDetailNavigation(null)) return;
+  const intent = beginNavigationIntent();
+  if (!await authorizeNavigationIntent(intent)) return false;
   discardDetailDraft();
   state.query = "";
   if (els.searchInput) els.searchInput.value = "";
   applyFilterChange();
   return true;
+}
+
+let navigationIntentRevision = 0;
+function beginNavigationIntent() {
+  return {
+    revision: ++navigationIntentRevision,
+    projectId: state.project,
+    selectedId: state.selectedId,
+  };
+}
+function isNavigationIntentCurrent(intent) {
+  return Boolean(intent)
+    && intent.revision === navigationIntentRevision
+    && intent.projectId === state.project
+    && intent.selectedId === state.selectedId;
+}
+async function authorizeNavigationIntent(intent) {
+  if (!isNavigationIntentCurrent(intent)) return false;
+  if (!await confirmDetailNavigation(null)) return false;
+  return isNavigationIntentCurrent(intent);
 }
 
 function bindEvents() {
@@ -1489,13 +1539,13 @@ function bindEvents() {
   els.mobileNavScrim?.addEventListener("click", () => setMobileNavOpen(false, { restoreFocus: true }));
   els.sidebar?.addEventListener("click", (event) => {
     if (!isMobileNavigationViewport()) return;
-    if (event.target.closest(".nav-item, .add-group-button, .settings-trigger")) setMobileNavOpen(false);
+    if (event.target.closest(".nav-item, .settings-trigger")) setMobileNavOpen(false);
   });
-  els.searchInput?.addEventListener("input", debounce(async () => {
+  const commitSearchInput = debounce(async (intent) => {
     const nextQuery = els.searchInput.value;
     if (nextQuery === state.query) return;
-    if (!await confirmDetailNavigation(null)) {
-      els.searchInput.value = state.query;
+    if (!await authorizeNavigationIntent(intent)) {
+      if (isNavigationIntentCurrent(intent)) els.searchInput.value = state.query;
       return;
     }
     discardDetailDraft();
@@ -1505,11 +1555,18 @@ function bindEvents() {
     if (state.viewMode === "asset") returnToLibrary();
     clearDetailSelection();
     await loadAssets();
-  }, 180));
+  }, 180);
+  els.searchInput?.addEventListener("input", () => {
+    // Capture ordering synchronously, before the debounce delay. A later click
+    // on a filter/sort/project control must outrank an older search keystroke
+    // even if the search callback wakes up afterwards.
+    commitSearchInput(beginNavigationIntent());
+  });
   els.sortSelect?.addEventListener("change", async () => {
     const nextSort = normalizeSort(els.sortSelect.value);
     if (nextSort === state.sort) return;
-    if (!await confirmDetailNavigation(null)) {
+    const intent = beginNavigationIntent();
+    if (!await authorizeNavigationIntent(intent)) {
       els.sortSelect.value = state.sort;
       return;
     }
@@ -1669,16 +1726,36 @@ function bindEvents() {
     event.preventDefault();
     startSidebarGroupCreate();
   });
+  let manualGroupClickTimer = null;
   els.sidebarManualGroupList?.addEventListener("click", (event) => {
     if (event.target.closest("[data-sidebar-group-editor]")) return;
     const button = event.target.closest("[data-filter]");
-    if (button) void setFilter(button.dataset.filter, button.dataset.value);
+    if (!button) return;
+    const filter = button.dataset.filter;
+    const value = button.dataset.value;
+    const intent = beginNavigationIntent();
+    // Keyboard activation has no dblclick ambiguity and should remain
+    // immediate. Pointer single-click waits briefly so a real double-click can
+    // be claimed exclusively by rename instead of also toggling the filter.
+    if (event.detail === 0) {
+      void setFilter(filter, value, intent);
+      return;
+    }
+    if (manualGroupClickTimer !== null) window.clearTimeout(manualGroupClickTimer);
+    manualGroupClickTimer = window.setTimeout(() => {
+      manualGroupClickTimer = null;
+      void setFilter(filter, value, intent);
+    }, 220);
   });
   els.sidebarManualGroupList?.addEventListener("dblclick", (event) => {
     const button = event.target.closest('[data-filter="group"][data-value]');
     if (!button) return;
     event.preventDefault();
     event.stopPropagation();
+    if (manualGroupClickTimer !== null) {
+      window.clearTimeout(manualGroupClickTimer);
+      manualGroupClickTimer = null;
+    }
     startSidebarGroupRename(button.dataset.value);
   });
   els.sidebarManualGroupList?.addEventListener("input", (event) => {
@@ -1706,7 +1783,8 @@ function bindEvents() {
   els.typeFilters?.addEventListener("click", async (event) => {
     const button = event.target.closest("[data-type]");
     if (!button || button.dataset.type === state.mediaKind) return;
-    if (!await confirmDetailNavigation(null)) return;
+    const intent = beginNavigationIntent();
+    if (!await authorizeNavigationIntent(intent)) return;
     discardDetailDraft();
     state.mediaKind = button.dataset.type;
     renderTypeFilters();
@@ -1718,7 +1796,8 @@ function bindEvents() {
     if (!select) return;
     const previousProject = state.project;
     if (select.value === previousProject) return;
-    if (!await confirmDetailNavigation(null)) {
+    const intent = beginNavigationIntent();
+    if (!await authorizeNavigationIntent(intent)) {
       select.value = previousProject;
       return;
     }
@@ -1727,13 +1806,26 @@ function bindEvents() {
       showToast(t("operationInProgress"), "default");
       return;
     }
-    discardDetailDraft();
-    if (state.activeStackId) assetStacks.abandonStackContext();
-    state.project = select.value; clearDetailSelection(); state.scope = "all"; clearFacets(); state.query = ""; els.searchInput.value = ""; state.nextCursor = null;
-    // Phase 3A：项目切换改变结果集语义，退出查看模式（设置菜单在侧栏，查看模式下仍可达）。
-    if (state.viewMode === "asset") returnToLibrary();
-    await loadStats(); await loadAssets();
-    startLibraryEventStream();
+    const nextProject = select.value;
+    try {
+      const switched = await switchProjectWorkspace(nextProject, {
+        shouldCommit: () => isNavigationIntentCurrent(intent),
+      });
+      if (!switched) {
+        select.value = state.project;
+        return;
+      }
+      discardDetailDraft();
+      assetStacks.abandonStackContext();
+      clearDetailSelection();
+      gallerySelection.clear();
+      if (els.searchInput) els.searchInput.value = "";
+      if (state.viewMode === "asset") returnToLibrary();
+      startLibraryEventStream();
+    } catch (error) {
+      select.value = previousProject;
+      showToast(error?.message || t("loadFailed"), "error");
+    }
   });
   els.settingsMenu?.addEventListener("click", (event) => {
     const button = event.target.closest("button");
@@ -2060,10 +2152,10 @@ function setSidebarNavigationState(type, value = "") {
 }
 
 /** One entry point for the three sidebar navigation zones. */
-async function setFilter(type, value = "") {
+async function setFilter(type, value = "", intent = beginNavigationIntent()) {
   const valid = type === "all" || SCOPES.includes(type) || type === "source" || type === "group";
   if (!valid) return;
-  if (!await confirmDetailNavigation(null)) return;
+  if (!await authorizeNavigationIntent(intent)) return;
   discardDetailDraft();
   if (!setSidebarNavigationState(type, value)) return;
   applyFilterChange();
@@ -2086,7 +2178,8 @@ async function showRelatedGenerations(asset, mode) {
   const conversationId = String(asset?.source?.conversation_id || "").trim();
   const messageId = String(asset?.source?.message_id || "").trim();
   if (!conversationId || (mode === "batch" && !messageId)) return;
-  if (!await confirmDetailNavigation(null)) return;
+  const intent = beginNavigationIntent();
+  if (!await authorizeNavigationIntent(intent)) return;
   discardDetailDraft();
   state.scope = "all";
   state.mediaKind = "all";
@@ -2454,9 +2547,6 @@ function shouldHydrateGalleryCard(entry, ordinal) {
 }
 
 function replaceVirtualGalleryCards(observerEntries) {
-  const grid = els.assetGrid;
-  const bottomOffset = grid ? Math.max(0, grid.scrollHeight - grid.scrollTop - grid.clientHeight) : null;
-  const preserveBottomOffset = bottomOffset !== null && bottomOffset <= 1200;
   const replacements = [];
   for (const item of observerEntries) {
     const card = item.target;
@@ -2515,10 +2605,6 @@ function replaceVirtualGalleryCards(observerEntries) {
   if (changed) {
     invalidateCardGeometryCache();
     gallerySelection.syncRenderedSelection({ prune: false, changedIds });
-    if (preserveBottomOffset && grid) {
-      const targetScrollTop = Math.max(0, grid.scrollHeight - grid.clientHeight - bottomOffset);
-      if (Math.abs(grid.scrollTop - targetScrollTop) > 0.5) grid.scrollTop = targetScrollTop;
-    }
   }
 }
 
@@ -2929,6 +3015,77 @@ function setupGalleryMediaVirtualization(roots = null) {
   });
 }
 
+function galleryCardIntrinsicHeight(card) {
+  const mediaButton = card.querySelector(":scope > .asset-card-select");
+  const info = card.querySelector(":scope > .asset-card-info");
+  const mediaHeight = mediaButton instanceof HTMLElement ? mediaButton.getBoundingClientRect().height : 0;
+  const infoHeight = info instanceof HTMLElement ? info.getBoundingClientRect().height : 0;
+  const contentHeight = mediaHeight + infoHeight;
+  return contentHeight > 0 ? contentHeight : (card.getBoundingClientRect().height || 0);
+}
+
+function masonryGeometrySpan(grid, geometry) {
+  const card = galleryCardVirtualNode(grid, geometry.id);
+  let span = card
+    ? Number.parseInt(String(card.style.gridRowEnd || "").replace(/\D+/g, ""), 10)
+    : galleryCardVirtualSpanCache.get(galleryVirtualSpanKey(geometry.id));
+  if (!Number.isFinite(span) || span <= 0) span = geometry.rowEnd - geometry.rowStart;
+  if (!Number.isFinite(span) || span <= 0) {
+    const entry = galleryCardVirtualEntries.get(geometry.id);
+    if (entry) span = estimatedGalleryCardSpan(entry.asset);
+  }
+  return Math.max(1, Number.isFinite(span) ? Math.ceil(span) : 1);
+}
+
+// A hydrated card may reveal a more accurate height than its virtual estimate.
+// Re-running shortest-column placement for the entire gallery at that point
+// makes later cards hop between columns, which is especially visible while an
+// infinite-scroll page is entering the warm zone. Keep the established column
+// assignment stable and shift only the affected column from the first changed
+// card downward. Full relayouts (resize, density or structural changes) still
+// use placeMasonryCards and are free to rebalance columns.
+function reflowPlacedMasonryColumns(grid, cards) {
+  const affectedColumns = new Map();
+  for (const card of cards) {
+    if (!(card instanceof HTMLElement) || !card.dataset.id) return false;
+    const geometry = galleryCardVirtualGeometryById.get(card.dataset.id);
+    const column = geometry ? galleryCardVirtualGeometryColumns[geometry.columnIndex] : null;
+    if (!geometry || !column) return false;
+    const index = column.findIndex((item) => item.id === geometry.id);
+    if (index < 0) return false;
+    const previous = affectedColumns.get(geometry.columnIndex);
+    affectedColumns.set(geometry.columnIndex, previous === undefined ? index : Math.min(previous, index));
+  }
+
+  for (const [columnIndex, startIndex] of affectedColumns) {
+    const column = galleryCardVirtualGeometryColumns[columnIndex];
+    let rowStart = startIndex > 0 ? column[startIndex - 1].rowEnd : 1;
+    for (let index = startIndex; index < column.length; index += 1) {
+      const geometry = column[index];
+      const span = masonryGeometrySpan(grid, geometry);
+      geometry.rowStart = rowStart;
+      geometry.rowEnd = rowStart + span;
+      const card = galleryCardVirtualNode(grid, geometry.id);
+      if (card) {
+        const columnStart = String(columnIndex + 1);
+        const nextRowStart = String(geometry.rowStart);
+        if (card.style.gridColumnStart !== columnStart) card.style.gridColumnStart = columnStart;
+        if (card.style.gridRowStart !== nextRowStart) card.style.gridRowStart = nextRowStart;
+        card.style.gridRowEnd = `span ${span}`;
+      }
+      rowStart = geometry.rowEnd;
+    }
+  }
+
+  invalidateCardGeometryCache();
+  syncGalleryVirtualExtent();
+  if (state.assets.length >= GALLERY_CARD_VIRTUAL_THRESHOLD) {
+    pruneGalleryCardDomWindow();
+    scheduleGalleryCardVirtualWindowSync();
+  }
+  return true;
+}
+
 function layoutMasonry(cards = null) {
   const grid = els.assetGrid;
   if (!grid) return;
@@ -2941,30 +3098,37 @@ function layoutMasonry(cards = null) {
   const measurements = [];
   let needsPlacement = !cards;
   let allTargetsUnplaced = Boolean(cards?.length);
+  let allTargetsPlaced = Boolean(cards?.length);
   targets.forEach((card) => {
     if (!(card instanceof HTMLElement) || !card.isConnected) return;
     const alreadyPlaced = Boolean(card.style.gridColumnStart && card.style.gridRowStart);
-    if (!alreadyPlaced) needsPlacement = true;
+    if (!alreadyPlaced) {
+      needsPlacement = true;
+      allTargetsPlaced = false;
+    }
     else allTargetsUnplaced = false;
     if (card.classList.contains("asset-card-virtual-placeholder")) return;
-    // content-visibility is enabled only after the real masonry span has been
-    // measured. Temporarily expose the card when a relayout is required so an
-    // offscreen intrinsic placeholder can never feed a fake height back into
-    // the masonry algorithm.
+    // Keep the existing grid span pinned while measuring. Removing grid-row-end
+    // forces a temporary one-row topology and can make Chromium's scroll anchor
+    // react to an intermediate layout that is never meant to be painted.
+    // Exposing descendants is enough because the card itself is align-self:start.
     const previousSpan = Number.parseInt(String(card.style.gridRowEnd || "").replace(/\D+/g, ""), 10);
     card.classList.remove("masonry-content-virtualized");
-    card.style.removeProperty("grid-row-end");
     measureTargets.push([card, previousSpan]);
   });
   // All layout-affecting writes above are complete before the first geometry
   // read, so Chromium performs one layout flush instead of a write/read cycle
   // for every card.
   measureTargets.forEach(([card, previousSpan]) => {
-    const height = card.getBoundingClientRect().height || 0;
+    const height = galleryCardIntrinsicHeight(card);
     if (height) measurements.push([card, Math.ceil(height + galleryGap), previousSpan]);
   });
+  const spanChangedCards = [];
   measurements.forEach(([card, span, previousSpan]) => {
-    if (!Number.isFinite(previousSpan) || previousSpan !== span) needsPlacement = true;
+    if (!Number.isFinite(previousSpan) || previousSpan !== span) {
+      needsPlacement = true;
+      spanChangedCards.push(card);
+    }
     card.style.gridRowEnd = `span ${span}`;
     if (card.dataset.id) galleryCardVirtualSpanCache.set(galleryVirtualSpanKey(card.dataset.id, virtualColumnWidth), span);
     card.classList.add("masonry-content-virtualized");
@@ -2973,6 +3137,7 @@ function layoutMasonry(cards = null) {
     invalidateCardGeometryCache();
     return;
   }
+  if (allTargetsPlaced && spanChangedCards.length && reflowPlacedMasonryColumns(grid, spanChangedCards)) return;
   const columnCount = Math.max(1, gridStyles.gridTemplateColumns.split(/\s+/).filter(Boolean).length);
   const canAppendIncrementally = allTargetsUnplaced
     && galleryCardVirtualGeometryColumns.length === columnCount

--- a/app/context-menu-actions.mjs
+++ b/app/context-menu-actions.mjs
@@ -66,31 +66,43 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
     return Number.isFinite(count) && count > 0 ? count : Math.max(1, selectedAssets.length);
   }
 
-  async function selectedMutationIds(asset, selectedAssets = [], options = {}) {
+  async function selectedMutationContext(asset, selectedAssets = [], options = {}) {
     const count = logicalSelectionCount(selectedAssets, options);
+    const selectionContext = typeof gallerySelection?.captureActionContext === "function"
+      ? gallerySelection.captureActionContext()
+      : null;
     if (count > 1 && typeof gallerySelection?.resolveSelectedAssetIds === "function") {
-      const ids = await gallerySelection.resolveSelectedAssetIds();
-      if (ids.length) return ids;
+      const resolved = await gallerySelection.resolveSelectedAssetIds(selectionContext || undefined);
+      if (resolved?.ids?.length) return { ...resolved, selectionContext };
+      if (resolved === null) return null;
     }
-    return [asset.id];
+    return { projectId: selectionContext?.projectId || state.project, ids: [asset.id], selectionContext };
   }
 
-  function mutationAssetsForIds(ids = []) {
+  function mutationContextIsCurrent(context) {
+    if (!context) return false;
+    if (context.projectId !== state.project) return false;
+    return !context.selectionContext
+      || typeof gallerySelection?.isActionContextCurrent !== "function"
+      || gallerySelection.isActionContextCurrent(context.selectionContext);
+  }
+
+  function mutationAssetsForIds(ids = [], projectId = state.project) {
     const loaded = new Map((state.assets || []).map((entry) => [entry.id, entry]));
-    return ids.map((id) => loaded.get(id) || { id, project_id: state.project });
+    return ids.map((id) => loaded.get(id) || { id, project_id: projectId });
   }
 
-  async function applyGroupMutation(ids, group) {
+  async function applyGroupMutation(projectId, ids, group) {
     return apiFetch("/api/assets/batch", {
       method: "POST",
-      body: { action: "group", projectId: state.project, assetIds: ids, group },
+      body: { action: "group", projectId, assetIds: ids, group },
     });
   }
 
   // Full manifest of one group via the existing paged asset query. Never cap a
   // user's export by an arbitrary asset count: cursor-loop detection provides
   // the safety bound without silently truncating large libraries.
-  async function fetchGroupAssets(groupName) {
+  async function fetchGroupAssets(groupName, projectId = state.project) {
     const collected = [];
     const seenAssetIds = new Set();
     const seenCursors = new Set();
@@ -100,7 +112,7 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
         if (seenCursors.has(cursor)) throw new Error("Group export pagination stalled.");
         seenCursors.add(cursor);
       }
-      const params = new URLSearchParams({ project: state.project, group: groupName, limit: "100" });
+      const params = new URLSearchParams({ project: projectId, group: groupName, limit: "100" });
       if (cursor) params.set("cursor", cursor);
       const result = await apiFetch(`/api/assets?${params}`);
       for (const asset of result.assets || []) {
@@ -153,10 +165,11 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
           icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="m7 10 5-5 5 5"/><path d="M12 5v12"/></svg>',
           action: async () => {
             await runAction(async () => {
-              const assets = await fetchGroupAssets(item.name);
+              const projectId = state.project;
+              const assets = await fetchGroupAssets(item.name, projectId);
               downloadJson(`mosa-group-${safeFileToken(item.name)}.json`, {
                 exportedAt: new Date().toISOString(),
-                project: state.project,
+                project: projectId,
                 group: item.name,
                 assets,
               });
@@ -236,11 +249,14 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
           icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 8v5h5"/><path d="M5.5 13a7 7 0 1 0 2-7"/></svg>',
           action: async () => {
             await runAction(async () => {
-              const ids = await selectedMutationIds(asset, selectedAssets, options);
-              const assets = mutationAssetsForIds(ids);
+              const context = await selectedMutationContext(asset, selectedAssets, options);
+              if (!context || !mutationContextIsCurrent(context)) return;
+              const { ids, projectId } = context;
+              const assets = mutationAssetsForIds(ids, projectId);
               for (const item of assets) {
                 await apiFetch(`/api/assets/${encodeURIComponent(item.project_id)}/${encodeURIComponent(item.id)}/restore`, { method: "POST" });
               }
+              if (!mutationContextIsCurrent(context)) return;
               showToast(assets.length > 1 ? t("assetsRestored", { count: assets.length }) : t("assetRestored"), "success");
               window.dispatchEvent(new CustomEvent("mosa:refresh-groups"));
               window.dispatchEvent(new CustomEvent("mosa:refresh-assets", {
@@ -255,15 +271,17 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
           icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 6h18M8 6V4h8v2m2 0-1 15H7L6 6"/><path d="M10 10v7M14 10v7"/></svg>',
           danger: true,
           action: async () => {
-            const ids = await selectedMutationIds(asset, selectedAssets, options);
-            const assets = mutationAssetsForIds(ids);
+            const context = await selectedMutationContext(asset, selectedAssets, options);
+            if (!context || !mutationContextIsCurrent(context)) return;
+            const { ids, projectId } = context;
+            const assets = mutationAssetsForIds(ids, projectId);
             const confirmed = await requestConfirmation({
               title: assets.length > 1 ? t("permanentDeleteAssetsTitle", { count: assets.length }) : t("permanentDeleteTitle"),
               description: t("permanentDeleteDescription"),
               confirmLabel: t("permanentDelete"),
               tone: "danger",
             });
-            if (!confirmed) return;
+            if (!confirmed || !mutationContextIsCurrent(context)) return;
             await runAction(async () => {
               await releaseAssetMedia?.(assets);
               const failed = [];
@@ -274,6 +292,7 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
                   failed.push({ assetId: item.id, error });
                 }
               }
+              if (!mutationContextIsCurrent(context)) return;
               if (failed.length) showToast(t("trashPartialDelete", { count: failed.length }), "error");
               else showToast(assets.length > 1 ? t("assetsPermanentlyDeleted", { count: assets.length }) : t("assetPermanentlyDeleted"), "success");
               window.dispatchEvent(new CustomEvent("mosa:refresh-groups"));
@@ -391,19 +410,22 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
         ? '<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="1.8"><path d="m12 3 2.8 5.7 6.2.9-4.5 4.4 1.1 6.2-5.6-3-5.6 3 1.1-6.2L3 9.6l6.2-.9L12 3Z"/></svg>'
         : '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="m12 3 2.8 5.7 6.2.9-4.5 4.4 1.1 6.2-5.6-3-5.6 3 1.1-6.2L3 9.6l6.2-.9L12 3Z"/></svg>',
       action: async () => {
-        const ids = await selectedMutationIds(asset, selectedAssets, options);
-        const assets = mutationAssetsForIds(ids);
+        const context = await selectedMutationContext(asset, selectedAssets, options);
+        if (!context || !mutationContextIsCurrent(context)) return;
+        const { ids, projectId } = context;
+        const assets = mutationAssetsForIds(ids, projectId);
         await runAction(async () => {
           if (isMultiple) {
             const response = await apiFetch("/api/assets/batch", {
               method: "POST",
               body: {
                 action: "favorite",
-                projectId: state.project,
+                projectId,
                 assetIds: ids,
                 favorite: !asset.favorite,
               },
             });
+            if (!mutationContextIsCurrent(context)) return;
             const outcome = reconcileBatchMutation(assets, response);
             if (outcome.failed.length) {
               showToast(t("batchPartialResult", { succeeded: outcome.succeeded.length, failed: outcome.failed.length }), "error");
@@ -414,6 +436,7 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
               await apiFetch(`/api/assets/${encodeURIComponent(asset.project_id)}/${encodeURIComponent(asset.id)}/favorite`, {
                 method: "POST",
               });
+              if (!mutationContextIsCurrent(context)) return;
               showToast(asset.favorite ? t("removedFromFavorites") : t("addedToFavorites"), "success");
             }
             window.dispatchEvent(new CustomEvent("mosa:refresh-assets", {
@@ -443,11 +466,15 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
             label: groupName,
             icon: `<svg width="14" height="14" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" fill="${savedColor}"/></svg>`,
             action: async () => {
-              const ids = await selectedMutationIds(asset, selectedAssets, options);
-              const assets = mutationAssetsForIds(ids);
+              const context = await selectedMutationContext(asset, selectedAssets, options);
+              if (!context || !mutationContextIsCurrent(context)) return;
+              const { ids, projectId } = context;
+              const assets = mutationAssetsForIds(ids, projectId);
               if (!await confirmSelectedAssetMutation(assets)) return;
+              if (!mutationContextIsCurrent(context)) return;
               await runAction(async () => {
-                const response = await applyGroupMutation(ids, groupName);
+                const response = await applyGroupMutation(projectId, ids, groupName);
+                if (!mutationContextIsCurrent(context)) return;
                 const outcome = reconcileBatchMutation(assets, response);
                 commitSelectedAssetMutation(assets);
                 if (outcome.failed.length) showToast(t("batchPartialResult", { succeeded: outcome.succeeded.length, failed: outcome.failed.length }), "error");
@@ -517,26 +544,30 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
         icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6h14Z"/></svg>',
         danger: true,
         action: async () => {
-          const ids = await selectedMutationIds(asset, selectedAssets, options);
-          const assets = mutationAssetsForIds(ids);
+          const context = await selectedMutationContext(asset, selectedAssets, options);
+          if (!context || !mutationContextIsCurrent(context)) return;
+          const { ids, projectId } = context;
+          const assets = mutationAssetsForIds(ids, projectId);
           const confirmed = await requestConfirmation({
             title: ids.length > 1 ? t("moveAssetsToTrashTitle", { count: ids.length }) : t("moveToTrashTitle"),
             description: t("moveToTrashDescription"),
             confirmLabel: t("moveToTrash"),
             tone: "danger",
           });
-          if (!confirmed) return;
+          if (!confirmed || !mutationContextIsCurrent(context)) return;
           if (!await confirmSelectedAssetMutation(assets)) return;
+          if (!mutationContextIsCurrent(context)) return;
 
           await runAction(async () => {
             const response = await apiFetch("/api/assets/batch", {
               method: "POST",
               body: {
                 action: "trash",
-                projectId: state.project,
+                projectId,
                 assetIds: ids,
               },
             });
+            if (!mutationContextIsCurrent(context)) return;
             const outcome = reconcileBatchMutation(assets, response);
             commitSelectedAssetMutation(outcome.succeeded);
             if (outcome.failed.length) {
@@ -596,10 +627,10 @@ export function createContextMenuActions({ state, els, t, apiClient, showToast, 
       {
         label: t("selectAll"),
         icon: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>',
-        shortcut: "⌘A",
-        disabled: true,
+        shortcut: /Mac|iPhone|iPad/.test(navigator.platform) ? "⌘A" : "Ctrl+A",
+        disabled: !state.pageTotal,
         action: async () => {
-          showToast(t("allSelected"), "success");
+          await gallerySelection?.selectAll?.({ announce: true });
         },
       },
     ];

--- a/app/gallery-selection.mjs
+++ b/app/gallery-selection.mjs
@@ -45,6 +45,7 @@ export function createGallerySelection({
   requestAssetPage,
   apiFetch,
   showToast,
+  getCardSelectionRects,
 }) {
   let pointer = null;
   let selectionBox = null;
@@ -71,6 +72,24 @@ export function createGallerySelection({
     } catch {
       return "";
     }
+  }
+
+  function captureActionContext() {
+    const selectedIds = new Set(ensureSelectionSet());
+    return {
+      projectId: state.project,
+      requestKey: currentSelectionRequestKey(),
+      revision: selectionRevision,
+      selectedIds,
+      stackNodes: new Map(ensureStackSelectionMap()),
+    };
+  }
+
+  function isActionContextCurrent(context) {
+    if (!context) return false;
+    return context.projectId === state.project
+      && context.requestKey === currentSelectionRequestKey()
+      && context.revision === selectionRevision;
   }
 
   function ensureStackSelectionMap() {
@@ -250,11 +269,14 @@ export function createGallerySelection({
     }
   }
 
-  async function resolveSelectedAssetIds() {
-    const selected = new Set(ensureSelectionSet());
-    const stackNodes = new Map(ensureStackSelectionMap());
-    if (!stackNodes.size) return [...selected];
-    if (typeof apiFetch !== "function") return [...selected].filter((id) => !stackNodes.has(id));
+  async function resolveSelectedAssetIds(context = captureActionContext()) {
+    if (!isActionContextCurrent(context)) return null;
+    const selected = new Set(context.selectedIds);
+    const stackNodes = new Map(context.stackNodes);
+    if (!stackNodes.size) return { projectId: context.projectId, ids: [...selected] };
+    if (typeof apiFetch !== "function") {
+      return { projectId: context.projectId, ids: [...selected].filter((id) => !stackNodes.has(id)) };
+    }
     for (const [coverId, stackId] of stackNodes) {
       selected.delete(coverId);
       const seenCursors = new Set();
@@ -264,15 +286,16 @@ export function createGallerySelection({
           if (seenCursors.has(cursor)) throw new Error("Stack selection pagination stalled.");
           seenCursors.add(cursor);
         }
-        const params = new URLSearchParams({ project: state.project, limit: "250", includeTotal: "0" });
+        const params = new URLSearchParams({ project: context.projectId, limit: "250", includeTotal: "0" });
         if (cursor) params.set("cursor", cursor);
         const page = await apiFetch(`/api/asset-stacks/${encodeURIComponent(stackId)}/assets?${params}`);
+        if (!isActionContextCurrent(context)) return null;
         for (const asset of page.assets || []) if (asset?.id) selected.add(asset.id);
         cursor = page.page?.nextCursor || "";
         if (!cursor) break;
       }
     }
-    return [...selected];
+    return { projectId: context.projectId, ids: [...selected] };
   }
 
   function replaceWith(id, { announce = false } = {}) {
@@ -328,21 +351,26 @@ export function createGallerySelection({
     pointer.startContentX = startX - bounds.left + scrollLeft;
     pointer.startContentY = startY - bounds.top + scrollTop;
     // Cache card geometry once per gesture in scroll-content coordinates.
-    // Pointermove can fire far above the display refresh rate; avoiding an
-    // all-card getBoundingClientRect() loop per event removes the largest
-    // source of marquee jank in large Stacks.
-    pointer.cardRects = [...els.assetGrid.querySelectorAll(":scope > .asset-card")].map((card) => {
-      const rect = card.getBoundingClientRect();
-      return {
-        id: card.dataset.id || "",
-        rect: {
-          left: rect.left - bounds.left + scrollLeft,
-          right: rect.right - bounds.left + scrollLeft,
-          top: rect.top - bounds.top + scrollTop,
-          bottom: rect.bottom - bounds.top + scrollTop,
-        },
-      };
-    }).filter((entry) => entry.id);
+    // Large galleries prune offscreen card DOM while marquee auto-scroll is
+    // active, so prefer the masonry geometry provider: it represents the whole
+    // loaded result window regardless of which cards are mounted. Small views
+    // keep the DOM measurement fallback. Pointermove then intersects a stable
+    // snapshot instead of a virtualized DOM window that changes underneath it.
+    const providedRects = typeof getCardSelectionRects === "function" ? getCardSelectionRects() : null;
+    pointer.cardRects = Array.isArray(providedRects) && providedRects.length
+      ? providedRects
+      : [...els.assetGrid.querySelectorAll(":scope > .asset-card")].map((card) => {
+        const rect = card.getBoundingClientRect();
+        return {
+          id: card.dataset.id || "",
+          rect: {
+            left: rect.left - bounds.left + scrollLeft,
+            right: rect.right - bounds.left + scrollLeft,
+            top: rect.top - bounds.top + scrollTop,
+            bottom: rect.bottom - bounds.top + scrollTop,
+          },
+        };
+      }).filter((entry) => entry.id);
     pointer.cardRectBands = new Map();
     for (const entry of pointer.cardRects) {
       const firstBand = Math.floor(entry.rect.top / MARQUEE_GEOMETRY_BAND_PX);
@@ -542,6 +570,8 @@ export function createGallerySelection({
     replaceWith,
     selectAll,
     selectRange,
+    captureActionContext,
+    isActionContextCurrent,
     resolveSelectedAssetIds,
     hasSelectedStacks: () => ensureStackSelectionMap().size > 0,
     syncRenderedSelection,

--- a/app/styles.css
+++ b/app/styles.css
@@ -370,7 +370,7 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
    （首次加载/追加页），搜索、筛选、排序的普通重渲染不重复播放。
    V2：普通卡片不保留容器铬件；选中态由卡片外侧 1px 圆角描边表达。 */
 .asset-card { position: relative; width: 100%; align-self: start; }
-.asset-card-virtual-placeholder { align-self: stretch; contain: layout paint style; pointer-events: none; }
+.asset-card-virtual-placeholder { align-self: stretch; contain: layout paint style; overflow-anchor: none; pointer-events: none; }
 .asset-card-virtual-surface { display: block; width: 100%; height: 100%; min-height: 48px; border-radius: var(--radius-card); background: var(--app-hover); opacity: .28; }
 .asset-card.masonry-content-virtualized {
   /* Masonry has already fixed the outer grid span, so Chromium can skip the
@@ -449,13 +449,13 @@ body.asset-stack-dragging { cursor: grabbing; user-select: none; }
 .asset-card-badge { overflow: hidden; max-width: 96px; text-overflow: ellipsis; white-space: nowrap; }
 
 /* 加载更多 */
-.asset-load-more { grid-column: 1 / -1; display: flex; justify-content: center; padding: 18px 0 28px; }
+.asset-load-more { grid-column: 1 / -1; display: flex; justify-content: center; padding: 18px 0 28px; overflow-anchor: none; }
 .asset-load-more[hidden] { display: none; }
 .asset-load-more button { min-height: 30px; padding: 0 14px; border: 1px solid var(--color-border-subtle); border-radius: var(--radius-control); color: var(--color-text-secondary); background: var(--app-card); cursor: pointer; font: inherit; font-size: 12px; font-weight: 500; }
 
 /* 无限滚动哨兵 */
-.infinite-scroll-sentinel { grid-column: 1 / -1; height: 1px; pointer-events: none; }
-.gallery-virtual-extent { height: 1px; min-height: 1px; pointer-events: none; visibility: hidden; }
+.infinite-scroll-sentinel { grid-column: 1 / -1; height: 1px; overflow-anchor: none; pointer-events: none; }
+.gallery-virtual-extent { height: 1px; min-height: 1px; overflow-anchor: none; pointer-events: none; visibility: hidden; }
 
 /* ===== 左键框选 / 多选 ===== */
 .grid.selection-active { padding-bottom: calc(var(--statusbar-height) + var(--space-2)); }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "better-sqlite3": "^13.0.1",
-        "sharp": "^0.35.3"
+        "sharp": "^0.35.4"
       },
       "bin": {
         "mosa": "bin/mosa.mjs"
@@ -781,9 +781,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -967,9 +967,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
-      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
       "cpu": [
         "arm64"
       ],
@@ -985,13 +985,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
-      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
       "cpu": [
         "x64"
       ],
@@ -1007,20 +1007,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.3.2"
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-freebsd-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
-      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1030,9 +1030,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
-      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
       "cpu": [
         "arm64"
       ],
@@ -1046,9 +1046,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
-      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
       "cpu": [
         "x64"
       ],
@@ -1062,9 +1062,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
-      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
       "cpu": [
         "arm"
       ],
@@ -1078,9 +1078,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
-      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
       ],
@@ -1094,9 +1094,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
-      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
       "cpu": [
         "ppc64"
       ],
@@ -1110,9 +1110,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
-      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1126,9 +1126,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
-      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
       "cpu": [
         "s390x"
       ],
@@ -1142,9 +1142,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
-      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
       ],
@@ -1158,9 +1158,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
-      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
       "cpu": [
         "arm64"
       ],
@@ -1174,9 +1174,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
-      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
       "cpu": [
         "x64"
       ],
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
-      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
       ],
@@ -1208,13 +1208,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.3.2"
+        "@img/sharp-libvips-linux-arm": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
-      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
       "cpu": [
         "arm64"
       ],
@@ -1230,13 +1230,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.3.2"
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
-      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1252,13 +1252,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
-      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
       "cpu": [
         "riscv64"
       ],
@@ -1274,13 +1274,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
-      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
       ],
@@ -1296,13 +1296,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.3.2"
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
-      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
       "cpu": [
         "x64"
       ],
@@ -1318,13 +1318,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.3.2"
+        "@img/sharp-libvips-linux-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
-      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
       "cpu": [
         "arm64"
       ],
@@ -1340,13 +1340,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
-      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
       ],
@@ -1362,17 +1362,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
-      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.11.1"
+        "@emnapi/runtime": "^1.11.3"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1382,16 +1382,16 @@
       }
     },
     "node_modules/@img/sharp-webcontainers-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
-      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1401,9 +1401,9 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
-      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
       "cpu": [
         "arm64"
       ],
@@ -1420,9 +1420,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
-      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
       "cpu": [
         "ia32"
       ],
@@ -1439,9 +1439,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
-      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
       "cpu": [
         "x64"
       ],
@@ -6772,9 +6772,9 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
-      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@img/colour": "^1.1.0",
@@ -6788,31 +6788,31 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.35.3",
-        "@img/sharp-darwin-x64": "0.35.3",
-        "@img/sharp-freebsd-wasm32": "0.35.3",
-        "@img/sharp-libvips-darwin-arm64": "1.3.2",
-        "@img/sharp-libvips-darwin-x64": "1.3.2",
-        "@img/sharp-libvips-linux-arm": "1.3.2",
-        "@img/sharp-libvips-linux-arm64": "1.3.2",
-        "@img/sharp-libvips-linux-ppc64": "1.3.2",
-        "@img/sharp-libvips-linux-riscv64": "1.3.2",
-        "@img/sharp-libvips-linux-s390x": "1.3.2",
-        "@img/sharp-libvips-linux-x64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
-        "@img/sharp-linux-arm": "0.35.3",
-        "@img/sharp-linux-arm64": "0.35.3",
-        "@img/sharp-linux-ppc64": "0.35.3",
-        "@img/sharp-linux-riscv64": "0.35.3",
-        "@img/sharp-linux-s390x": "0.35.3",
-        "@img/sharp-linux-x64": "0.35.3",
-        "@img/sharp-linuxmusl-arm64": "0.35.3",
-        "@img/sharp-linuxmusl-x64": "0.35.3",
-        "@img/sharp-webcontainers-wasm32": "0.35.3",
-        "@img/sharp-win32-arm64": "0.35.3",
-        "@img/sharp-win32-ia32": "0.35.3",
-        "@img/sharp-win32-x64": "0.35.3"
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
       },
       "peerDependenciesMeta": {
         "@types/node": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^13.0.1",
-    "sharp": "^0.35.3"
+    "sharp": "^0.35.4"
   },
   "devDependencies": {
     "@electron-forge/cli": "7.11.2",

--- a/test/card-action-contract.test.mjs
+++ b/test/card-action-contract.test.mjs
@@ -221,7 +221,7 @@ test("17. no API, data-structure or persistence changes", async () => {
   // leave the hash table; their security-relevant behaviour is asserted
   // structurally below. The lockfile stays hash-pinned.
   const expected = {
-    "package-lock.json": "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec",
+    "package-lock.json": "51f3ff53219df2cfe3ea27ad9caf932a0cadbe062fec8905a11e39819a81fe54",
   };
   for (const [file, hash] of Object.entries(expected)) {
     const text = await readFile(resolve(root, file), "utf8");
@@ -233,7 +233,7 @@ test("17. no API, data-structure or persistence changes", async () => {
   assert.match(server, /process\.exit\(1\)/, "server.mjs must exit non-zero on isolation guard rejection");
   // package.json dependency sections stay frozen.
   const manifest = JSON.parse(await readFile(resolve(root, "package.json"), "utf8"));
-  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies must stay untouched in Phase 1C");
+  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "0339eb218322b3a863818f979cfe4aca62624c31811a775da305ccda617d91a7", "package.json dependencies must stay untouched in Phase 1C");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies must stay untouched in Phase 1C");
   const app = await readApp();
   // The favorite flow still posts to the same endpoint; renderGrid stays free of API calls.

--- a/test/confirm-dialog-contract.test.mjs
+++ b/test/confirm-dialog-contract.test.mjs
@@ -299,9 +299,9 @@ test("56-57. package manifest and lockfile unchanged", async () => {
   // qa:packaged launcher scripts, so the whole-manifest hash no longer holds;
   // the dependency sections the freeze really guards stay byte-identical.
   const manifest = JSON.parse(pkg);
-  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies frozen");
+  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "0339eb218322b3a863818f979cfe4aca62624c31811a775da305ccda617d91a7", "package.json dependencies frozen");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies frozen");
-  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json frozen");
+  assert.equal(sha256(lock), "51f3ff53219df2cfe3ea27ad9caf932a0cadbe062fec8905a11e39819a81fe54", "package-lock.json frozen");
 });
 
 // 58. The stylesheet stays free of !important while hosting the dialog styles.

--- a/test/desktop-i18n-contract.test.mjs
+++ b/test/desktop-i18n-contract.test.mjs
@@ -25,7 +25,7 @@ const DESKTOP_TEXT = {
   // approved scope) added qa:web/qa:electron/qa:packaged launcher scripts.
   // Its dependency sections are still frozen via the structural assertions in
   // the package metadata test below.
-  "package-lock.json": "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec",
+  "package-lock.json": "51f3ff53219df2cfe3ea27ad9caf932a0cadbe062fec8905a11e39819a81fe54",
 };
 
 function sliceBetween(source, startMarker, endMarker) {
@@ -156,6 +156,6 @@ test("package metadata stays frozen and the runtime preload preserves its approv
   // qa:packaged launcher scripts to package.json, so its dependency sections
   // (the frozen semantics) are pinned structurally instead of by file hash.
   const manifest = JSON.parse(await read("package.json"));
-  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies must remain unchanged");
+  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "0339eb218322b3a863818f979cfe4aca62624c31811a775da305ccda617d91a7", "package.json dependencies must remain unchanged");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies must remain unchanged");
 });

--- a/test/electron-preload-runtime-contract.test.mjs
+++ b/test/electron-preload-runtime-contract.test.mjs
@@ -33,7 +33,7 @@ const EXPECTED_API_KEYS = [
 // R1 isolation fix (2026-08-09, approved scope) added qa:web/qa:electron/
 // qa:packaged launcher scripts to package.json, so only its dependency
 // sections stay hash-pinned (see the dependency assertions below).
-const LOCKFILE_SHA256 = "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec";
+const LOCKFILE_SHA256 = "51f3ff53219df2cfe3ea27ad9caf932a0cadbe062fec8905a11e39819a81fe54";
 
 const read = (relativePath) => readFile(resolve(root, relativePath), "utf8");
 const sha256 = (value) => createHash("sha256").update(value).digest("hex");
@@ -125,7 +125,7 @@ test("preload path, module format, security settings, and API surface are stable
   assert.match(main, /minWidth: 960,/);
   assert.match(main, /minHeight: 640,/);
   const manifest = JSON.parse(packageJson);
-  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies were not changed by this phase");
+  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "0339eb218322b3a863818f979cfe4aca62624c31811a775da305ccda617d91a7", "package.json dependencies were not changed by this phase");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies were not changed by this phase");
   assert.equal(sha256(lockfile), LOCKFILE_SHA256, "package-lock.json was not changed by this phase");
   assert.doesNotMatch(packageJson, /electron-preload-runtime-contract/);

--- a/test/frontend-interaction-regressions.test.mjs
+++ b/test/frontend-interaction-regressions.test.mjs
@@ -160,6 +160,14 @@ test("manual sidebar groups create and rename inline without routing through the
   assert.match(app, /function startSidebarGroupRename\(groupName\)/);
   assert.match(app, /async function commitSidebarGroupEdit\(\)/);
   assert.match(app, /addGroupBtn\?\.addEventListener\("click"[\s\S]*?startSidebarGroupCreate\(\)/);
+  assert.match(app, /if \(event\.target\.closest\("\.nav-item, \.settings-trigger"\)\) setMobileNavOpen\(false\);/,
+    "mobile add-group keeps the sidebar open so the inline editor remains reachable");
+  assert.doesNotMatch(app, /\.nav-item, \.add-group-button, \.settings-trigger/,
+    "the add-group trigger must not immediately close the mobile drawer");
+  assert.match(app, /let manualGroupClickTimer = null;[\s\S]*?window\.setTimeout\(\(\) => \{[\s\S]*?setFilter\(filter, value, intent\);[\s\S]*?\}, 220\);/,
+    "pointer single-click waits for double-click arbitration instead of toggling the group first");
+  assert.match(app, /sidebarManualGroupList\?\.addEventListener\("dblclick"[\s\S]*?window\.clearTimeout\(manualGroupClickTimer\)[\s\S]*?startSidebarGroupRename/,
+    "double-click cancels the pending filter navigation and owns rename exclusively");
   assert.match(app, /sidebarManualGroupList\?\.addEventListener\("focusout"[\s\S]*?commitSidebarGroupEdit\(\)/);
   assert.match(app, /event\.key === "Enter"[\s\S]*?commitSidebarGroupEdit\(\)/);
   assert.match(actions, /label: t\("renameGroup"\)/);
@@ -262,6 +270,46 @@ test("group export paginates until exhaustion without a silent asset cap", async
   assert.match(actions, /if \(seenCursors\.has\(cursor\)\) throw new Error\("Group export pagination stalled\."\);/);
   assert.match(actions, /if \(!cursor\) break;/,
     "pagination terminates only when the server reports no next cursor");
+  assert.match(actions, /const projectId = state\.project;\s+const assets = await fetchGroupAssets\(item\.name, projectId\)/,
+    "group export freezes the project at action start instead of reading live state on every page");
+  assert.match(actions, /project: projectId/,
+    "the exported manifest records the same frozen project used for pagination");
+});
+
+test("project switching commits one complete destination workspace or leaves the old project untouched", async () => {
+  const [app, apiClient] = await Promise.all([
+    readApp(),
+    readFile(resolve(root, "app/api-client.mjs"), "utf8"),
+  ]);
+  const switcher = sliceBetween(apiClient, "async function switchProjectWorkspace(project, options = {})", "let assetRequestSequence");
+  assert.match(switcher, /const \[library, navigation, assetsResult\] = await Promise\.all\(/,
+    "destination library/navigation/gallery data are fetched before project state changes");
+  const firstCommit = switcher.indexOf("state.project = projectId;");
+  const fetchDone = switcher.indexOf("const [library, navigation, assetsResult] = await Promise.all");
+  assert.ok(firstCommit > fetchDone, "project id is not changed before the destination workspace is available");
+  assert.match(switcher, /if \(typeof options\.shouldCommit === "function" && !options\.shouldCommit\(\)\) return false;/,
+    "a slower obsolete project request cannot commit after a newer project intent");
+  assert.match(switcher, /state\.selectedId = null;[\s\S]*?state\.selectedIds = new Set\(\);[\s\S]*?state\.assets = assetsResult\.assets \|\| \[\];/,
+    "selection and gallery are replaced inside the same project transaction");
+  assert.match(app, /await switchProjectWorkspace\(nextProject, \{[\s\S]*?shouldCommit: \(\) => isNavigationIntentCurrent\(intent\)[\s\S]*?\}\);[\s\S]*?startLibraryEventStream\(\);[\s\S]*?catch \(error\) \{[\s\S]*?select\.value = previousProject;/,
+    "the UI restores the original project selector when the transaction fails");
+});
+
+test("context-menu mutations freeze selection/project context and empty-grid Select All is real", async () => {
+  const actions = await readFile(resolve(root, "app/context-menu-actions.mjs"), "utf8");
+  const selection = await readFile(resolve(root, "app/gallery-selection.mjs"), "utf8");
+  assert.match(selection, /function captureActionContext\(\)[\s\S]*?projectId: state\.project[\s\S]*?revision: selectionRevision/);
+  assert.match(selection, /async function resolveSelectedAssetIds\(context = captureActionContext\(\)\)[\s\S]*?project: context\.projectId/,
+    "Stack expansion uses the frozen project for every cursor page");
+  assert.match(selection, /if \(!isActionContextCurrent\(context\)\) return null;/,
+    "a project/query/selection change cancels stale bulk action resolution");
+  assert.match(actions, /function selectedMutationContext\(asset, selectedAssets = \[\], options = \{\}\)/);
+  assert.match(actions, /projectId,[\s\S]*?assetIds: ids/,
+    "batch mutations send the frozen project id rather than live state.project");
+  assert.match(actions, /shortcut: \/Mac\|iPhone\|iPad\/\.test\(navigator\.platform\) \? "⌘A" : "Ctrl\+A"/,
+    "context-menu shortcut copy follows the current platform");
+  assert.match(actions, /disabled: !state\.pageTotal,[\s\S]*?gallerySelection\?\.selectAll\?\.\(\{ announce: true \}\)/,
+    "empty-grid Select All delegates to the same real selection pipeline as the toolbar/shortcut");
 });
 
 test("global drag guard blocks default file navigation outside an active library drop target", async () => {
@@ -372,7 +420,7 @@ test("masonry image loads only repair their own card instead of remeasuring the 
   assert.match(masonry, /const card = media\.closest\("\.asset-card"\);\s*if \(card\) scheduleMasonryLayout\(card\);/, "an image settle schedules only its containing card");
   assert.doesNotMatch(masonry, /addEventListener\("load",\s*schedule/, "media load must not schedule a full-grid layout");
   assert.match(masonry, /Math\.abs\(width - masonryObservedWidth\) < 0\.5/, "ResizeObserver ignores height-only churn from masonry itself");
-  assert.match(masonry, /card\.classList\.remove\("masonry-content-virtualized"\);[\s\S]*?getBoundingClientRect\(\)[\s\S]*?card\.classList\.add\("masonry-content-virtualized"\)/,
+  assert.match(masonry, /card\.classList\.remove\("masonry-content-virtualized"\);[\s\S]*?galleryCardIntrinsicHeight\(card\)[\s\S]*?card\.classList\.add\("masonry-content-virtualized"\)/,
     "offscreen content virtualization is enabled only after the real masonry height is measured");
   assert.match(css, /\.asset-card\.masonry-content-virtualized\s*\{[^}]*content-visibility:\s*auto;/,
     "laid-out cards use browser-native offscreen rendering virtualization");
@@ -527,12 +575,31 @@ test("large galleries use explicit masonry placement and bounded card hydration"
     "virtual placeholder height follows the known media aspect ratio");
   assert.match(virtualization, /galleryCardVirtualScrollGrid\.addEventListener\("scroll", handleGalleryCardVirtualScroll/,
     "indexed scroll synchronization guards large compositor jumps without an O(N) card scan");
+  assert.match(app, /function gallerySelectionRects\(\)[\s\S]*?galleryCardVirtualGeometryById\.values\(\)[\s\S]*?columnIndex \* \(columnWidth \+ gap\)/,
+    "marquee selection can use the complete masonry geometry instead of only the currently mounted DOM window");
+  assert.match(app, /getCardSelectionRects: gallerySelectionRects/,
+    "the shared selection controller receives the stable masonry geometry provider");
   assert.match(masonry, /const columnEnds = Array\(columnCount\)\.fill\(1\)/,
     "masonry placement tracks column heights in a linear pass");
   assert.match(masonry, /const canAppendIncrementally =[\s\S]*?galleryCardVirtualGeometryColumns\[columnIndex\]\.push\(geometry\)[\s\S]*?return;/,
     "infinite-scroll append extends existing masonry columns instead of re-placing the full gallery");
-  assert.match(masonry, /const previousSpan[\s\S]*?removeProperty\("grid-row-end"\)[\s\S]*?measureTargets\.forEach[\s\S]*?getBoundingClientRect\(\)/,
-    "masonry preserves the previous span and batches layout writes before geometry reads");
+  assert.match(masonry, /const previousSpan[\s\S]*?measureTargets\.forEach[\s\S]*?galleryCardIntrinsicHeight\(card\)/,
+    "masonry preserves the existing grid span while batching intrinsic-height reads");
+  assert.doesNotMatch(masonry, /removeProperty\("grid-row-end"\)/,
+    "height verification must not collapse a placed card to a temporary one-row grid item");
+  assert.match(app, /function reflowPlacedMasonryColumns\(grid, cards\)[\s\S]*?affectedColumns[\s\S]*?geometry\.rowStart = rowStart[\s\S]*?return true;/,
+    "hydration height corrections keep established column assignments stable");
+  assert.match(masonry, /allTargetsPlaced && spanChangedCards\.length && reflowPlacedMasonryColumns\(grid, spanChangedCards\)/,
+    "placed-card height corrections use stable per-column reflow before any global rebalance");
+  const hydration = sliceBetween(app, "function replaceVirtualGalleryCards", "function flushGalleryCardVirtualPendingChanges");
+  assert.doesNotMatch(hydration, /grid\.scrollTop\s*=/,
+    "virtual hydration must not drag the user's viewport to preserve a bottom offset");
+  assert.match(css, /\.asset-card-virtual-placeholder\s*\{[^}]*overflow-anchor:\s*none;/,
+    "ephemeral virtual cards cannot become Chromium scroll anchors");
+  assert.match(css, /\.infinite-scroll-sentinel\s*\{[^}]*overflow-anchor:\s*none;/,
+    "the replaceable pagination sentinel cannot become a scroll anchor");
+  assert.match(css, /\.gallery-virtual-extent\s*\{[^}]*overflow-anchor:\s*none;/,
+    "the synthetic virtual extent cannot become a scroll anchor");
   assert.match(masonry, /card\.style\.gridColumnStart = String\(columnStart\)/);
   assert.match(masonry, /card\.style\.gridRowStart = String\(rowStart\)/);
   assert.doesNotMatch(css, /grid-auto-flow:\s*dense/,

--- a/test/gallery-empty-state-contract.test.mjs
+++ b/test/gallery-empty-state-contract.test.mjs
@@ -240,9 +240,9 @@ test("41-43. styles stay inside the token boundary; dependencies stay frozen", a
   // qa:packaged launcher scripts, so the whole-manifest hash no longer holds;
   // the dependency sections the freeze really guards stay byte-identical.
   const manifest = JSON.parse(pkg);
-  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies must stay untouched");
+  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "0339eb218322b3a863818f979cfe4aca62624c31811a775da305ccda617d91a7", "package.json dependencies must stay untouched");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies must stay untouched");
-  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json must stay untouched");
+  assert.equal(sha256(lock), "51f3ff53219df2cfe3ea27ad9caf932a0cadbe062fec8905a11e39819a81fe54", "package-lock.json must stay untouched");
 });
 
 test("44. Phase 1–4C neighbouring contracts and anchors stay intact", async () => {

--- a/test/import-flow.test.mjs
+++ b/test/import-flow.test.mjs
@@ -362,7 +362,8 @@ test("blocks a double submit and shows a loading state while saving", async () =
   assert.match(app, /\} finally \{\s*setImportBusy\(false\);/);
   // Success still selects the new asset and refreshes the gallery.
   assert.match(app, /state\.selectedId = result\.asset\.id;\s*\n\s*clearImportForm\(\); closeImportModal\(\{ force: true \}\);/);
-  assert.match(app, /await loadStats\(\); await loadAssets\(\);/);
+  assert.match(app, /await Promise\.all\(\[loadStats\(\), loadAssets\(\)\]\);/,
+    "success refreshes stats and gallery together instead of serialising two independent reads");
 });
 
 test("keeps the import dialog's focus contract and translates every new string", async () => {

--- a/test/inspector-cowart-original-actions-contract.test.mjs
+++ b/test/inspector-cowart-original-actions-contract.test.mjs
@@ -118,9 +118,9 @@ test("59-60. dependency freeze: manifest, lockfile, and app.js imports unchanged
   // qa:packaged launcher scripts, so the whole-manifest hash no longer holds;
   // the dependency sections the freeze really guards stay byte-identical.
   const manifest = JSON.parse(pkg);
-  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies must stay untouched");
+  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "0339eb218322b3a863818f979cfe4aca62624c31811a775da305ccda617d91a7", "package.json dependencies must stay untouched");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies must stay untouched");
-  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json must stay untouched");
+  assert.equal(sha256(lock), "51f3ff53219df2cfe3ea27ad9caf932a0cadbe062fec8905a11e39819a81fe54", "package-lock.json must stay untouched");
   assert.deepEqual([...app.matchAll(/^import .* from "(.*)";$/gm)].map((match) => match[1]).sort(),
     ["./api-client.mjs", "./asset-stacks.mjs", "./asset-view.mjs", "./bridge-status-poller.mjs", "./confirm-dialog.mjs", "./context-menu-actions.mjs", "./context-menu-bindings.mjs", "./context-menu.mjs", "./gallery-selection.mjs", "./i18n-runtime.mjs", "./image-preview.mjs", "./inspector-markup.mjs", "./library-reconciliation.mjs", "./tag-utils.mjs", "./toast-manager.mjs"], "app.js imports only approved local helpers");
 });

--- a/test/inspector-information-architecture-contract.test.mjs
+++ b/test/inspector-information-architecture-contract.test.mjs
@@ -501,9 +501,9 @@ test("48-51. hygiene: no !important, no undefined tokens, manifest and dependenc
   // qa:packaged launcher scripts, so the whole-manifest hash no longer holds;
   // the dependency sections the freeze really guards stay byte-identical.
   const manifest = JSON.parse(pkg);
-  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies must stay untouched");
+  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "0339eb218322b3a863818f979cfe4aca62624c31811a775da305ccda617d91a7", "package.json dependencies must stay untouched");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies must stay untouched");
-  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json must stay untouched");
+  assert.equal(sha256(lock), "51f3ff53219df2cfe3ea27ad9caf932a0cadbe062fec8905a11e39819a81fe54", "package-lock.json must stay untouched");
 
   // 51. app.js gains no new imports (no new runtime dependencies).
   assert.deepEqual([...app.matchAll(/^import .* from "(.*)";$/gm)].map((match) => match[1]).sort(),

--- a/test/inspector-version-workflow-contract.test.mjs
+++ b/test/inspector-version-workflow-contract.test.mjs
@@ -319,9 +319,9 @@ test("39-48. layout order, neighbouring contracts, and dependency freeze", async
   // qa:packaged launcher scripts, so the whole-manifest hash no longer holds;
   // the dependency sections the freeze really guards stay byte-identical.
   const manifest = JSON.parse(pkg);
-  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies must stay untouched");
+  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "0339eb218322b3a863818f979cfe4aca62624c31811a775da305ccda617d91a7", "package.json dependencies must stay untouched");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies must stay untouched");
-  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json must stay untouched");
+  assert.equal(sha256(lock), "51f3ff53219df2cfe3ea27ad9caf932a0cadbe062fec8905a11e39819a81fe54", "package-lock.json must stay untouched");
 
   // 48. app.js gains no new imports (no new runtime dependencies, no
   // third-party Select component).

--- a/test/large-view-mode-contract.test.mjs
+++ b/test/large-view-mode-contract.test.mjs
@@ -410,10 +410,10 @@ test("34. package files stay untouched", async () => {
   // qa:packaged launcher scripts, so the whole-manifest hash no longer holds;
   // the dependency sections the freeze really guards stay byte-identical.
   const manifest = JSON.parse(pkg);
-  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies must stay untouched");
+  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "0339eb218322b3a863818f979cfe4aca62624c31811a775da305ccda617d91a7", "package.json dependencies must stay untouched");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies must stay untouched");
   const lock = await readFile(resolve(root, "package-lock.json"), "utf8");
-  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json must stay untouched");
+  assert.equal(sha256(lock), "51f3ff53219df2cfe3ea27ad9caf932a0cadbe062fec8905a11e39819a81fe54", "package-lock.json must stay untouched");
 });
 
 // 35. Runtime-verified fix: the shortcuts Escape chain must bail when an

--- a/test/minimum-window-responsive-contract.test.mjs
+++ b/test/minimum-window-responsive-contract.test.mjs
@@ -265,9 +265,9 @@ test("40-41. package 与 lockfile 不变、无新依赖", async () => {
   // qa:packaged launcher scripts, so the whole-manifest hash no longer holds;
   // the dependency sections the freeze really guards stay byte-identical.
   const manifest = JSON.parse(pkg);
-  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405");
+  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "0339eb218322b3a863818f979cfe4aca62624c31811a775da305ccda617d91a7");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac");
-  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec");
+  assert.equal(sha256(lock), "51f3ff53219df2cfe3ea27ad9caf932a0cadbe062fec8905a11e39819a81fe54");
 });
 
 test("42. styles.css 不使用 !important", async () => {

--- a/test/phase7-polish-contract.test.mjs
+++ b/test/phase7-polish-contract.test.mjs
@@ -251,7 +251,7 @@ test("13. No !important in app or extension surfaces", async () => {
 // 14. Manifest pinned: no new dependencies, lockfile intact.
 test("14. package manifest and lockfile unchanged", async () => {
   const manifest = JSON.parse(await read("package.json"));
-  assert.deepEqual(manifest.dependencies, { "better-sqlite3": "^13.0.1", sharp: "^0.35.3" }, "dependencies pinned");
+  assert.deepEqual(manifest.dependencies, { "better-sqlite3": "^13.0.1", sharp: "^0.35.4" }, "dependencies pinned");
   const expectedDevDeps = [
     "eslint",
     "electron",

--- a/test/search-location-contract.test.mjs
+++ b/test/search-location-contract.test.mjs
@@ -104,8 +104,10 @@ test("6. i18n placeholder uses the V2 copy in both locales", async () => {
 test("7. the input event listener still binds #searchInput", async () => {
   const app = await readApp();
   assert.match(app, /searchInput: document\.querySelector\("#searchInput"\)/, "element lookup must keep the #searchInput ID");
-  assert.match(app, /els\.searchInput\?\.addEventListener\("input", debounce\(async \(\) => \{/,
-    "the debounced input listener must stay bound to els.searchInput");
+  assert.match(app, /const commitSearchInput = debounce\(async \(intent\) => \{/,
+    "search commit stays debounced");
+  assert.match(app, /els\.searchInput\?\.addEventListener\("input", \(\) => \{[\s\S]*?commitSearchInput\(beginNavigationIntent\(\)\);[\s\S]*?\}\);/,
+    "the input listener synchronously captures navigation ordering before the debounce wakes up");
   assert.match(app, /const nextQuery = els\.searchInput\.value;/,
     "search must snapshot the proposed value before any destructive navigation");
 });
@@ -122,9 +124,11 @@ test("8. the search state field is unchanged", async () => {
 // 9. The search algorithm, API and i18n behaviour stay locked.
 test("9. search algorithm, API and i18n behaviour stay locked", async () => {
   const [app, apiClient] = await Promise.all([readApp(), readApiClient()]);
-  assert.match(app, /if \(!await confirmDetailNavigation\(null\)\) \{\s+els\.searchInput\.value = state\.query;\s+return;\s+\}/,
-    "search must not discard an unsaved Inspector draft");
-  assert.match(app, /state\.query = nextQuery;\s+state\.nextCursor = null;[\s\S]*?clearDetailSelection\(\);\s+await loadAssets\(\);\s+\}, 180\)/,
+  assert.match(app, /if \(!await authorizeNavigationIntent\(intent\)\) \{\s+if \(isNavigationIntentCurrent\(intent\)\) els\.searchInput\.value = state\.query;\s+return;\s+\}/,
+    "search must flush the Inspector draft and reject stale navigation intents before committing");
+  assert.match(app, /async function authorizeNavigationIntent\(intent\) \{\s+if \(!isNavigationIntentCurrent\(intent\)\) return false;\s+if \(!await confirmDetailNavigation\(null\)\) return false;\s+return isNavigationIntentCurrent\(intent\);\s+\}/,
+    "all async result-set navigation shares one stale-intent guard");
+  assert.match(app, /state\.query = nextQuery;\s+state\.nextCursor = null;[\s\S]*?clearDetailSelection\(\);\s+await loadAssets\(\);\s+\}, 180\);/,
     "the 180ms committed query → loadAssets pipeline must remain intact");
   assert.match(apiClient, /const params = new URLSearchParams\(\{ project: request\.project, q: request\.query \}\)/,
     "the /api/assets query construction must stay unchanged");

--- a/test/search-location-contract.test.mjs
+++ b/test/search-location-contract.test.mjs
@@ -168,10 +168,10 @@ test("11. no duplicate or hidden synced search control exists", async () => {
 test("12. no new dependencies", async () => {
   const pkg = await readFile(resolve(root, "package.json"), "utf8");
   const manifest = JSON.parse(pkg);
-  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies must stay untouched");
+  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "0339eb218322b3a863818f979cfe4aca62624c31811a775da305ccda617d91a7", "package.json dependencies must stay untouched");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies must stay untouched");
   const lock = await readFile(resolve(root, "package-lock.json"), "utf8");
-  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json must stay untouched");
+  assert.equal(sha256(lock), "51f3ff53219df2cfe3ea27ad9caf932a0cadbe062fec8905a11e39819a81fe54", "package-lock.json must stay untouched");
 });
 
 // 13. No !important anywhere in the stylesheet (comments stripped).

--- a/test/shell-layout-contract.test.mjs
+++ b/test/shell-layout-contract.test.mjs
@@ -229,6 +229,6 @@ test("26-28. hygiene: no !important, no undefined tokens, no new dependencies", 
   // qa:packaged launcher scripts, so the whole-manifest hash no longer holds;
   // the dependency sections the freeze really guards stay byte-identical.
   const manifest = JSON.parse(pkg);
-  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies must stay untouched");
+  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "0339eb218322b3a863818f979cfe4aca62624c31811a775da305ccda617d91a7", "package.json dependencies must stay untouched");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies must stay untouched");
 });

--- a/test/toast-manager-contract.test.mjs
+++ b/test/toast-manager-contract.test.mjs
@@ -285,9 +285,9 @@ test("57-58. package manifest and lockfile unchanged", async () => {
   // qa:packaged launcher scripts, so the whole-manifest hash no longer holds;
   // the dependency sections the freeze really guards stay byte-identical.
   const manifest = JSON.parse(pkg);
-  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies frozen");
+  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "0339eb218322b3a863818f979cfe4aca62624c31811a775da305ccda617d91a7", "package.json dependencies frozen");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies frozen");
-  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json frozen");
+  assert.equal(sha256(lock), "51f3ff53219df2cfe3ea27ad9caf932a0cadbe062fec8905a11e39819a81fe54", "package-lock.json frozen");
 });
 
 // 59. The stylesheet stays free of !important while hosting toast styles.

--- a/test/topbar-hierarchy-contract.test.mjs
+++ b/test/topbar-hierarchy-contract.test.mjs
@@ -284,7 +284,10 @@ test("22. the search lives in the topbar, not the sidebar", async () => {
   const sidebarEnd = html.indexOf("</aside>", sidebarStart);
   assert.equal(html.slice(sidebarStart, sidebarEnd).includes('id="searchInput"'), false, "no search input may remain in the sidebar");
   const app = await readApp();
-  assert.match(app, /els\.searchInput\?\.addEventListener\("input", debounce/, "search event wiring unchanged");
+  assert.match(app, /const commitSearchInput = debounce\(async \(intent\) => \{/,
+    "search commit remains debounced");
+  assert.match(app, /els\.searchInput\?\.addEventListener\("input", \(\) => \{[\s\S]*?commitSearchInput\(beginNavigationIntent\(\)\);/,
+    "the topbar input remains the single search event source");
 });
 
 // 23. No !important anywhere in the stylesheet (comments stripped).

--- a/test/trash-gallery-regression.test.mjs
+++ b/test/trash-gallery-regression.test.mjs
@@ -34,8 +34,10 @@ test("Move to Trash uses one batch mutation and reconciles removed cards before 
 
   assert.match(actions, /apiFetch\("\/api\/assets\/batch"[\s\S]*?action: "trash"[\s\S]*?assetIds: ids/,
     "Trash selection must not issue one HTTP DELETE per card");
-  assert.match(actions, /selectedMutationIds\(asset, selectedAssets, options\)/,
-    "Trash must operate on the complete logical selection, including unloaded pages and Stack members");
+  assert.match(actions, /selectedMutationContext\(asset, selectedAssets, options\)/,
+    "Trash must resolve the complete logical selection through the frozen action context, including unloaded pages and Stack members");
+  assert.match(actions, /if \(!context \|\| !mutationContextIsCurrent\(context\)\) return;/,
+    "a stale project/query/selection context must cancel before the Trash mutation");
   assert.match(actions, /removedAssetIds: outcome\.succeeded\.map/,
     "partial batches must remove only server-confirmed successes from the visible gallery");
   assert.match(bindings, /kind: "asset-deleted", entityType: "asset", entityId: String\(id\)/,

--- a/test/ui-component-contract.test.mjs
+++ b/test/ui-component-contract.test.mjs
@@ -299,7 +299,7 @@ test("out-of-scope files stay locked and the Phase 1C card contract is stable", 
   // leave the hash table; their security-relevant behaviour is asserted
   // structurally below. The lockfile stays hash-pinned.
   const expected = {
-    "package-lock.json": "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec",
+    "package-lock.json": "51f3ff53219df2cfe3ea27ad9caf932a0cadbe062fec8905a11e39819a81fe54",
   };
   for (const [file, hash] of Object.entries(expected)) {
     const text = await readFile(resolve(root, file), "utf8");
@@ -311,7 +311,7 @@ test("out-of-scope files stay locked and the Phase 1C card contract is stable", 
   assert.match(server, /process\.exit\(1\)/, "server.mjs must exit non-zero on isolation guard rejection");
   // package.json dependency sections stay frozen.
   const manifest = JSON.parse(await readFile(resolve(root, "package.json"), "utf8"));
-  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "73c83773a57e21a20917d81b24288bdfddd9bb7ddd644fdaedd6e6cfba13c405", "package.json dependencies must stay untouched");
+  assert.equal(sha256(JSON.stringify(manifest.dependencies)), "0339eb218322b3a863818f979cfe4aca62624c31811a775da305ccda617d91a7", "package.json dependencies must stay untouched");
   assert.equal(sha256(JSON.stringify(manifest.devDependencies)), "11f67ce00f34b4d3dfb9b9ed0dfb428b0368ad5e0a17bd3bafaa40e3c2124fac", "package.json devDependencies must stay untouched");
   // The Phase 1C/1C.1 card quick-action contract rules are locked verbatim against drift.
   // Phase 1C.1 re-locks: child-button disclosure granularity, 28px click area (Phase 1B

--- a/test/viewer-pagination-navigation.test.mjs
+++ b/test/viewer-pagination-navigation.test.mjs
@@ -367,5 +367,5 @@ test("26. transform resets on switch", async () => {
 // 27. The lockfile is untouched by Batch 2A.
 test("27. package-lock unchanged", async () => {
   const lock = await readLock();
-  assert.equal(sha256(lock), "5f63f56e0757215ab2e5f2773de24afe1e7fa9a5bddc41adde805856f0fe09ec", "package-lock.json must not change in Batch 2A");
+  assert.equal(sha256(lock), "51f3ff53219df2cfe3ea27ad9caf932a0cadbe062fec8905a11e39819a81fe54", "package-lock.json must not change in Batch 2A");
 });


### PR DESCRIPTION
Summary:

- stabilize gallery masonry hydration and scroll behavior
- make project switching transactional
- add navigation intent protection against async stale state
- freeze selection/action context for async mutations
- fix manual group click/double-click arbitration
- stabilize marquee selection across virtualized galleries
- fix mobile add-group behavior
- restore functional Select All context-menu behavior
- update regression tests

Validation already completed locally:

- npm test
- npm run lint
- npm run check
- git diff --check
- MOSA_GALLERY_QA_ASSET_COUNT=400 npm run qa:gallery:performance