### PR TITLE
fix: stabilize gallery pagination scrolling

### DIFF
--- a/app/app.mjs
+++ b/app/app.mjs
@@ -2623,11 +2623,14 @@ function flushGalleryCardVirtualPendingChanges() {
       taken += 1;
     }
   };
-  // Normal scrolling should hydrate from the 1200px warm zone before a card is
-  // visible. If a fast fling outruns that runway, resolve a bounded visible
-  // batch per frame rather than freezing the compositor to hydrate the whole
-  // viewport synchronously.
-  if (galleryCardVirtualVisiblePendingChanges.size) takeChanges(galleryCardVirtualVisiblePendingChanges, 6);
+  // Normal scrolling hydrates from the 1200px warm zone before a card becomes
+  // visible. If a fast fling outruns that runway, the visible set is still
+  // bounded by the viewport, so resolve the complete visible queue in this
+  // pre-paint frame. Spreading it across several frames exposes placeholders
+  // and makes cards visibly swap/jump while the user is scrolling.
+  if (galleryCardVirtualVisiblePendingChanges.size) {
+    takeChanges(galleryCardVirtualVisiblePendingChanges, galleryCardVirtualVisiblePendingChanges.size);
+  }
   // Eviction must make progress in the same frame as visible hydration. If
   // the background queue waited for the visible queue to empty, a fast scroll
   // would retain every card it ever visited and defeat DOM virtualization.
@@ -3432,6 +3435,17 @@ function galleryPaginationMarkup() {
   return `<div class="asset-load-more" hidden><button type="button" data-action="load-more">${escapeHtml(t("loadMore"))}</button></div><div class="infinite-scroll-sentinel" data-sentinel="true"></div>`;
 }
 
+function removeGalleryPaginationBoundary(grid) {
+  grid.querySelectorAll(":scope > .asset-load-more, :scope > .infinite-scroll-sentinel").forEach((element) => element.remove());
+}
+
+function insertGalleryPaginationBoundary(grid) {
+  if (!state.nextCursor) return;
+  const extent = grid.querySelector(":scope > .gallery-virtual-extent");
+  if (extent) extent.insertAdjacentHTML("beforebegin", galleryPaginationMarkup());
+  else grid.insertAdjacentHTML("beforeend", galleryPaginationMarkup());
+}
+
 function reconcileAssetCards(entries) {
   const grid = els.assetGrid;
   if (!grid) return { changedCards: [], replacedFocusedCard: false, structureChanged: false };
@@ -3489,8 +3503,12 @@ function reconcileAssetCards(entries) {
     if (card !== cursor) grid.insertBefore(card, cursor);
     cursor = card.nextElementSibling;
   });
-  grid.querySelectorAll(":scope > .asset-load-more, :scope > .infinite-scroll-sentinel, :scope > .gallery-virtual-extent").forEach((element) => element.remove());
-  if (state.nextCursor) grid.insertAdjacentHTML("beforeend", galleryPaginationMarkup());
+  // Pagination controls are replaceable, but the virtual extent belongs to the
+  // masonry virtualization layer. Keeping it mounted preserves the scroll range
+  // while a reconciliation is being laid out and avoids an intermediate
+  // scrollHeight collapse near the pagination boundary.
+  removeGalleryPaginationBoundary(grid);
+  insertGalleryPaginationBoundary(grid);
   if (changedCards.length || existingCards.size !== desiredCards.length) invalidateCardGeometryCache();
   return { changedCards, replacedFocusedCard, structureChanged };
 }
@@ -3498,16 +3516,22 @@ function reconcileAssetCards(entries) {
 function appendAssetCards(entries) {
   const grid = els.assetGrid;
   if (!grid) return [];
-  grid.querySelectorAll(":scope > .asset-load-more, :scope > .infinite-scroll-sentinel, :scope > .gallery-virtual-extent").forEach((element) => element.remove());
+  // Never tear down the virtual extent during an append. It is the stable
+  // representation of the already-laid-out gallery height; removing it even
+  // for one synchronous append/layout cycle can clamp scrollTop in Chromium
+  // before the new page has received explicit masonry coordinates.
+  removeGalleryPaginationBoundary(grid);
   const createdCards = createAssetCardElements(entries);
   const changedCards = entries.map((entry) => createdCards.get(entry.id)).filter(Boolean);
   if (changedCards.length) {
-    grid.append(...changedCards);
+    const extent = grid.querySelector(":scope > .gallery-virtual-extent");
+    if (extent) extent.before(...changedCards);
+    else grid.append(...changedCards);
     changedCards.forEach((card) => {
       if (card.dataset.id) galleryCardVirtualNodes.set(card.dataset.id, card);
     });
   }
-  if (state.nextCursor) grid.insertAdjacentHTML("beforeend", galleryPaginationMarkup());
+  insertGalleryPaginationBoundary(grid);
   if (changedCards.length) invalidateCardGeometryCache();
   return changedCards;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mosa",
-  "version": "0.2.1-rc.5",
+  "version": "0.2.1-rc.6",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",
   "type": "module",

--- a/test/frontend-interaction-regressions.test.mjs
+++ b/test/frontend-interaction-regressions.test.mjs
@@ -526,11 +526,21 @@ test("infinite-scroll append uses a tail-only render path and virtualizes decode
   const app = await readApp();
   const apiClient = await readFile(resolve(root, "app/api-client.mjs"), "utf8");
   const render = sliceBetween(app, "function renderGrid()", "/** Routed through the state machine");
+  const paginationRemoval = sliceBetween(app, "function removeGalleryPaginationBoundary(grid)", "function insertGalleryPaginationBoundary(grid)");
+  const append = sliceBetween(app, "function appendAssetCards(entries)", "// F-24");
   const virtualization = sliceBetween(app, "function setupGalleryMediaVirtualization", "function layoutMasonry");
   const infiniteScroll = sliceBetween(app, "function setupInfiniteScroll()", "/**\n * Placeholders sized like real cards");
 
   assert.match(render, /state\.assets\.slice\(animateFrom\)/, "append maps only the incoming tail");
   assert.match(render, /appendAssetCards\(domCards\)/, "append avoids a full card reconciliation");
+  assert.match(paginationRemoval, /:scope > \.asset-load-more, :scope > \.infinite-scroll-sentinel/,
+    "pagination lifecycle removes only replaceable controls");
+  assert.doesNotMatch(paginationRemoval, /gallery-virtual-extent/,
+    "pagination lifecycle must never remove the masonry virtual extent");
+  assert.match(append, /const extent = grid\.querySelector\(":scope > \.gallery-virtual-extent"\);[\s\S]*?extent\.before\(\.\.\.changedCards\)/,
+    "new page cards are inserted ahead of the stable virtual extent");
+  assert.match(append, /insertGalleryPaginationBoundary\(grid\)/,
+    "the replacement sentinel is restored without rebuilding the virtual extent");
   assert.match(app, /class=\"asset-load-more\" hidden/, "normal infinite scrolling keeps the pagination boundary invisible");
   assert.match(render, /syncRenderedSelection\(\{[\s\S]*?prune: false,[\s\S]*?changedIds:/,
     "append selection sync touches only the newly mounted tail");
@@ -561,8 +571,10 @@ test("large galleries use explicit masonry placement and bounded card hydration"
     "native intersection observation drives card hydration in supported browsers");
   assert.match(virtualization, /galleryCardVirtualLowerBound/,
     "the non-IntersectionObserver fallback binary-searches per-column masonry geometry instead of scanning every card");
-  assert.match(virtualization, /takeChanges\(galleryCardVirtualVisiblePendingChanges, 6\)/,
-    "fast-scroll visible hydration is bounded per frame instead of blocking the compositor");
+  assert.match(virtualization, /takeChanges\(galleryCardVirtualVisiblePendingChanges, galleryCardVirtualVisiblePendingChanges\.size\)/,
+    "a fast-scroll viewport hydrates its complete visible set before the next paint");
+  assert.match(virtualization, /takeChanges\(galleryCardVirtualBackgroundPendingChanges, 6\)/,
+    "offscreen preloading and eviction remain frame-budgeted");
   assert.doesNotMatch(virtualization, /flushVisibleGalleryCardVirtualChanges/,
     "the scroll path never synchronously hydrates the whole visible virtual set");
   assert.match(virtualization, /if \(hydratedCards\.length\) \{[\s\S]*?setupGalleryMediaVirtualization\(hydratedCards\);[\s\S]*?hydratedCards\.forEach\(\(card\) => scheduleMasonryLayout\(card\)\);[\s\S]*?\}/,


### PR DESCRIPTION
## Summary\n- preserve the masonry virtual extent while infinite-scroll pages append\n- hydrate the complete visible virtual-card queue before paint while keeping background work frame-budgeted\n- bump desktop package version to 0.2.1-rc.6\n- add regression coverage for pagination-boundary and hydration stability\n\n## Validation\n- npm run lint\n- npm run check\n- npm test: 1064 tests, 1062 passed, 0 failed, 2 skipped\n- npm run qa:gallery:performance: passed\n- rc.6 macOS and Windows packages built and package contents verified