### PR TITLE
fix: restore authenticated drag workflows and runtime supervision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This file records user-visible changes. Internal deployment notes, local paths, 
 
 No user-visible changes recorded yet.
 
+## 0.2.1-rc.8 — 2026-09-11 / Release Candidate
+
+### Desktop runtime ownership and drag workflow recovery / 桌面运行时接管与拖拽工作流恢复
+
+- Hardened macOS background-runtime supervision so the desktop app can safely take ownership of the correct local MOSA runtime without leaving stale process state behind.
+- Restored authenticated drag-to-stack creation and drag-into-existing-stack workflows while preserving the local runtime capability boundary.
+- Added a first-party HttpOnly browser-session capability for direct loopback Web UI launches so state-changing actions no longer fail with `Unauthorized MOSA client.` when the page is opened without a fragment token.
+- Fixed drag-to-group target lifetime so dropping assets onto manual groups or Unorganized continues to work after drag visual state is cleared.
+- Expanded end-to-end regression coverage to exercise direct drag Stack creation from a bare local URL, Stack reordering, and browser mutation authentication.
+
 ## 0.2.1-rc.7 — 2026-09-11 / Release Candidate
 
 ### Runtime integrity, group workflows, and release validation / 运行时完整性、分组工作流与发布验证

--- a/app/api-client.mjs
+++ b/app/api-client.mjs
@@ -4,6 +4,7 @@
 import { FACET_KEYS, GALLERY_INITIAL_PAGE_SIZE, GALLERY_PAGE_SIZE } from "./config.mjs";
 
 let cachedClientToken;
+let browserSessionRefreshPromise = null;
 
 export function mosaClientToken() {
   if (cachedClientToken !== undefined) return cachedClientToken;
@@ -33,6 +34,19 @@ export function mosaMutationHeaders(method = "POST") {
   return token ? { "x-mosa-client-token": token } : {};
 }
 
+async function refreshMosaBrowserSession() {
+  if (typeof window === "undefined" || typeof fetch !== "function") return false;
+  if (browserSessionRefreshPromise) return browserSessionRefreshPromise;
+  browserSessionRefreshPromise = fetch("/", {
+    method: "GET",
+    cache: "no-store",
+    credentials: "same-origin",
+  }).then((response) => response.ok).catch(() => false).finally(() => {
+    browserSessionRefreshPromise = null;
+  });
+  return browserSessionRefreshPromise;
+}
+
 export function createApiClient(deps) {
   // Consume the one-time bootstrap capability as soon as the client is
   // constructed. Keeping it in the URL fragment until the first mutation
@@ -59,35 +73,47 @@ export function createApiClient(deps) {
 
   async function apiFetch(path, options = {}) {
     const method = options.method || "GET";
-    const headers = {
-      ...(options.body ? { "content-type": "application/json" } : {}),
-      ...mosaMutationHeaders(method),
-      ...(options.headers || {}),
-    };
-    const response = await fetch(path, {
-      method,
-      headers: Object.keys(headers).length ? headers : undefined,
-      body: options.body ? JSON.stringify(options.body) : undefined,
-      signal: options.signal,
-    });
-    const raw = await response.text();
-    let payload = {};
-    try { payload = raw ? JSON.parse(raw) : {}; }
-    catch {
-      // 200 + 非法 JSON（反代/网关错误页）不得伪装成空结果——否则画廊会渲染
-      // “没有找到匹配的素材”空态而非错误态。HTTP/2 下 statusText 恒为空串，
-      // 错误消息退回状态码文本。
-      if (!response.ok) throw new Error(response.statusText || `HTTP ${response.status}`);
-      throw new Error(`Invalid JSON response (HTTP ${response.status})`);
-    }
-    if (!response.ok) {
+    const isMutation = !["GET", "HEAD", "OPTIONS"].includes(String(method).toUpperCase());
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const headers = {
+        ...(options.body ? { "content-type": "application/json" } : {}),
+        ...mosaMutationHeaders(method),
+        ...(options.headers || {}),
+      };
+      const response = await fetch(path, {
+        method,
+        headers: Object.keys(headers).length ? headers : undefined,
+        body: options.body ? JSON.stringify(options.body) : undefined,
+        signal: options.signal,
+        credentials: "same-origin",
+      });
+      const raw = await response.text();
+      let payload = {};
+      try { payload = raw ? JSON.parse(raw) : {}; }
+      catch {
+        // 200 + 非法 JSON（反代/网关错误页）不得伪装成空结果——否则画廊会渲染
+        // “没有找到匹配的素材”空态而非错误态。HTTP/2 下 statusText 恒为空串，
+        // 错误消息退回状态码文本。
+        if (!response.ok) throw new Error(response.statusText || `HTTP ${response.status}`);
+        throw new Error(`Invalid JSON response (HTTP ${response.status})`);
+      }
+      if (response.ok) return payload;
+      // A source/background runtime can be restarted while a browser tab stays
+      // open. Its old cookie/header capability then becomes stale even though
+      // the page is still the trusted same-origin MOSA UI. Refresh the
+      // HttpOnly browser session from the root document and retry exactly once;
+      // unrelated 401s and persistent auth failures still surface normally.
+      if (attempt === 0 && isMutation && payload.code === "MOSA_CLIENT_UNAUTHORIZED"
+        && await refreshMosaBrowserSession()) {
+        continue;
+      }
       // Carry the server's machine-readable code so callers can attribute a
       // failure to a specific form field instead of matching on prose.
       const error = new Error(payload.error || response.statusText);
       if (payload.code) error.code = payload.code;
       throw error;
     }
-    return payload;
+    throw new Error("MOSA request failed after authentication refresh.");
   }
 
   async function loadProjects() {

--- a/app/asset-stacks.mjs
+++ b/app/asset-stacks.mjs
@@ -525,6 +525,7 @@ export function createAssetStackController({
     const completed = drag.dragging;
     const targetId = dropTarget?.dataset.id || "";
     const placement = dropPlacement;
+    const groupTarget = dropGroupTarget;
     pointer = null;
     state.assetStackDragCandidate = false;
     state.assetStackDragging = false;
@@ -536,8 +537,8 @@ export function createAssetStackController({
     suppressSyntheticClick();
     event.preventDefault();
     // 侧边栏投放优先：分组项 → 移入该组；“待整理”项 → 移出分组。
-    if (dropGroupTarget) {
-      const item = dropGroupTarget;
+    if (groupTarget) {
+      const item = groupTarget;
       const filter = item.dataset.filter;
       const value = filter === "group" ? item.dataset.value : "";
       void runStackMutation(() => finishGroupDrop(drag.assetIds, value));

--- a/lib/mosa-runtime.mjs
+++ b/lib/mosa-runtime.mjs
@@ -15,7 +15,8 @@ import {
   isAllowedIngestOrigin,
   isAllowedLocalOrigin,
   isApprovedExtensionOrigin,
-  isAuthorizedMosaClientToken,
+  isAuthorizedMosaClientRequest,
+  mosaBrowserClientCookieHeader,
   mosaClientTokenFingerprint,
   normalizeMosaClientToken,
   parseAllowedIngestOrigins,
@@ -331,7 +332,12 @@ export async function startMosaRuntime(options = {}) {
     }
 
     if (!isWebCaptureRoute && requiresMosaClientToken(req.method, url.pathname)) {
-      if (!isAuthorizedMosaClientToken(req.headers["x-mosa-client-token"], clientToken)) {
+      if (!isAuthorizedMosaClientRequest(
+        req.headers["x-mosa-client-token"],
+        req.headers.cookie,
+        clientToken,
+        activePort,
+      )) {
         sendJson(res, 401, { error: "Unauthorized MOSA client.", code: "MOSA_CLIENT_UNAUTHORIZED" });
         return;
       }
@@ -348,7 +354,7 @@ export async function startMosaRuntime(options = {}) {
       return;
     }
 
-    await handleStatic(res, url.pathname);
+    await handleStatic(res, url.pathname, activePort);
   } catch (error) {
     const statusCode = error instanceof URIError ? 400 : (Number(error?.statusCode) || 500);
     const internal = statusCode >= 500;
@@ -704,7 +710,12 @@ function parseSingleByteRange(header, size) {
   return { start, end };
 }
 
-async function handleStatic(res, pathname) {
+function setBrowserClientCookie(res, activePort) {
+  const cookie = mosaBrowserClientCookieHeader(clientToken, activePort);
+  if (cookie) res.setHeader("Set-Cookie", cookie);
+}
+
+async function handleStatic(res, pathname, activePort) {
   const fileName = pathname === "/" ? "index.html" : basename(pathname);
   const filePath = join(appDir, fileName);
   if (resolve(filePath) !== join(appDir, fileName)) {
@@ -715,7 +726,9 @@ async function handleStatic(res, pathname) {
   try {
     const content = await readFile(filePath);
     res.statusCode = 200;
-    res.setHeader("content-type", staticMime(filePath));
+    const contentType = staticMime(filePath);
+    res.setHeader("content-type", contentType);
+    if (contentType.startsWith("text/html")) setBrowserClientCookie(res, activePort);
     // Explicit cache control for UI static files to prevent stale content issues.
     // index.html, CSS, JS, MJS, SVG etc. should be revalidated on each request
     // since they lack content hash in the URL (versioned URLs are a future optimization).
@@ -726,6 +739,7 @@ async function handleStatic(res, pathname) {
     const content = await readFile(join(appDir, "index.html"));
     res.statusCode = 200;
     res.setHeader("content-type", "text/html; charset=utf-8");
+    setBrowserClientCookie(res, activePort);
     res.setHeader("Cache-Control", "no-cache, must-revalidate");
     res.end(content);
   }

--- a/lib/server-security.ts
+++ b/lib/server-security.ts
@@ -3,6 +3,7 @@ import { realpathSync } from "node:fs";
 import { createHash, timingSafeEqual } from "node:crypto";
 
 const CLIENT_TOKEN_PATTERN = /^[A-Za-z0-9_-]{43,128}$/;
+export const MOSA_BROWSER_CLIENT_COOKIE_PREFIX = "mosa-browser-client-";
 
 export function normalizeMosaClientToken(value: unknown): string {
   const token = String(value || "").trim();
@@ -25,6 +26,59 @@ export function isAuthorizedMosaClientToken(provided: unknown, configured: unkno
 export function mosaClientTokenFingerprint(value: unknown): string {
   const token = normalizeMosaClientToken(value);
   return token ? createHash("sha256").update(token).digest("base64url").slice(0, 22) : "";
+}
+
+function normalizeBrowserClientPort(value: unknown): string {
+  const numeric = Number(value);
+  return Number.isInteger(numeric) && numeric >= 1 && numeric <= 65_535 ? String(numeric) : "";
+}
+
+export function mosaBrowserClientCookieName(port: unknown): string {
+  const normalizedPort = normalizeBrowserClientPort(port);
+  return normalizedPort ? `${MOSA_BROWSER_CLIENT_COOKIE_PREFIX}${normalizedPort}` : "";
+}
+
+export function mosaBrowserClientToken(value: unknown, port: unknown): string {
+  const token = normalizeMosaClientToken(value);
+  const normalizedPort = normalizeBrowserClientPort(port);
+  if (!token || !normalizedPort) return "";
+  return createHash("sha256")
+    .update("mosa-browser-client\0")
+    .update(normalizedPort)
+    .update("\0")
+    .update(token)
+    .digest("base64url");
+}
+
+export function mosaBrowserClientCookieHeader(value: unknown, port: unknown): string {
+  const name = mosaBrowserClientCookieName(port);
+  const token = mosaBrowserClientToken(value, port);
+  return name && token ? `${name}=${token}; Path=/; HttpOnly; SameSite=Strict` : "";
+}
+
+function cookieValue(cookieHeader: unknown, name: string): string {
+  if (!name) return "";
+  const header = String(cookieHeader || "");
+  for (const part of header.split(";")) {
+    const separator = part.indexOf("=");
+    if (separator < 0) continue;
+    if (part.slice(0, separator).trim() !== name) continue;
+    return part.slice(separator + 1).trim();
+  }
+  return "";
+}
+
+export function isAuthorizedMosaClientRequest(
+  providedToken: unknown,
+  cookieHeader: unknown,
+  configuredToken: unknown,
+  port: unknown,
+): boolean {
+  if (isAuthorizedMosaClientToken(providedToken, configuredToken)) return true;
+  const expectedBrowserToken = mosaBrowserClientToken(configuredToken, port);
+  if (!expectedBrowserToken) return false;
+  const browserToken = cookieValue(cookieHeader, mosaBrowserClientCookieName(port));
+  return isAuthorizedMosaClientToken(browserToken, expectedBrowserToken);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mosa",
-  "version": "0.2.1-rc.7",
+  "version": "0.2.1-rc.8",
   "private": true,
   "license": "PolyForm-Noncommercial-1.0.0",
   "type": "module",

--- a/scripts/e2e-critical-flows.mjs
+++ b/scripts/e2e-critical-flows.mjs
@@ -60,7 +60,7 @@ try {
   console.log("[e2e] Electron renderer: restart -> persistence verification");
   await runElectronRound("verify", desktopSearchTerm, desktopRecipeChange);
 
-  console.log("[e2e] Web renderer: Stack create -> enter -> reorder cover -> return");
+  console.log("[e2e] Web renderer: bare URL -> direct-drag Stack create -> enter -> reorder cover -> return");
   await runWebStackRound();
 
   console.log(JSON.stringify({ ok: true, storage: "sqlite", flows: ["web", "electron", "stack"], restartVerified: true }));
@@ -122,7 +122,7 @@ async function runWebStackRound() {
       cwd: rootDir,
       env: {
         ...process.env,
-        MOSA_E2E_WEB_TARGET_URL: `http://127.0.0.1:${port}/#mosa-client-token=${encodeURIComponent(QA_CLIENT_TOKEN)}`,
+        MOSA_E2E_WEB_TARGET_URL: `http://127.0.0.1:${port}/`,
         MOSA_E2E_WEB_USER_DATA: webUserData,
         MOSA_E2E_WEB_FLOW: "stack",
       },

--- a/scripts/e2e-ui-flow.mjs
+++ b/scripts/e2e-ui-flow.mjs
@@ -222,17 +222,16 @@ export function createStackUiFlowSource() {
   pointer(window, 'pointerup', selfDropTo.left + selfDropTo.width / 2, selfDropTo.top + selfDropTo.height / 2, 90);
   await sleep(80);
   if (document.querySelector('#assetGrid > .asset-card.is-stack')) throw new Error('Self-drop unexpectedly created a Stack');
-  const stackButton = await waitFor(
-    () => {
-      const button = document.querySelector('#selectionStack');
-      return button && !button.disabled ? button : null;
-    },
-    'enabled Stack action',
-  );
-  stackButton.click();
+  ctrlClick(initialCards[0].querySelector('.asset-card-select'));
+  ctrlClick(initialCards[1].querySelector('.asset-card-select'));
+  const dragFrom = initialCards[0].getBoundingClientRect();
+  const dragTo = initialCards[1].getBoundingClientRect();
+  pointer(initialCards[0].querySelector('.asset-card-select'), 'pointerdown', dragFrom.left + dragFrom.width / 2, dragFrom.top + dragFrom.height / 2, 92);
+  pointer(window, 'pointermove', dragTo.left + dragTo.width / 2, dragTo.top + dragTo.height / 2, 92);
+  pointer(window, 'pointerup', dragTo.left + dragTo.width / 2, dragTo.top + dragTo.height / 2, 92);
   const stackCard = await waitFor(
     () => document.querySelector('#assetGrid > .asset-card.is-stack'),
-    'collapsed Stack card',
+    'collapsed Stack card created by direct drag',
   );
   const stackId = stackCard.dataset.stackId;
   const rootCountAfterStack = document.querySelectorAll('#assetGrid > .asset-card').length;

--- a/scripts/macos-web-capture-supervisor.mjs
+++ b/scripts/macos-web-capture-supervisor.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
+import { watch } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
@@ -16,6 +17,57 @@ const DEFAULT_TAKEOVER_GRACE_MS = 5000;
 const DEFAULT_CONTROLLED_TAKEOVER_GRACE_MS = 30_000;
 const DEFAULT_TAKEOVER_POLL_MS = 250;
 const DEFAULT_PROBE_TIMEOUT_MS = 1200;
+const DEFAULT_SOURCE_CHANGE_SETTLE_MS = 750;
+
+export function watchOwnedRuntimeSources({
+  watchImpl = watch,
+  settleMs = DEFAULT_SOURCE_CHANGE_SETTLE_MS,
+  sources = [
+    { path: join(repositoryRoot, "app"), recursive: true },
+    { path: join(repositoryRoot, "lib"), recursive: true },
+    { path: serverEntry, recursive: false },
+    { path: join(repositoryRoot, "package.json"), recursive: false },
+  ],
+} = {}) {
+  const watchers = [];
+  let settleTimer = null;
+  let closed = false;
+  let resolveChange;
+  const promise = new Promise((resolvePromise) => { resolveChange = resolvePromise; });
+
+  const closeHandles = () => {
+    for (const watcher of watchers.splice(0)) watcher.close?.();
+  };
+  const scheduleChange = () => {
+    if (closed) return;
+    if (settleTimer) clearTimeout(settleTimer);
+    settleTimer = setTimeout(() => {
+      if (closed) return;
+      closed = true;
+      settleTimer = null;
+      closeHandles();
+      resolveChange({ reason: "source-change" });
+    }, Math.max(50, Number(settleMs) || DEFAULT_SOURCE_CHANGE_SETTLE_MS));
+    settleTimer.unref?.();
+  };
+
+  for (const source of sources) {
+    const watcher = watchImpl(source.path, { recursive: source.recursive === true }, scheduleChange);
+    watcher.on?.("error", scheduleChange);
+    watchers.push(watcher);
+  }
+
+  return {
+    promise,
+    close() {
+      if (closed) return;
+      closed = true;
+      if (settleTimer) clearTimeout(settleTimer);
+      settleTimer = null;
+      closeHandles();
+    },
+  };
+}
 
 export async function probeMosaOwner({
   port = process.env.MOSA_PORT || DEFAULT_MOSA_DESKTOP_PORT,
@@ -99,6 +151,7 @@ export async function runSupervisor({
     env: process.env,
     stdio: "inherit",
   }),
+  watchSources = () => watchOwnedRuntimeSources(),
   sleep = (delayMs) => new Promise((resolveSleep) => setTimeout(resolveSleep, delayMs)),
   idlePollMs = DEFAULT_IDLE_POLL_MS,
   takeoverGraceMs = DEFAULT_TAKEOVER_GRACE_MS,
@@ -142,7 +195,29 @@ export async function runSupervisor({
       lastIdleReason = "";
       child = spawnRuntime();
       logger.info?.(`[MOSA supervisor] started background runtime PID ${child.pid || "unknown"}.`);
-      const exit = await waitForChildExit(child);
+      const sourceWatch = watchSources();
+      const exitPromise = waitForChildExit(child).then((exit) => ({ type: "exit", exit }));
+      const outcome = await Promise.race([
+        exitPromise,
+        sourceWatch.promise.then(() => ({ type: "source-change" })),
+      ]);
+      sourceWatch.close?.();
+
+      if (outcome.type === "source-change") {
+        if (!stopping && child.exitCode == null && child.signalCode == null) {
+          logger.info?.("[MOSA supervisor] source changed; restarting the owned background runtime.");
+          child.kill("SIGTERM");
+        }
+        await exitPromise;
+        child = null;
+        if (stopping) break;
+        // Re-enter through probe instead of spawning blindly. A desktop app
+        // may have acquired the library lock while the old source runtime was
+        // shutting down, and the cooperative ownership rule must still win.
+        continue;
+      }
+
+      const exit = outcome.exit;
       child = null;
       if (stopping) break;
 

--- a/test/asset-stack-ui.test.mjs
+++ b/test/asset-stack-ui.test.mjs
@@ -124,6 +124,16 @@ test("visual stack behavior is wired into the shared web and desktop renderer", 
   assert.match(stackController, /setPointerCapture\(event\.pointerId\)/);
   assert.match(stackController, /if \(pointerMoveFrame !== null\) \{\s+cancelAnimationFrame\(pointerMoveFrame\);\s+pointerMoveFrame = null;\s+flushPointerMove\(\);/,
     "pointerup flushes a coalesced move before resolving the drop target");
+  const endPointer = stackController.slice(
+    stackController.indexOf("function endPointer"),
+    stackController.indexOf("async function finishGroupDrop"),
+  );
+  assert.match(endPointer, /const groupTarget = dropGroupTarget;/,
+    "sidebar drops snapshot their target before visual drag state is cleared");
+  assert.ok(endPointer.indexOf("const groupTarget = dropGroupTarget;") < endPointer.indexOf("removeGhost();"),
+    "sidebar drop target must survive removeGhost/clearDropTarget until the mutation is scheduled");
+  assert.match(endPointer, /if \(groupTarget\)[\s\S]*?finishGroupDrop\(drag\.assetIds, value\)/,
+    "the preserved sidebar target drives the group mutation");
   assert.match(stackController, /lostpointercapture/);
   assert.match(stackController, /window\.addEventListener\("blur"/);
   assert.match(stackController, /moveBlockRelative\(currentIds, drag\.assetIds, targetId, placement\)/);

--- a/test/frontend-interaction-regressions.test.mjs
+++ b/test/frontend-interaction-regressions.test.mjs
@@ -653,6 +653,16 @@ test("background stats refresh skips the effectively static library-path request
   assert.match(stats, /const rawGroups = result\.navigation \|\| \{\}/);
 });
 
+test("mutation auth recovers once from a restarted same-origin runtime", async () => {
+  const apiClient = await readFile(resolve(root, "app/api-client.mjs"), "utf8");
+  const fetcher = sliceBetween(apiClient, "async function apiFetch(path, options = {})", "async function loadProjects()");
+  assert.match(apiClient, /async function refreshMosaBrowserSession\(\)/);
+  assert.match(apiClient, /fetch\("\/", \{[\s\S]*?cache: "no-store"[\s\S]*?credentials: "same-origin"/);
+  assert.match(fetcher, /for \(let attempt = 0; attempt < 2; attempt \+= 1\)/);
+  assert.match(fetcher, /payload\.code === "MOSA_CLIENT_UNAUTHORIZED"[\s\S]*?await refreshMosaBrowserSession\(\)/);
+  assert.match(fetcher, /credentials: "same-origin"/);
+});
+
 test("infinite scroll rearms deterministically after an appended page replaces the sentinel", async () => {
   const app = await readApp();
   const scrolling = sliceBetween(app, "let infiniteScrollObserver = null;", "/**\n * Placeholders sized like real cards");

--- a/test/macos-web-capture-supervisor.test.mjs
+++ b/test/macos-web-capture-supervisor.test.mjs
@@ -142,8 +142,12 @@ test("source watcher resolves once and closes every watched handle", async () =>
     watchImpl: (_path, _options, callback) => {
       callbacks.push(callback);
       const handle = new EventEmitter();
+      const keepEventLoopAlive = setTimeout(() => {}, 1000);
       handle.closed = false;
-      handle.close = () => { handle.closed = true; };
+      handle.close = () => {
+        clearTimeout(keepEventLoopAlive);
+        handle.closed = true;
+      };
       handles.push(handle);
       return handle;
     },

--- a/test/macos-web-capture-supervisor.test.mjs
+++ b/test/macos-web-capture-supervisor.test.mjs
@@ -5,6 +5,7 @@ import {
   probeMosaOwner,
   probeRuntimeLease,
   runSupervisor,
+  watchOwnedRuntimeSources,
   waitForReplacementOwner,
 } from "../scripts/macos-web-capture-supervisor.mjs";
 
@@ -127,4 +128,78 @@ test("supervisor stands by while desktop owns the library and starts service aft
 
   assert.equal(spawnCount, 1);
   assert.ok(probeCount >= 3);
+});
+
+test("source watcher resolves once and closes every watched handle", async () => {
+  const callbacks = [];
+  const handles = [];
+  const sourceWatch = watchOwnedRuntimeSources({
+    settleMs: 1,
+    sources: [
+      { path: "/tmp/app", recursive: true },
+      { path: "/tmp/server.mjs", recursive: false },
+    ],
+    watchImpl: (_path, _options, callback) => {
+      callbacks.push(callback);
+      const handle = new EventEmitter();
+      handle.closed = false;
+      handle.close = () => { handle.closed = true; };
+      handles.push(handle);
+      return handle;
+    },
+  });
+
+  callbacks[0]();
+  callbacks[1]();
+  assert.deepEqual(await sourceWatch.promise, { reason: "source-change" });
+  assert.equal(handles.every((handle) => handle.closed), true);
+});
+
+test("supervisor restarts an owned background runtime when source changes", async () => {
+  const signalTarget = new EventEmitter();
+  let spawnCount = 0;
+  let watchCount = 0;
+  const children = [];
+
+  function makeChild(pid) {
+    const child = new EventEmitter();
+    child.pid = pid;
+    child.exitCode = null;
+    child.signalCode = null;
+    child.kill = (signal) => {
+      child.signalCode = signal;
+      queueMicrotask(() => child.emit("exit", null, signal));
+      return true;
+    };
+    children.push(child);
+    return child;
+  }
+
+  await runSupervisor({
+    signalTarget,
+    probe: async () => ({ state: "unavailable" }),
+    spawnRuntime: () => {
+      spawnCount += 1;
+      const child = makeChild(5000 + spawnCount);
+      if (spawnCount === 2) queueMicrotask(() => signalTarget.emit("SIGTERM"));
+      return child;
+    },
+    watchSources: () => {
+      watchCount += 1;
+      return {
+        promise: watchCount === 1
+          ? Promise.resolve({ reason: "source-change" })
+          : new Promise(() => {}),
+        close() {},
+      };
+    },
+    sleep: async () => {},
+    takeoverGraceMs: 1,
+    takeoverPollMs: 1,
+    logger: { info() {}, warn() {} },
+  });
+
+  assert.equal(spawnCount, 2);
+  assert.equal(children[0].signalCode, "SIGTERM");
+  assert.equal(children[1].signalCode, "SIGTERM");
 });

--- a/test/mosa-runtime.test.mjs
+++ b/test/mosa-runtime.test.mjs
@@ -139,6 +139,29 @@ test("management mutations reject callers without the runtime capability", async
   });
 });
 
+test("first-party browser HTML bootstraps an HttpOnly mutation capability", async (t) => {
+  const root = await makeTemporaryRoot(t, "mosa-runtime-browser-auth-");
+  const runtime = await startMosaRuntime(runtimeOptions(root));
+  t.after(() => runtime.stop());
+
+  const page = await fetch(`${runtime.url}/`);
+  assert.equal(page.status, 200);
+  const setCookie = page.headers.get("set-cookie") || "";
+  assert.match(setCookie, new RegExp(`^mosa-browser-client-${runtime.port}=[A-Za-z0-9_-]{43}; Path=/; HttpOnly; SameSite=Strict$`));
+  const browserCookie = setCookie.split(";", 1)[0];
+
+  const mutation = await fetch(`${runtime.url}/api/assets/batch`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      cookie: browserCookie,
+      "x-mosa-client-token": "stale-renderer-token",
+    },
+    body: JSON.stringify({ action: "group", projectId: "default", assetIds: ["missing"], group: "" }),
+  });
+  assert.notEqual(mutation.status, 401);
+});
+
 test("runtime shutdown closes active library event streams before waiting for HTTP drain", async (t) => {
   const root = await makeTemporaryRoot(t, "mosa-runtime-sse-shutdown-");
   const runtime = await startMosaRuntime(runtimeOptions(root));

--- a/test/server-security.test.mjs
+++ b/test/server-security.test.mjs
@@ -8,7 +8,11 @@ import {
   isAllowedIngestOrigin,
   isAllowedLocalOrigin,
   isApprovedExtensionOrigin,
+  isAuthorizedMosaClientRequest,
   isAuthorizedMosaClientToken,
+  mosaBrowserClientCookieHeader,
+  mosaBrowserClientCookieName,
+  mosaBrowserClientToken,
   mosaClientTokenFingerprint,
   normalizeMosaClientToken,
   parseAllowedIngestOrigins,
@@ -26,9 +30,17 @@ test("allows only same-origin browser requests", () => {
 
 test("management mutations require a high-entropy runtime capability", () => {
   const token = "a".repeat(43);
+  const browserToken = mosaBrowserClientToken(token, 43517);
+  const browserCookieName = mosaBrowserClientCookieName(43517);
   assert.equal(normalizeMosaClientToken(token), token);
   assert.equal(isAuthorizedMosaClientToken(token, token), true);
   assert.equal(isAuthorizedMosaClientToken(`${token.slice(0, -1)}b`, token), false);
+  assert.equal(browserToken.length, 43);
+  assert.equal(browserCookieName, "mosa-browser-client-43517");
+  assert.match(mosaBrowserClientCookieHeader(token, 43517), /^mosa-browser-client-43517=[A-Za-z0-9_-]{43}; Path=\/; HttpOnly; SameSite=Strict$/);
+  assert.equal(isAuthorizedMosaClientRequest("", `${browserCookieName}=${browserToken}`, token, 43517), true);
+  assert.equal(isAuthorizedMosaClientRequest("stale", `${browserCookieName}=${browserToken}`, token, 43517), true);
+  assert.equal(isAuthorizedMosaClientRequest("", `${browserCookieName}=${browserToken}`, token, 43518), false);
   assert.equal(mosaClientTokenFingerprint(token).length, 22);
   assert.equal(requiresMosaClientToken("POST", "/api/assets/create"), true);
   assert.equal(requiresMosaClientToken("DELETE", "/api/trash"), true);


### PR DESCRIPTION
## Summary
- restore authenticated drag-to-stack and drag-into-stack workflows
- recover same-origin browser mutation capability after a runtime restart
- supervise owned macOS runtime sources and restart safely on source changes
- prepare MOSA 0.2.1-rc.8

## Validation
- npm ci
- npm test: 1100 passed, 0 failed, 0 cancelled, 2 skipped
- npm run lint
- npm run check
- npm audit --omit=dev

The website repository's untracked hero PNGs are intentionally out of scope.