### PR TITLE
docs: add APSAL attribution notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This file records user-visible changes. Internal deployment notes, local paths, 
 
 ## Unreleased
 
-- No user-visible changes recorded yet.
+### Documentation and attribution
+
+- Added a durable third-party notice crediting APSAL Open `v0.14.0` as a design influence on MOSA's recipe snapshot model, while explicitly separating that attribution from MOSA's own PolyForm Noncommercial licensing.
 
 ## 0.2.1-rc.6 — 2026-09-10 / Release Candidate
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ See [PRIVACY.md](PRIVACY.md) for the full data boundary and [SECURITY.md](SECURI
 - [Contributing guide](CONTRIBUTING.md): development workflow, checks, and privacy requirements.
 - [Support guide](SUPPORT.md): questions, bug reports, and feature requests.
 - [Changelog](CHANGELOG.md): user-visible changes and release status.
+- [Third-party notices](THIRD_PARTY_NOTICES.md): upstream projects that materially informed MOSA's design or implementation.
 
 ## License
 
@@ -131,3 +132,5 @@ MOSA is source-available under the [PolyForm Noncommercial License 1.0.0](LICENS
 - Redistributions must preserve the license terms and required copyright notice.
 
 MOSA is source-available software, not OSI-approved open-source software.
+
+Third-party attribution is documented separately in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) and does not change MOSA's own license terms.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,22 @@
+# Third-party notices
+
+This file records upstream projects that materially informed MOSA's design or implementation. It is separate from MOSA's own license terms.
+
+## APSAL Open
+
+MOSA's recipe snapshot model was informed by the immutable, reproducible creative-record concepts in **APSAL Open**.
+
+- Project: `henyjone/apsal-open`
+- Reference release: `v0.14.0`
+- Reference commit: `823f1cbc5557310fa092620391181c1d13485b15`
+- Upstream code license: Apache License 2.0
+- Upstream author: HenyJone / APSAL Open
+- Source: <https://github.com/henyjone/apsal-open/tree/v0.14.0>
+
+The influence is at the design level. In MOSA, the resulting recipe snapshot system records a frozen generation recipe with content-derived identity, Prompt and recipe digests, normalized reference declarations, provenance, and change lineage. The current MOSA implementation lives in `lib/recipe-snapshot.ts` and the corresponding storage/API layers.
+
+MOSA does not vendor, bundle, execute, or depend on APSAL Open source code. No APSAL source files are distributed as part of MOSA. MOSA's own source remains licensed under the repository's [PolyForm Noncommercial License 1.0.0](LICENSE); this notice does not relicense MOSA under Apache-2.0.
+
+APSAL contains substantially broader authoring, protocol, registry, packaging, and Studio functionality. This notice should not be read as claiming those systems are part of MOSA.
+
+The upstream Apache License 2.0 text is available in APSAL Open's tagged source at <https://github.com/henyjone/apsal-open/blob/v0.14.0/LICENSE>.


### PR DESCRIPTION
## What changed

- Add `THIRD_PARTY_NOTICES.md` with a durable attribution to APSAL Open `v0.14.0` as a design influence on MOSA's recipe snapshot model.
- Pin the upstream reference commit and Apache-2.0 license while explicitly stating that MOSA does not vendor APSAL source code and remains under PolyForm Noncommercial.
- Link the notice from README and record the documentation change under Unreleased.

## Verification

- `npm ci`
- `node_modules/.bin/eslint .`
- `node scripts/check-source.mjs`
- `npm test`
- `git diff --check`

This PR is documentation-only and was prepared in an isolated worktree so it does not touch the current uncommitted development work on `main`.