### PR TITLE
fix: supervise macOS background runtime ownership

### DIFF
--- a/scripts/install-macos-web-capture-service.sh
+++ b/scripts/install-macos-web-capture-service.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  printf 'error: this installer is for macOS only\n' >&2
+  exit 1
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+node_bin="$(command -v node || true)"
+[[ -n "$node_bin" && -x "$node_bin" ]] || { printf 'error: node is required\n' >&2; exit 1; }
+
+label="com.azhuilab.mosa.web-capture"
+domain="gui/$(id -u)"
+plist_dir="$HOME/Library/LaunchAgents"
+plist="$plist_dir/$label.plist"
+log_dir="$HOME/Library/Logs/MOSA"
+env_file="$HOME/.config/mosa/web-capture.env"
+supervisor="$repo_root/scripts/macos-web-capture-supervisor.mjs"
+
+[[ -r "$env_file" ]] || { printf 'error: missing MOSA Web Capture environment file: %s\n' "$env_file" >&2; exit 1; }
+[[ -r "$supervisor" ]] || { printf 'error: missing supervisor: %s\n' "$supervisor" >&2; exit 1; }
+
+mkdir -p "$plist_dir" "$log_dir"
+temporary_plist="$plist.tmp.$$"
+cleanup() { rm -f -- "$temporary_plist"; }
+trap cleanup EXIT
+
+xml_escape() {
+  printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g'
+}
+
+escaped_home="$(xml_escape "$HOME")"
+escaped_repo="$(xml_escape "$repo_root")"
+escaped_node="$(xml_escape "$node_bin")"
+escaped_env="$(xml_escape "$env_file")"
+escaped_supervisor="$(xml_escape "$supervisor")"
+escaped_stdout="$(xml_escape "$log_dir/web-capture.out.log")"
+escaped_stderr="$(xml_escape "$log_dir/web-capture.err.log")"
+escaped_path="$(xml_escape "$(dirname "$node_bin"):/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin")"
+
+cat > "$temporary_plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$label</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/zsh</string>
+    <string>-c</string>
+    <string>set -eu; set -a; source &quot;$escaped_env&quot;; set +a; exec &quot;$escaped_node&quot; &quot;$escaped_supervisor&quot;</string>
+  </array>
+  <key>WorkingDirectory</key><string>$escaped_repo</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key><string>$escaped_home</string>
+    <key>PATH</key><string>$escaped_path</string>
+  </dict>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>ThrottleInterval</key><integer>10</integer>
+  <key>ProcessType</key><string>Background</string>
+  <key>StandardOutPath</key><string>$escaped_stdout</string>
+  <key>StandardErrorPath</key><string>$escaped_stderr</string>
+</dict>
+</plist>
+EOF
+
+plutil -lint "$temporary_plist" >/dev/null
+chmod 0644 "$temporary_plist"
+mv -f -- "$temporary_plist" "$plist"
+
+launchctl bootout "$domain/$label" >/dev/null 2>&1 || true
+for attempt in {1..40}; do
+  if ! launchctl print "$domain/$label" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.25
+done
+if launchctl print "$domain/$label" >/dev/null 2>&1; then
+  printf 'error: %s did not finish unloading from %s\n' "$label" "$domain" >&2
+  exit 1
+fi
+
+bootstrap_ok=0
+for attempt in {1..8}; do
+  if launchctl bootstrap "$domain" "$plist"; then
+    bootstrap_ok=1
+    break
+  fi
+  sleep 0.25
+done
+[[ "$bootstrap_ok" -eq 1 ]] || { printf 'error: could not bootstrap %s\n' "$label" >&2; exit 1; }
+launchctl enable "$domain/$label"
+launchctl kickstart "$domain/$label"
+
+printf 'Installed %s with cooperative MOSA runtime supervision.\n' "$label"
+printf 'plist: %s\n' "$plist"
+printf 'supervisor: %s\n' "$supervisor"

--- a/scripts/macos-web-capture-supervisor.mjs
+++ b/scripts/macos-web-capture-supervisor.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DEFAULT_MOSA_DESKTOP_PORT, normalizeMosaPort } from "../lib/runtime-defaults.mjs";
+import { verifyMosaRuntimeLockProcessIdentity } from "../lib/runtime-lock.js";
+
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = resolve(moduleDir, "..");
+const serverEntry = join(repositoryRoot, "server.mjs");
+const DEFAULT_IDLE_POLL_MS = 5000;
+const DEFAULT_TAKEOVER_GRACE_MS = 5000;
+const DEFAULT_CONTROLLED_TAKEOVER_GRACE_MS = 30_000;
+const DEFAULT_TAKEOVER_POLL_MS = 250;
+const DEFAULT_PROBE_TIMEOUT_MS = 1200;
+
+export async function probeMosaOwner({
+  port = process.env.MOSA_PORT || DEFAULT_MOSA_DESKTOP_PORT,
+  libraryDir = process.env.MOSA_LIBRARY_DIR || join(homedir(), "MOSA Library"),
+  fetchImpl = globalThis.fetch,
+  timeoutMs = DEFAULT_PROBE_TIMEOUT_MS,
+  leaseProbe = () => probeRuntimeLease({ libraryDir }),
+} = {}) {
+  const normalizedPort = normalizeMosaPort(port, { label: "MOSA supervisor port" });
+  const expectedLibraryDir = resolve(libraryDir);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), Math.max(100, Number(timeoutMs) || DEFAULT_PROBE_TIMEOUT_MS));
+  try {
+    const response = await fetchImpl(`http://127.0.0.1:${normalizedPort}/api/health`, {
+      signal: controller.signal,
+    });
+    if (!response?.ok) {
+      const lease = await leaseProbe();
+      return lease.state === "starting" ? lease : { state: "conflict", reason: `HTTP ${response?.status || 0}` };
+    }
+    const health = await response.json();
+    if (health?.product !== "mosa" || typeof health.libraryDir !== "string") {
+      return { state: "conflict", reason: "non-mosa-listener" };
+    }
+    if (resolve(health.libraryDir) !== expectedLibraryDir) {
+      return { state: "conflict", reason: "different-library" };
+    }
+    return { state: "attached", health };
+  } catch (error) {
+    const code = error?.cause?.code || error?.code;
+    const lease = await leaseProbe();
+    if (lease.state === "starting") return lease;
+    if (code === "ECONNREFUSED") return { state: "unavailable" };
+    if (error?.name === "AbortError") return { state: "conflict", reason: "timeout" };
+    return { state: "conflict", reason: code || "unverified-listener" };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function probeRuntimeLease({
+  libraryDir = process.env.MOSA_LIBRARY_DIR || join(homedir(), "MOSA Library"),
+  readFileImpl = readFile,
+  isProcessAlive = defaultIsProcessAlive,
+  verifyProcessIdentity = verifyMosaRuntimeLockProcessIdentity,
+} = {}) {
+  const lockPath = join(resolve(libraryDir), ".mosa-runtime.lock");
+  try {
+    const owner = JSON.parse(await readFileImpl(lockPath, "utf8"));
+    if (!Number.isInteger(owner?.pid) || owner.pid <= 0 || typeof owner?.token !== "string" || !owner.token) {
+      return { state: "unavailable" };
+    }
+    if (!isProcessAlive(owner.pid)) return { state: "unavailable" };
+    const identityMatch = await verifyProcessIdentity(owner);
+    if (identityMatch === false) return { state: "unavailable" };
+    return { state: "starting", owner: { pid: owner.pid } };
+  } catch {
+    return { state: "unavailable" };
+  }
+}
+
+export async function waitForReplacementOwner({
+  probe = probeMosaOwner,
+  sleep = (delayMs) => new Promise((resolveSleep) => setTimeout(resolveSleep, delayMs)),
+  graceMs = DEFAULT_TAKEOVER_GRACE_MS,
+  pollMs = DEFAULT_TAKEOVER_POLL_MS,
+} = {}) {
+  const checks = Math.max(1, Math.ceil(Math.max(0, Number(graceMs) || 0) / Math.max(1, Number(pollMs) || 1)));
+  for (let index = 0; index < checks; index += 1) {
+    const status = await probe();
+    if (status.state !== "unavailable") return status;
+    if (index + 1 < checks) await sleep(pollMs);
+  }
+  return { state: "unavailable" };
+}
+
+export async function runSupervisor({
+  probe = () => probeMosaOwner(),
+  spawnRuntime = () => spawn(process.execPath, [serverEntry], {
+    cwd: repositoryRoot,
+    env: process.env,
+    stdio: "inherit",
+  }),
+  sleep = (delayMs) => new Promise((resolveSleep) => setTimeout(resolveSleep, delayMs)),
+  idlePollMs = DEFAULT_IDLE_POLL_MS,
+  takeoverGraceMs = DEFAULT_TAKEOVER_GRACE_MS,
+  controlledTakeoverGraceMs = DEFAULT_CONTROLLED_TAKEOVER_GRACE_MS,
+  takeoverPollMs = DEFAULT_TAKEOVER_POLL_MS,
+  logger = console,
+  signalTarget = process,
+} = {}) {
+  let stopping = false;
+  let child = null;
+  let lastIdleReason = "";
+
+  const stop = () => {
+    stopping = true;
+    if (child && child.exitCode == null && child.signalCode == null) child.kill("SIGTERM");
+  };
+  signalTarget.once?.("SIGINT", stop);
+  signalTarget.once?.("SIGTERM", stop);
+
+  try {
+    while (!stopping) {
+      const current = await probe();
+      if (current.state === "attached" || current.state === "starting") {
+        if (lastIdleReason !== current.state) {
+          logger.info?.(current.state === "attached"
+            ? "[MOSA supervisor] another verified MOSA runtime owns this library; standing by."
+            : "[MOSA supervisor] another active MOSA runtime owns the library lock and is starting; standing by.");
+        }
+        lastIdleReason = current.state;
+        await sleep(idlePollMs);
+        continue;
+      }
+      if (current.state === "conflict") {
+        const reason = `conflict:${current.reason || "unknown"}`;
+        if (lastIdleReason !== reason) logger.warn?.(`[MOSA supervisor] port is occupied by an unverified or different runtime (${current.reason || "unknown"}); standing by.`);
+        lastIdleReason = reason;
+        await sleep(idlePollMs);
+        continue;
+      }
+
+      lastIdleReason = "";
+      child = spawnRuntime();
+      logger.info?.(`[MOSA supervisor] started background runtime PID ${child.pid || "unknown"}.`);
+      const exit = await waitForChildExit(child);
+      child = null;
+      if (stopping) break;
+
+      const replacement = await waitForReplacementOwner({
+        probe,
+        sleep,
+        graceMs: exit?.signal === "SIGTERM" ? controlledTakeoverGraceMs : takeoverGraceMs,
+        pollMs: takeoverPollMs,
+      });
+      if (replacement.state === "attached" || replacement.state === "starting") {
+        logger.info?.("[MOSA supervisor] background runtime yielded to another verified MOSA owner.");
+        continue;
+      }
+      if (replacement.state === "conflict") {
+        logger.warn?.(`[MOSA supervisor] background runtime exited and the port is now occupied (${replacement.reason || "unknown"}); standing by.`);
+        continue;
+      }
+      logger.warn?.(`[MOSA supervisor] background runtime exited (${formatExit(exit)}); restarting after takeover grace.`);
+    }
+  } finally {
+    signalTarget.off?.("SIGINT", stop);
+    signalTarget.off?.("SIGTERM", stop);
+    if (child && child.exitCode == null && child.signalCode == null) {
+      child.kill("SIGTERM");
+      await waitForChildExit(child).catch(() => {});
+    }
+  }
+}
+
+function waitForChildExit(child) {
+  if (child.exitCode != null || child.signalCode != null) {
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  }
+  return new Promise((resolveExit, rejectExit) => {
+    const onError = (error) => {
+      cleanup();
+      rejectExit(error);
+    };
+    const onExit = (code, signal) => {
+      cleanup();
+      resolveExit({ code, signal });
+    };
+    const cleanup = () => {
+      child.off("error", onError);
+      child.off("exit", onExit);
+    };
+    child.once("error", onError);
+    child.once("exit", onExit);
+  });
+}
+
+function formatExit(exit) {
+  if (exit?.signal) return `signal ${exit.signal}`;
+  return `code ${exit?.code ?? "unknown"}`;
+}
+
+function defaultIsProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await runSupervisor();
+}

--- a/test/macos-web-capture-supervisor.test.mjs
+++ b/test/macos-web-capture-supervisor.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { EventEmitter } from "node:events";
+import {
+  probeMosaOwner,
+  probeRuntimeLease,
+  runSupervisor,
+  waitForReplacementOwner,
+} from "../scripts/macos-web-capture-supervisor.mjs";
+
+test("supervisor recognizes a verified MOSA owner for the same library", async () => {
+  const status = await probeMosaOwner({
+    port: 43517,
+    libraryDir: "/tmp/mosa-library",
+    fetchImpl: async () => ({
+      ok: true,
+      json: async () => ({ product: "mosa", libraryDir: "/tmp/mosa-library" }),
+    }),
+  });
+  assert.equal(status.state, "attached");
+});
+
+test("supervisor refuses to start over a different library or non-MOSA listener", async () => {
+  const differentLibrary = await probeMosaOwner({
+    libraryDir: "/tmp/mosa-library",
+    fetchImpl: async () => ({
+      ok: true,
+      json: async () => ({ product: "mosa", libraryDir: "/tmp/other-library" }),
+    }),
+  });
+  assert.deepEqual(differentLibrary, { state: "conflict", reason: "different-library" });
+
+  const foreign = await probeMosaOwner({
+    libraryDir: "/tmp/mosa-library",
+    fetchImpl: async () => ({ ok: true, json: async () => ({ product: "other" }) }),
+  });
+  assert.deepEqual(foreign, { state: "conflict", reason: "non-mosa-listener" });
+});
+
+test("supervisor treats an active verified runtime lock as an owner while HTTP is still starting", async () => {
+  const lease = await probeRuntimeLease({
+    libraryDir: "/tmp/mosa-library",
+    readFileImpl: async () => JSON.stringify({ token: "owner-token", pid: 4242, processIdentity: "start-1" }),
+    isProcessAlive: () => true,
+    verifyProcessIdentity: async () => true,
+  });
+  assert.deepEqual(lease, { state: "starting", owner: { pid: 4242 } });
+
+  const status = await probeMosaOwner({
+    libraryDir: "/tmp/mosa-library",
+    fetchImpl: async () => {
+      const error = new Error("connection refused");
+      error.code = "ECONNREFUSED";
+      throw error;
+    },
+    leaseProbe: async () => lease,
+  });
+  assert.deepEqual(status, lease);
+});
+
+test("stale or recycled runtime locks never suppress background recovery", async () => {
+  const dead = await probeRuntimeLease({
+    libraryDir: "/tmp/mosa-library",
+    readFileImpl: async () => JSON.stringify({ token: "owner-token", pid: 4242, processIdentity: "start-1" }),
+    isProcessAlive: () => false,
+  });
+  assert.deepEqual(dead, { state: "unavailable" });
+
+  const recycled = await probeRuntimeLease({
+    libraryDir: "/tmp/mosa-library",
+    readFileImpl: async () => JSON.stringify({ token: "owner-token", pid: 4242, processIdentity: "start-1" }),
+    isProcessAlive: () => true,
+    verifyProcessIdentity: async () => false,
+  });
+  assert.deepEqual(recycled, { state: "unavailable" });
+});
+
+test("takeover grace observes a desktop owner before restarting the background runtime", async () => {
+  const states = [
+    { state: "unavailable" },
+    { state: "unavailable" },
+    { state: "attached", health: { product: "mosa" } },
+  ];
+  let sleeps = 0;
+  const result = await waitForReplacementOwner({
+    probe: async () => states.shift() || { state: "attached" },
+    sleep: async () => { sleeps += 1; },
+    graceMs: 1000,
+    pollMs: 250,
+  });
+  assert.equal(result.state, "attached");
+  assert.equal(sleeps, 2);
+});
+
+test("supervisor stands by while desktop owns the library and starts service after it leaves", async () => {
+  const signalTarget = new EventEmitter();
+  let probeCount = 0;
+  let spawnCount = 0;
+  const child = new EventEmitter();
+  child.pid = 4242;
+  child.exitCode = null;
+  child.signalCode = null;
+  child.kill = (signal) => {
+    child.signalCode = signal;
+    queueMicrotask(() => child.emit("exit", null, signal));
+    return true;
+  };
+
+  await runSupervisor({
+    signalTarget,
+    probe: async () => {
+      probeCount += 1;
+      if (probeCount <= 2) return { state: "attached" };
+      return { state: "unavailable" };
+    },
+    spawnRuntime: () => {
+      spawnCount += 1;
+      queueMicrotask(() => signalTarget.emit("SIGTERM"));
+      return child;
+    },
+    sleep: async () => {},
+    idlePollMs: 1,
+    takeoverGraceMs: 1,
+    takeoverPollMs: 1,
+    logger: { info() {}, warn() {} },
+  });
+
+  assert.equal(spawnCount, 1);
+  assert.ok(probeCount >= 3);
+});


### PR DESCRIPTION
## Summary

- replace direct launchd KeepAlive service ownership with a cooperative supervisor
- stand by while the desktop app owns the same MOSA library
- restore the background runtime automatically after the desktop app exits
- detect active runtime locks during startup so the supervisor does not race a desktop handoff
- use a longer grace window only for controlled SIGTERM ownership transfers while retaining fast crash recovery
- make LaunchAgent reinstall wait for the old job to fully unload before bootstrap
- add regression coverage for verified owners, startup leases, stale/recycled locks, takeover grace, and recovery

## Verification

- targeted supervisor tests: 6/6 pass
- service-manager + runtime-lock + supervisor integration tests: 31/31 pass
- `npm run lint`
- `npm run check`
- `git diff --check`
- live macOS ownership handoff validated: desktop -> background -> desktop, with launchd supervisor staying at `runs = 1`

These changes live under `scripts/` and tests, so they do not alter the rc.7 runtime fingerprint.